### PR TITLE
feat(redux): 微信端 connect 的 mapDispatchToProps 参数支持传递对象 #298

### DIFF
--- a/packages/taro-redux/src/connect/connect.js
+++ b/packages/taro-redux/src/connect/connect.js
@@ -15,10 +15,29 @@ function isEqual (a, b) {
   return a === b
 }
 
+function wrapPropsWithDispatch (mapDispatchToProps, dispatch) {
+  if (typeof mapDispatchToProps === 'function') {
+    return mapDispatchToProps(dispatch)
+  } 
+
+  if (isObject(mapDispatchToProps)) {
+    return Object.keys(mapDispatchToProps)
+      .reduce((props, key) => {
+        const actionCreator = mapDispatchToProps[key]
+        if (typeof actionCreator === 'function') {
+          props[key] = (...args) => dispatch(actionCreator(...args))
+        }
+        return props
+      }, {})
+  }
+
+  return {}
+}
+
 export default function connect (mapStateToProps, mapDispatchToProps) {
   const store = getStore()
   const dispatch = store.dispatch
-  const initMapDispatch = typeof mapDispatchToProps === 'function' ? mapDispatchToProps(dispatch) : {}
+  const initMapDispatch = wrapPropsWithDispatch(mapDispatchToProps, dispatch)
   initMapDispatch.dispatch = dispatch
 
   const stateListener = function () {


### PR DESCRIPTION
增加了对微信端 connect 第二个参数 mapDispatchToProps 传递为对象的支持。#298

以前必须传递为函数：
```js
export default connect(mapStateToProps, (dispatch) => ({
  add: () => dispatch(add())
}))(Component)
```

现在可以传递对象：
```js
export default connect(mapStateToProps, {
  add,
  minus,
})(Component)
```

当前未发布到新版本时，可以用以下的方法做兼容：
```js
// utils/index.js
import { bindActionCreators } from 'redux';

export function withDispatch(actionCreators) {
  if (typeof actionCreators === 'object') {
    return function mapDisptchToProps(dispatch) {
      return bindActionCreators(actionCreators, dispatch);
    };
  }
  return actionCreators;
}

// pages/index/index.js
import { withDispatch } from '../../utils';

// ...

export default connect(mapStateToProps, withDispatch({
  minus,
  plus
}))(Component);
```
上面的方法有点烦琐，其实可以直接包装一下 connect 返回一个新的 connect 函数，但是测试发现 connect 自带黑科技（原因未知，如直接赋值给另一变量或者在一个函数里面调用它），改写了后不触发生命周期函数，state 的计算是放在生命周期函数里面的，所以会导致 props 为空对象。
