### PR TITLE
fix(taroize) WXS 标签允许没有src属性，只有module属性

### DIFF
--- a/packages/taroize/src/wxml.ts
+++ b/packages/taroize/src/wxml.ts
@@ -41,7 +41,7 @@ interface Text {
 
 export interface WXS {
   module: string
-  src: string
+  src?: string | null
 }
 
 type AllKindNode = Element | Comment | Text
@@ -224,8 +224,8 @@ function getWXS (attrs: t.JSXAttribute[], path: NodePath<t.JSXElement>): WXS {
     }
   }
 
-  if (!moduleName || !src) {
-    throw new Error('一个 WXS 需要同时存在两个属性：`wxs`, `src`')
+  if (!moduleName) {
+    throw new Error('WXS标签需存在 module 属性')
   }
 
   path.remove()


### PR DESCRIPTION
Hello Taro,
WXS文档: https://developers.weixin.qq.com/miniprogram/dev/framework/view/wxs/ 中允许在标签中写wxs的逻辑，所有src属性可以不必填。

```html
<!--wxml-->
<wxs module="m1">
var msg = "hello world";

module.exports.message = msg;
</wxs>

<view> {{m1.message}} </view>
```