### PR TITLE
taro类型文件中加入navigateToMiniProgramAppIdList字段支持

### DIFF
--- a/packages/taro/types/index.d.ts
+++ b/packages/taro/types/index.d.ts
@@ -323,6 +323,11 @@ declare namespace Taro {
      * @since 2.3.0
      */
     resizable?: boolean
+    /**
+     * 需要跳转的小程序列表
+     * @since 2.4.0 
+     */
+    navigateToMiniProgramAppIdList?: string[]
   }
 
   interface Config extends PageConfig, AppConfig {


### PR DESCRIPTION
微信2.4.0开始小程序之间跳转需要在全局配置中增加navigateToMiniProgramAppIdList字段
