### PR TITLE
fix: mapStateToProps 缺少第二个参数ownProps

### DIFF
--- a/packages/taro-redux/src/connect/connect.js
+++ b/packages/taro-redux/src/connect/connect.js
@@ -23,7 +23,7 @@ export default function connect (mapStateToProps, mapDispatchToProps) {
 
   const stateListener = function () {
     let isChanged = false
-    const newMapState = mapStateToProps(store.getState())
+    const newMapState = mapStateToProps(store.getState(), this.props)
     Object.keys(newMapState).forEach(key => {
       let val = newMapState[key]
       if (isObject(val) && isObject(initMapDispatch[key])) {
@@ -46,8 +46,8 @@ export default function connect (mapStateToProps, mapDispatchToProps) {
   return function connectComponent (Component) {
     let unSubscribe = null
     return class Connect extends Component {
-      constructor () {
-        super(Object.assign(...arguments, mergeObjects(mapStateToProps(store.getState()), initMapDispatch)))
+      constructor (props) {
+        super(Object.assign(...arguments, mergeObjects(mapStateToProps(store.getState(), props), initMapDispatch)))
         Object.keys(initMapDispatch).forEach(key => {
           this[`__event_${key}`] = initMapDispatch[key]
         })
@@ -55,7 +55,7 @@ export default function connect (mapStateToProps, mapDispatchToProps) {
 
       componentWillMount () {
         const store = getStore()
-        Object.assign(this.props, mergeObjects(mapStateToProps(store.getState()), initMapDispatch))
+        Object.assign(this.props, mergeObjects(mapStateToProps(store.getState(), this.props), initMapDispatch))
         unSubscribe = store.subscribe(stateListener.bind(this))
         if (super.componentWillMount) {
           super.componentWillMount()


### PR DESCRIPTION
`mapStateToProps`与 react-redux 的 `mapStateToProps`方法使用有差异，缺少第二个参数`ownProps`