### PR TITLE
Update .eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,8 @@ module.exports = {
   globals: {
     wx: true,
     getApp: true,
-    getCurrentPages: true
+    getCurrentPages: true,
+    requirePlugin: true
   },
   rules: {
     'no-unused-expressions': 0,


### PR DESCRIPTION
requirePlugin 挂载到全局空间下
因为微信小程序开始提供插件功能。参考：https://developers.weixin.qq.com/miniprogram/dev/framework/plugin/using.html