### PR TITLE
Update index.d.ts

### DIFF
--- a/packages/taro/types/index.d.ts
+++ b/packages/taro/types/index.d.ts
@@ -79,7 +79,7 @@ declare namespace Taro {
 
   function getEnv(): 'WEAPP' | 'WEB' | 'RN';
 
-  function render(component: Component, element: Element)
+  function render(component: Component, element: Element | null)
 
   /**
    *


### PR DESCRIPTION
因为 `document.getElementById` 会返回 `HTMLElement | null`，从而导致 tslint 报错。