### PR TITLE
fix: fix form item typing for `name` property

### DIFF
--- a/packages/taro-components/types/Input.d.ts
+++ b/packages/taro-components/types/Input.d.ts
@@ -1,7 +1,7 @@
 import { ComponentType } from 'react'
-import { StandardProps, BaseEventFunction } from './common'
+import { StandardProps, BaseEventFunction, FormItemProps } from './common'
 
-interface InputProps extends StandardProps {
+interface InputProps extends StandardProps, FormItemProps {
 
   /**
    * 输入框的初始内容

--- a/packages/taro-components/types/Picker.d.ts
+++ b/packages/taro-components/types/Picker.d.ts
@@ -1,7 +1,7 @@
 import { ComponentType } from 'react'
-import { StandardProps, BaseEventFunction } from './common'
+import { StandardProps, BaseEventFunction, FormItemProps } from './common'
 
-interface PickerStandardProps extends StandardProps {
+interface PickerStandardProps extends StandardProps, FormItemProps {
   /**
    * 是否禁用
    *

--- a/packages/taro-components/types/Slider.d.ts
+++ b/packages/taro-components/types/Slider.d.ts
@@ -1,7 +1,7 @@
 import { ComponentType } from 'react'
-import { StandardProps, BaseEventFunction } from './common'
+import { StandardProps, BaseEventFunction, FormItemProps } from './common'
 
-interface SliderProps extends StandardProps {
+interface SliderProps extends StandardProps, FormItemProps {
 
   /**
    * 最小值

--- a/packages/taro-components/types/Switch.d.ts
+++ b/packages/taro-components/types/Switch.d.ts
@@ -1,7 +1,7 @@
 import { ComponentType } from 'react'
-import { StandardProps, BaseEventFunction } from './common'
+import { StandardProps, BaseEventFunction, FormItemProps } from './common'
 
-interface SwitchProps extends StandardProps {
+interface SwitchProps extends StandardProps, FormItemProps {
 
   /**
    * 是否选中

--- a/packages/taro-components/types/Textarea.d.ts
+++ b/packages/taro-components/types/Textarea.d.ts
@@ -1,7 +1,7 @@
 import { ComponentType } from 'react'
-import { StandardProps, BaseEventFunction } from './common'
+import { StandardProps, BaseEventFunction, FormItemProps } from './common'
 
-interface TextareaProps extends StandardProps {
+interface TextareaProps extends StandardProps, FormItemProps {
 
   /**
    * 输入框的内容

--- a/packages/taro-components/types/common.d.ts
+++ b/packages/taro-components/types/common.d.ts
@@ -28,6 +28,13 @@ export interface StandardProps extends EventProps {
   animation?: object[]
 }
 
+interface FormItemProps {
+  /**
+   * 表单数据标识
+   */
+  name?: string,
+}
+
 interface EventProps {
   /**
    * 手指触摸动作开始


### PR DESCRIPTION
之前的typing文件，表单项没有包含name 属性。