### PR TITLE
fix(h5): 修复 PUT 、DELETE 等请求 body 为对象时无法发送 body 的问题

### DIFF
--- a/packages/taro-h5/src/api/request/index.js
+++ b/packages/taro-h5/src/api/request/index.js
@@ -45,7 +45,7 @@ export default function request (options) {
   params.cache = options.cache || 'default'
   if (methodUpper === 'GET' || methodUpper === 'HEAD') {
     url = generateRequestUrlWithParams(url, options.data)
-  } else if (methodUpper === 'POST' && typeof options.data === 'object') {
+  } else if (typeof options.data === 'object') {
     let contentType = options.header && (options.header['Content-Type'] || options.header['content-type'])
     if (contentType === 'application/json') {
       params.body = JSON.stringify(options.data)


### PR DESCRIPTION
修复仅对 `POST` 请求进行 `JSON.stringify`，导致当发送 `PUT` 、`DELETE` 等请求时，而 `body` 为对象却没有进行 `JSON.stringify`，`body `类型为 `object`， 无法发送 `body` 的问题（`Fetch` 的 `body` 类型貌似不能为 `object`）。