### PR TITLE
feat(taro-cli | postcss-pxtransform): 增加尺寸设计稿换算配置

### DIFF
--- a/packages/postcss-pxtransform/index.js
+++ b/packages/postcss-pxtransform/index.js
@@ -24,7 +24,7 @@ var legacyOptions = {
   'propWhiteList': 'propList'
 }
 
-const DEVICE_RATIO = {
+const deviceRatio = {
   '640': 2.34 / 2,
   '750': 1,
   '828': 1.81 / 2
@@ -34,17 +34,18 @@ const baseFontSize = 40
 
 const DEFAULT_WEAPP_OPTIONS = {
   platform: 'weapp',
-  designWidth: 750
+  designWidth: 750,
+  deviceRatio,
 }
 
 var targetUnit
 
 module.exports = postcss.plugin('postcss-pxtransform', function (options) {
-  options = options || DEFAULT_WEAPP_OPTIONS
+  options = Object.assign(DEFAULT_WEAPP_OPTIONS, options || {});
 
   switch (options.platform) {
     case 'weapp': {
-      options.rootValue = DEVICE_RATIO[options.designWidth]
+      options.rootValue = options.deviceRatio[options.designWidth]
       targetUnit = 'rpx'
       break
     }

--- a/packages/taro-cli/src/weapp.js
+++ b/packages/taro-cli/src/weapp.js
@@ -800,12 +800,22 @@ function compileDepStyles (outputFilePath, styleFiles, depStyleList) {
     const customPxtransformConf = customPostcssConf.pxtransform || {}
 
     try {
+      const postcssPxtransformOption = {
+        designWidth: projectConfig.designWidth || 750,
+        platform: 'weapp'
+      }
+
+      const DEVICE_RATIO = 'deviceRatio'
+      if (projectConfig.hasOwnProperty(DEVICE_RATIO)) {
+        postcssPxtransformOption[DEVICE_RATIO] = projectConfig.deviceRatio
+      }
+
       const postcssResult = await postcss([
         autoprefixer({ browsers: browserList }),
-        pxtransform(Object.assign({
-          designWidth: projectConfig.designWidth || 750,
-          platform: 'weapp'
-        }, customPxtransformConf))
+        pxtransform(Object.assign(
+          postcssPxtransformOption,
+          customPxtransformConf
+        ))
       ]).process(resContent, {
         from: undefined
       })

--- a/packages/taro-cli/templates/default/config/index
+++ b/packages/taro-cli/templates/default/config/index
@@ -2,6 +2,11 @@ const config = {
   projectName: '<%= projectName %>',
   date: '<%= date %>',
   designWidth: 750,
+  deviceRatio: {
+    '640': 2.34 / 2,
+    '750': 1,
+    '828': 1.81 / 2
+  },
   sourceRoot: 'src',
   outputRoot: 'dist',
   plugins: {


### PR DESCRIPTION
增加 `尺寸设计稿换算配置` 的可配置的设置，使用方法：
```
// config/index.js

const config = {
  ....
  deviceRatio: {
      '640': 2.34 / 2,
      '750': 1 / 2,
      '828': 1.81 / 2
  }
  ....
}
```