### PR TITLE
fix(webpackChain): 漏传第二个参数webpack

### DIFF
--- a/packages/taro-webpack-runner/src/index.ts
+++ b/packages/taro-webpack-runner/src/index.ts
@@ -19,7 +19,7 @@ import { BuildConfig } from './util/types'
 
 const customizeChain = (chain, config) => {
   if (config.webpackChain instanceof Function) {
-    config.webpackChain(chain)
+    config.webpackChain(chain, webpack)
   }
 }
 


### PR DESCRIPTION
https://nervjs.github.io/taro/docs/config-detail.html#h5webpackchain

webpackChain 应有两个参数, 但源码里只传了一个