### PR TITLE
trtriggerEvent 增加一个字段，让原生用组件时，事件能直接传递值

### DIFF
--- a/packages/taro-weapp/src/component.js
+++ b/packages/taro-weapp/src/component.js
@@ -91,11 +91,15 @@ class BaseComponent {
       fn.apply(scope, args)
     } else {
       // 普通的
-      const keyLower = key.toLocaleLowerCase()
-      this.$scope.triggerEvent(keyLower, {
+      let detail = {
         __isCustomEvt: true,
         __arguments: args
-      })
+      };
+      if( args.length > 0 ){
+        detail.value = args[1];
+      }
+      const keyLower = key.toLocaleLowerCase()
+      this.$scope.triggerEvent(keyLower, detail)
     }
   }
 }


### PR DESCRIPTION
小程序使用taro编译的组件时，事件的传递值不是直接e.detail.就能拿到，现在加上一个value的字段，能在混用的时候方便拿到对应的值