### PR TITLE
将cli写入模板依赖

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,15 @@ export default class Index extends Component {
       list: [1, 2, 3]
     }
   }
-  
+
   componentWillMount () {}
-  
+
   componentDidMount () {}
-  
+
   componentWillUpdate (nextProps, nextState) {}
-  
+
   componentDidUpdate (prevProps, prevState) {}
- 
+
   shouldComponentUpdate (nextProps, nextState) {
     return true
   }
@@ -102,7 +102,7 @@ Taro 方案的初心就是为了打造一个多端开发的解决方案。目前
 
 安装 Taro 开发工具 `@tarojs/cli`
 
-使用 npm或者yarn 全局安装
+使用 npm或者yarn 全局安装，或者直接使用[npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b)
 
 ```bash
 $ npm install -g @tarojs/cli
@@ -115,7 +115,7 @@ $ yarn global add @tarojs/cli
 $ taro init myApp
 ```
 
-npm5.2+ 也可在不全局安装的情况下使用  [npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) 创建模板项目
+npm5.2+ 也可在不全局安装的情况下使用 npx 创建模板项目
 
 ```bash
 $ npx @tarojs/cli init myApp
@@ -123,22 +123,47 @@ $ npx @tarojs/cli init myApp
 
 进入项目目录开始开发，可以选择小程序预览模式，或者H5预览模式，若使用微信小程序预览模式，则需要自行下载并打开[微信开发者工具](https://developers.weixin.qq.com/miniprogram/dev/devtools/download.html)，选择预览项目根目录下 `dist` 目录。
 
-```bash
-# 微信小程序编译预览模式
-$ taro build --type weapp --watch
+微信小程序编译预览模式
 
-# H5编译预览模式
+```bash
+# npm script
+$ npm run dev:weapp
+# 仅限全局安装
+$ taro build --type weapp --watch
+# npx用户也可以使用
+$ npx taro build --type weapp --watch
+```
+
+H5编译预览模式
+```bash
+# npm script
+$ npm run dev:h5
+# 仅限全局安装
 $ taro build --type h5 --watch
+# npx用户也可以使用
+$ npx taro build --type h5 --watch
 ```
 
 项目打包
 
+打包小程序代码
 ```bash
-# 打包小程序代码
+# npm script
+$ npm build dev:weapp
+# 仅限全局安装
 $ taro build --type weapp
+# npx用户也可以使用
+$ npx taro build --type weapp
+```
 
-# 打包H5代码
+打包H5代码
+```bash
+# npm script
+$ npm build dev:h5
+# 仅限全局安装
 $ taro build --type h5
+# npx用户也可以使用
+$ npx taro build --type h5
 ```
 
 ## License

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -4,7 +4,7 @@
 
 安装 Taro 开发工具 `@tarojs/cli`
 
-使用 npm或者yarn 全局安装
+使用 npm 或者 yarn 全局安装，或者直接使用[npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b)
 
 ```bash
 $ npm install -g @tarojs/cli
@@ -19,12 +19,31 @@ $ yarn global add @tarojs/cli
 $ taro init myApp
 ```
 
-进入项目目录开始开发，可以选择小程序预览模式，或者h5预览模式，若使用微信小程序预览模式，则需要自行下载并打开[微信开发者工具](https://developers.weixin.qq.com/miniprogram/dev/devtools/download.html)，选择预览项目根目录下 `dist` 目录。
+npm5.2+ 也可在不全局安装的情况下使用 npx 创建模板项目
 
 ```bash
-# 微信小程序编译预览模式
-$ taro build --type weapp --watch
+$ npx @tarojs/cli init myApp
+```
 
-# H5编译预览模式
+进入项目目录开始开发，可以选择小程序预览模式，或者h5预览模式，若使用微信小程序预览模式，则需要自行下载并打开[微信开发者工具](https://developers.weixin.qq.com/miniprogram/dev/devtools/download.html)，选择预览项目根目录下 `dist` 目录。
+
+微信小程序编译预览模式
+
+```bash
+# npm script
+$ npm run dev:weapp
+# 仅限全局安装
+$ taro build --type weapp --watch
+# npx用户也可以使用
+$ npx taro build --type weapp --watch
+```
+
+H5编译预览模式
+```bash
+# npm script
+$ npm run dev:h5
+# 仅限全局安装
 $ taro build --type h5 --watch
+# npx用户也可以使用
+$ npx taro build --type h5 --watch
 ```

--- a/packages/taro-cli/templates/default/pkg
+++ b/packages/taro-cli/templates/default/pkg
@@ -18,6 +18,7 @@
     "nervjs": "^1.2.18"
   },
   "devDependencies": {
+    "@tarojs/cli": "^<%= version %>",
     "@tarojs/plugin-babel": "^<%= version %>",
     "@tarojs/plugin-csso": "^<%= version %>",
     "@tarojs/plugin-sass": "^<%= version %>",

--- a/packages/taro-cli/templates/default/pkg
+++ b/packages/taro-cli/templates/default/pkg
@@ -5,6 +5,10 @@
   "description": "<%= description %>",
   "main": "index.js",
   "scripts": {
+    "build:weapp": "taro build --type weapp",
+    "build:h5": "taro build --type h5",
+    "dev:weapp": "npm run build:weapp -- --watch",
+    "dev:h5": "npm run build:h5 -- --watch",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",


### PR DESCRIPTION
- 4723de7 将cli写入模板依赖，方便非全局安装模式执行build https://github.com/NervJS/taro/issues/44
- 5a2dfbe 模板增加npm script，简化开发与构建的操作
- 2b8001a 更新相关文档

cli作为模板依赖测试
![image](https://user-images.githubusercontent.com/3221051/41187314-35b4083e-6bd9-11e8-8ba4-7b42621fb483.png)

小程序编译预览测试
![image](https://user-images.githubusercontent.com/3221051/41187321-46cbce90-6bd9-11e8-8a78-bf7b22707ea9.png)

H5编译预览测试
![image](https://user-images.githubusercontent.com/3221051/41187325-5eb77216-6bd9-11e8-861c-964f985dd88e.png)

打包小程序代码测试
![image](https://user-images.githubusercontent.com/3221051/41187342-85ef727a-6bd9-11e8-8c11-78b051cc07ba.png)

打包H5代码测试
![image](https://user-images.githubusercontent.com/3221051/41187347-986260ca-6bd9-11e8-8d56-10d96f5b914b.png)


