### PR TITLE
docs bug: events.md import 未引入 Events

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -3,7 +3,7 @@
 Taro 提供了 `Taro.Events` 来实现消息机制，使用时需要实例化它，如下
 
 ```javascript
-import Taro from '@tarojs/taro'
+import Taro, {Events} from '@tarojs/taro'
 
 const events = new Events()
 


### PR DESCRIPTION
events.md 文档中未引入 Events，会报错 Events is not defined

import Taro from '@tarojs/taro'
=> 应改为
import Taro,{Events} from '@tarojs/taro'
