### PR TITLE
h5配置开启https文档介绍

### DIFF
--- a/docs/config-detail.md
+++ b/docs/config-detail.md
@@ -123,6 +123,12 @@ devServer: {
   port: 10086
 }
 ```
+默认是`http`服务，如果想开启`https`服务需要做如下配置。
+```
+devServer: {
+  https: true
+}
+```
 
 ### h5.publicPath
 


### PR DESCRIPTION
主要是在使用中H5需要开启https服务，通过查阅`taro-webpack-runner/src/index.ts`中的`buildDev`方法中介绍了开启`https`设置方法，因此增加了开启`https`服务文档介绍。

如果使用的不对，请告知正确用法，谢谢。