### PR TITLE
fix#674 outputPath读取projectConfig中的outputRoot

### DIFF
--- a/packages/taro-cli/src/build.js
+++ b/packages/taro-cli/src/build.js
@@ -5,11 +5,14 @@ const chalk = require('chalk')
 const Util = require('./util')
 const CONFIG = require('./config')
 
+const _ = require('lodash')
 const appPath = process.cwd()
+const configDir = path.join(appPath, Util.PROJECT_CONFIG)
+const projectConfig = require(configDir)(_.merge)
 
 function build (args, buildConfig) {
   const { type, watch } = buildConfig
-  const outputPath = path.join(appPath, CONFIG.OUTPUT_DIR)
+  const outputPath = path.join(appPath, projectConfig.outputRoot || CONFIG.OUTPUT_DIR)
   if (!fs.existsSync(outputPath)) {
     fs.mkdirSync(outputPath)
   } else {


### PR DESCRIPTION
build默认路径为dist，修改为读取outputRoot