### PR TITLE
微信 API navigateBack 改为可选参数

### DIFF
--- a/packages/taro/types/index.d.ts
+++ b/packages/taro/types/index.d.ts
@@ -6590,7 +6590,7 @@ declare namespace Taro {
    *     ```
    * @see https://developers.weixin.qq.com/miniprogram/dev/api/ui-navigate.html#wxnavigatebackobject
    */
-  function navigateBack(OBJECT: navigateBack.Param): void
+  function navigateBack(OBJECT?: navigateBack.Param): void
 
   namespace createAnimation {
     type Param = {


### PR DESCRIPTION
- 修改 `taro/types` 中的微信 API navigateBack 为可选参数