### PR TITLE
fix(cli): pkg模版typescript与@tarojs/plugin-typescript依赖缺失, fix #233

### DIFF
--- a/packages/taro-cli/templates/default/index.js
+++ b/packages/taro-cli/templates/default/index.js
@@ -35,7 +35,8 @@ module.exports = function (creater, params, helper, cb) {
     description,
     projectName,
     version,
-    css
+    css,
+    typescript
   })
   creater.template(template, 'project', path.join(projectPath, 'project.config.json'), {
     description,

--- a/packages/taro-cli/templates/default/pkg
+++ b/packages/taro-cli/templates/default/pkg
@@ -27,7 +27,8 @@
     "@tarojs/plugin-csso": "^<%= version %>",<% if (css !== 'none') {%>
     "@tarojs/plugin-<%= css %>": "^<%= version %>",<%}%>
     "@tarojs/plugin-uglifyjs": "^<%= version %>",
-    "@tarojs/webpack-runner": "^<%= version %>",
+    "@tarojs/webpack-runner": "^<%= version %>",<% if (typescript) {%>
+    "@tarojs/plugin-typescript": "^<%= version %>",<%}%>
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
@@ -37,7 +38,7 @@
     "eslint-config-taro": "^<%= version %>",
     "eslint-plugin-react": "^7.8.2",
     "eslint-plugin-import": "^2.12.0",
-    "eslint-plugin-taro": "^<%= version %>",
-    "typescript": "^2.9.2"
+    "eslint-plugin-taro": "^<%= version %>",<% if (typescript) {%>
+    "typescript": "^2.9.2"<%}%>
   }
 }

--- a/packages/taro-cli/templates/default/pkg
+++ b/packages/taro-cli/templates/default/pkg
@@ -25,10 +25,10 @@
     "@tarojs/cli": "^<%= version %>",
     "@tarojs/plugin-babel": "^<%= version %>",
     "@tarojs/plugin-csso": "^<%= version %>",<% if (css !== 'none') {%>
-    "@tarojs/plugin-<%= css %>": "^<%= version %>",<%}%>
-    "@tarojs/plugin-uglifyjs": "^<%= version %>",
-    "@tarojs/webpack-runner": "^<%= version %>",<% if (typescript) {%>
+    "@tarojs/plugin-<%= css %>": "^<%= version %>",<%}%><% if (typescript) {%>
     "@tarojs/plugin-typescript": "^<%= version %>",<%}%>
+    "@tarojs/plugin-uglifyjs": "^<%= version %>",
+    "@tarojs/webpack-runner": "^<%= version %>",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
@@ -38,7 +38,7 @@
     "eslint-config-taro": "^<%= version %>",
     "eslint-plugin-react": "^7.8.2",
     "eslint-plugin-import": "^2.12.0",
-    "eslint-plugin-taro": "^<%= version %>",<% if (typescript) {%>
+    "eslint-plugin-taro": "^<%= version %>"<% if (typescript) {%>,
     "typescript": "^2.9.2"<%}%>
   }
 }

--- a/packages/taro-cli/templates/redux/index.js
+++ b/packages/taro-cli/templates/redux/index.js
@@ -43,7 +43,8 @@ module.exports = function (creater, params, helper, cb) {
     description,
     projectName,
     version,
-    css
+    css,
+    typescript
   })
   creater.template(template, 'project', path.join(projectPath, 'project.config.json'), {
     description,

--- a/packages/taro-cli/templates/redux/pkg
+++ b/packages/taro-cli/templates/redux/pkg
@@ -31,7 +31,8 @@
     "@tarojs/cli": "^<%= version %>",
     "@tarojs/plugin-babel": "^<%= version %>",
     "@tarojs/plugin-csso": "^<%= version %>",<% if (css !== 'none') {%>
-    "@tarojs/plugin-<%= css %>": "^<%= version %>",<%}%>
+    "@tarojs/plugin-<%= css %>": "^<%= version %>",<%}%><% if (typescript) {%>
+    "@tarojs/plugin-typescript": "^<%= version %>",<%}%>
     "@tarojs/plugin-uglifyjs": "^<%= version %>",
     "@tarojs/webpack-runner": "^<%= version %>",
     "babel-plugin-transform-class-properties": "^6.24.1",
@@ -43,6 +44,7 @@
     "eslint-config-taro": "^<%= version %>",
     "eslint-plugin-react": "^7.8.2",
     "eslint-plugin-import": "^2.12.0",
-    "eslint-plugin-taro": "^<%= version %>"
+    "eslint-plugin-taro": "^<%= version %>"<% if (typescript) {%>,
+    "typescript": "^2.9.2"<%}%>
   }
 }


### PR DESCRIPTION
开启typescript时，package.json里默认没有@tarojs/plugin-typescript这个包，导致编译失败。
添加了对typescript的判断，本地测试默认模版下，开与不开typescript都能正常编译了。