### PR TITLE
修复 await Taro.connectSocket 获取不到 SocketTask 的错误

### DIFF
--- a/packages/taro-weapp/src/native-api.js
+++ b/packages/taro-weapp/src/native-api.js
@@ -118,7 +118,13 @@ function processApis (taro) {
             obj[k] = (res) => {
               options[k] && options[k](res)
               if (k === 'success') {
-                resolve(res)
+                if (key === 'connectSocket') {
+                  resolve(
+                    Promise.resolve().then(() => Object.assign(task, res))
+                  )
+                } else {
+                  resolve(res)
+                }
               } else if (k === 'fail') {
                 reject(res)
               }


### PR DESCRIPTION
revert f5ad3e5 (fix 619)
fix #619 
fix #919

#### Checklist
- [x]  commit message follows commit guidelines
- [ ]  documentation is changed or added
- [ ]  tests and/or benchmarks are included

#### Affected core subsystem(s)

- packages/taro-weapp

#### Description of change

之前解决 issue #619  的提交引发了 #919   

微信小程序中
```javascript
let successResult
const task = wx.connectSocket({success(result){
    successResult = result
}})

task !== successResult
```

且 task instanceof SocketTask(如果有) 为true，successResult 是常规的object。

commit f5ad3e5 中将 resolve(task) 这个情况去掉了，造成没有情况返回 socketTask。
出现了 #919 （这个现象，让我误以为是api变更导致，实际上小程序api的变更，只是增加了api，并没有改变connectSocket的同步返回值，回调返回值）

会导致 [websocket测试案例](https://github.com/NervJS/taro/blob/7bbd49ca3bd2f7c7738c32c5a1f37cefc74e7fc6/packages/taro-rn/src/__tests__/websocket.test.js#L133) (如果有小程序版的)失败

此PR改善对 #619 的fix方式，通过一个microtask消除task为null的bug，顺便将success返回的结果并入socketTask上，以与其他promise化的api保证一致的预期结果。

#### TODO
- 上述最后的一步处理待商榷，有那么点儿不一样
