### PR TITLE
feat: 新增 taro h5 模式的动态加载 import() 功能

### DIFF
--- a/packages/taro-transformer-wx/package-lock.json
+++ b/packages/taro-transformer-wx/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tarojs/transformer-wx",
-	"version": "1.0.0-beta.9",
+	"version": "1.0.0-beta.11",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -21,12 +21,6 @@
 				"esutils": "^2.0.2",
 				"js-tokens": "^3.0.0"
 			}
-		},
-		"@tarojs/taro": {
-			"version": "1.0.0-beta.9",
-			"resolved": "https://registry.npmjs.org/@tarojs/taro/-/taro-1.0.0-beta.9.tgz",
-			"integrity": "sha512-tuXmlRDhKCcvy2DoqG0m8WFD5sK6+EU9G1PkahzIwzHbdtFLf+SEXl6z+NoRKFA38wuZ7ks3ffOS8cE8IUfzLw==",
-			"dev": true
 		},
 		"@types/babel-core": {
 			"version": "6.25.5",
@@ -543,6 +537,12 @@
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
 			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
+		},
+		"babel-plugin-syntax-dynamic-import": {
+			"version": "6.18.0",
+			"resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-dynamic-import/download/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+			"dev": true
 		},
 		"babel-plugin-syntax-flow": {
 			"version": "6.18.0",
@@ -4181,6 +4181,7 @@
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.3.tgz",
 			"integrity": "sha512-/jAn9/tEX4gnpyRATxgHEOV6xbcyxgT7iUnxo9Y3+OB0zX00TgKIv/2FZCf5brBbICcwbLqVv2ImjvWWrQMSYw==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"safe-buffer": "^5.1.2",
 				"yallist": "^3.0.0"
@@ -4190,7 +4191,8 @@
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
 					"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/packages/taro-transformer-wx/package.json
+++ b/packages/taro-transformer-wx/package.json
@@ -47,6 +47,7 @@
     "babel-plugin-danger-remove-unused-import": "^1.0.13",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-traverse": "^6.26.0",
     "babel-types": "^6.26.0",
     "html": "^1.0.0",

--- a/packages/taro-transformer-wx/src/index.ts
+++ b/packages/taro-transformer-wx/src/index.ts
@@ -171,7 +171,8 @@ export default function transform (options: Options): TransformResult {
         'exponentiationOperator',
         'asyncGenerators',
         'objectRestSpread',
-        'decorators'
+        'decorators',
+        'dynamicImport'
       ] as any[]
     },
     plugins: [[require('babel-plugin-danger-remove-unused-import'), { ignore: ['Taro'] }]]


### PR DESCRIPTION
用 taro h5 模式的时候，希望用到动态加载 import()，
但每次我在代码里面用到import()的时候就会提示
unknown: 'import' and 'export' may only appear at the top level (31:8)

这是因为在编译时 ast 解析报的错，
是否可以在taro-transformer-wx中转换的babel插件配置加上dynamicImport选项？