### PR TITLE
fix(cli): fix the order of merge external babel config before compile script

### DIFF
--- a/packages/taro-cli/src/weapp.js
+++ b/packages/taro-cli/src/weapp.js
@@ -911,8 +911,8 @@ function copyFilesFromSrcToOutput (files) {
 }
 
 async function compileScriptFile (filePath, content) {
-  const babelConfig = Object.assign({}, pluginsConfig.babel, defaultBabelConfig)
-  const tsConfig = Object.assign({}, pluginsConfig.typescript, defaultTSConfig)
+  const babelConfig = Object.assign({}, defaultBabelConfig, pluginsConfig.babel)
+  const tsConfig = Object.assign({}, defaultTSConfig, pluginsConfig.typescript)
   if (Util.REG_TYPESCRIPT.test(filePath)) {
     const compileTSRes = await npmProcess.callPlugin('typescript', content, entryFilePath, tsConfig)
     if (compileTSRes && compileTSRes.outputText) {


### PR DESCRIPTION
## Discovery
添加自定义plugin的时候发现始终无法生效
## Analysis
自定义的外部babel config在compileScript的时候被内部默认的config以assign的方式覆盖了
## Fix
修改覆盖优先级……