### PR TITLE
fix #809 支持在 yarn workspace 目录结构下进行 build

### DIFF
--- a/packages/taro-cli/src/util/index.js
+++ b/packages/taro-cli/src/util/index.js
@@ -155,6 +155,19 @@ exports.FILE_PROCESSOR_MAP = {
   '.styl': 'stylus'
 }
 
+exports.findRoot = function findRoot (sPath) {
+  sPath = sPath || process.cwd()
+  if (!sPath.length) return null
+  var dir = sPath.join(path.sep)
+  try {
+    const isRoot = fs.existsSync(path.join(dir, 'package.json'))
+    if (isRoot) return dir
+  } catch (e) {}
+  sPath = sPath.split(path.sep)
+  sPath.pop()
+  return findRoot(sPath)
+}
+
 exports.isNpmPkg = function (name) {
   if (/^(\.|\/)/.test(name)) {
     return false

--- a/packages/taro-cli/src/util/resolve_npm_files.js
+++ b/packages/taro-cli/src/util/resolve_npm_files.js
@@ -19,7 +19,8 @@ const {
   generateEnvList,
   REG_TYPESCRIPT,
   BUILD_TYPES,
-  REG_STYLE
+  REG_STYLE,
+  findRoot
 } = require('./index')
 
 const npmProcess = require('./npm')
@@ -145,7 +146,7 @@ function recursiveRequire (filePath, files, isProduction, npmConfig = {}) {
   let fileContent = fs.readFileSync(filePath).toString()
   let outputNpmPath
   if (!npmConfig.dir) {
-    outputNpmPath = filePath.replace('node_modules', path.join(outputDirName, npmConfig.name))
+    outputNpmPath = filePath.replace(/(.*?)node_modules/, path.join(findRoot(), outputDirName, npmConfig.name))
     outputNpmPath = outputNpmPath.replace(/node_modules/g, npmConfig.name)
   } else {
     const npmFilePath = filePath.replace(/(.*)node_modules/, '')

--- a/packages/taro-cli/src/weapp.js
+++ b/packages/taro-cli/src/weapp.js
@@ -89,7 +89,7 @@ function getExactedNpmFilePath (npmName, filePath) {
       outputNpmPath = npmInfoMainPath
     } else {
       if (!weappNpmConfig.dir) {
-        outputNpmPath = npmInfoMainPath.replace(NODE_MODULES, path.join(outputDirName, weappNpmConfig.name))
+        outputNpmPath = npmInfoMainPath.replace(NODE_MODULES_REG, path.join(Util.findRoot(), outputDirName, weappNpmConfig.name))
       } else {
         const npmFilePath = npmInfoMainPath.replace(NODE_MODULES_REG, '')
         outputNpmPath = path.join(path.resolve(configDir, '..', weappNpmConfig.dir), weappNpmConfig.name, npmFilePath)


### PR DESCRIPTION
fix #809 

yarn workspace 目录结构下，子项目的公共依赖被提升到了 workspace 的 node_modules 里。导致之前计算目标路径的方法出错，复制到了 workspace 目录下。

加了个 findRoot 工具函数，用于找到最接近工作目录的 package.json 所在路径。