### PR TITLE
fix a bug where miss a comma

### DIFF
--- a/packages/taro-cli/templates/default/config/index
+++ b/packages/taro-cli/templates/default/config/index
@@ -48,7 +48,7 @@ const config = {
           config: {
 
           }
-        }
+        },
         url: {
           enable: true,
           config: {


### PR DESCRIPTION
Missing a comma before 'url' in taro/packages/taro-cli/templates/default/config/index.js line 51