### PR TITLE
:wrench: chore: remove array request and use `wx.request`

### DIFF
--- a/packages/taro-weapp/src/native-api.js
+++ b/packages/taro-weapp/src/native-api.js
@@ -1,32 +1,32 @@
 import { onAndSyncApis, noPromiseApis, otherApis } from '@tarojs/taro'
 
-const RequestQueue = {
-  MAX_REQUEST: 5,
-  queue: [],
-  request (options) {
-    this.push(options)
-    this.run()
-  },
+// const RequestQueue = {
+//   MAX_REQUEST: 5,
+//   queue: [],
+//   request (options) {
+//     this.push(options)
+//     this.run()
+//   },
 
-  push (options) {
-    this.queue.push(options)
-  },
+//   push (options) {
+//     this.queue.push(options)
+//   },
 
-  run () {
-    if (!this.queue.length) {
-      return
-    }
-    if (this.queue.length <= this.MAX_REQUEST) {
-      let options = this.queue.shift()
-      let completeFn = options.complete
-      options.complete = () => {
-        completeFn && completeFn.apply(options, [...arguments])
-        this.run()
-      }
-      wx.request(options)
-    }
-  }
-}
+//   run () {
+//     if (!this.queue.length) {
+//       return
+//     }
+//     if (this.queue.length <= this.MAX_REQUEST) {
+//       let options = this.queue.shift()
+//       let completeFn = options.complete
+//       options.complete = () => {
+//         completeFn && completeFn.apply(options, [...arguments])
+//         this.run()
+//       }
+//       wx.request(options)
+//     }
+//   }
+// }
 
 function request (options) {
   options = options || {}
@@ -51,8 +51,8 @@ function request (options) {
     options['complete'] = res => {
       originComplete && originComplete(res)
     }
-
-    RequestQueue.request(options)
+    // just use wx.request, has been sloved in native
+    wx.request(options)
   })
   return p
 }


### PR DESCRIPTION
原先wx.request 有对并发请求数量的限制(现在文档上也写着上限为10)，但是亲测发现，比如使用wx.request并发请求20个接口，也会先让10个请求进入一个队列，队列中请求结束之后，自动发出剩余请求。表象并不是以前的报错。所以，不需要再对wx.request 进行二次封装处理。