### PR TITLE
fix connect cover props bug

### DIFF
--- a/packages/taro-redux/src/connect/connect.js
+++ b/packages/taro-redux/src/connect/connect.js
@@ -15,7 +15,9 @@ export default function connect (mapStateToProps, mapDispatchToProps) {
       if (isObject(val) && isObject(initMapDispatch[key])) {
         val = mergeObjects(val, initMapDispatch[key])
       }
-      this.prevProps = Object.assign({}, this.props)
+      if (!isChanged) {
+        this.prevProps = Object.assign({}, this.props)
+      }
       if (this.props[key] !== val) {
         this.props[key] = val
         isChanged = true

--- a/packages/taro-redux/src/connect/connect.js
+++ b/packages/taro-redux/src/connect/connect.js
@@ -15,10 +15,8 @@ export default function connect (mapStateToProps, mapDispatchToProps) {
       if (isObject(val) && isObject(initMapDispatch[key])) {
         val = mergeObjects(val, initMapDispatch[key])
       }
-      if (!isChanged) {
-        this.prevProps = Object.assign({}, this.props)
-      }
       if (this.props[key] !== val) {
+        this.prevProps = Object.assign({}, this.props)
         this.props[key] = val
         isChanged = true
       }


### PR DESCRIPTION
当使用如下情况时，会出现在`componentWillReceiveProps`中取得的`this.props`会与`nextProps`相同

```javascript
@connect(({ counter }) => ({
  num: counter.num,
  str: counter.str,
}), (dispatch) => ({
  add () {
    dispatch({type: 'counter/do', payload: 1}) // 这个更新counter中的num
  },
}))
class Index extends Component {
// ....
}
```

如上例子中，当调用`add`时，使得`store`订阅的`stateListener`触发时，通过`mapStateToProps`得到的`newMapState`的`keys`有2个，因此在遍历`newMapState`过程中会循环2次，第一次循环中`this.props`（旧的）会先被赋值给`this.prevProps`，并且`this.props[key] !== val`会成立，导致`this.props`更新，下一次循环的时候更新的`this.props`（新的）又会被赋值到`this.prevProps`中，导致`this.prevProps`存入最新的prop。