### PR TITLE
H5请求参数与小程序保持一致 自动将key: value参数转成FormData

### DIFF
--- a/packages/taro-h5/src/__test__/request-test.js
+++ b/packages/taro-h5/src/__test__/request-test.js
@@ -72,11 +72,11 @@ describe('request', () => {
     })
       .then(res => {
         expect(fetch.mock.calls[0][0]).toBe('https://github.com')
+        let data = new FormData()
+        data.append('arg', 123)
         expect(fetch.mock.calls[0][1]).toEqual({
           method: 'POST',
-          body: {
-            arg: 123
-          },
+          body: data,
           headers: {
             'A': 'CCC'
           },

--- a/packages/taro-h5/src/api/request/index.js
+++ b/packages/taro-h5/src/api/request/index.js
@@ -9,6 +9,17 @@ function generateRequestUrlWithParams (url, params) {
   return url
 }
 
+function generateRequestBodyWithData (data) {
+  if (typeof data === 'object' && !('append' in data)) {
+    let formData = new FormData()
+    Object.keys(data).forEach(function (key) {
+      formData.append(key, data[key])
+    })
+    data = formData
+  }
+  return data
+}
+
 export default function request (options) {
   options = options || {}
   if (typeof options === 'string') {
@@ -46,7 +57,7 @@ export default function request (options) {
   if (methodUpper === 'GET' || methodUpper === 'HEAD') {
     url = generateRequestUrlWithParams(url, options.data)
   } else {
-    params.body = options.data
+    params.body = generateRequestBodyWithData(options.data)
   }
   if (options.header) {
     params.headers = options.header


### PR DESCRIPTION
修复POST请求时，data为对象时小程序与H5请求参数不一致问题