### PR TITLE
fix(templates)：修复decorator无法作用到property的问题

### DIFF
--- a/packages/taro-cli/templates/default/config/index
+++ b/packages/taro-cli/templates/default/config/index
@@ -16,8 +16,8 @@ const config = {
         'env'
       ],
       plugins: [
-        'transform-class-properties',
         'transform-decorators-legacy',
+        'transform-class-properties',
         'transform-object-rest-spread'
       ]
     }

--- a/packages/taro-cli/templates/mobx/config/index
+++ b/packages/taro-cli/templates/mobx/config/index
@@ -16,8 +16,8 @@ const config = {
         'env'
       ],
       plugins: [
-        'transform-class-properties',
         'transform-decorators-legacy',
+        'transform-class-properties',
         'transform-object-rest-spread'
       ]
     }

--- a/packages/taro-cli/templates/redux/config/index
+++ b/packages/taro-cli/templates/redux/config/index
@@ -16,8 +16,8 @@ const config = {
         'env'
       ],
       plugins: [
-        'transform-class-properties',
         'transform-decorators-legacy',
+        'transform-class-properties',
         'transform-object-rest-spread'
       ]
     }


### PR DESCRIPTION
当前在property中使用decorator存在无效的问题，主要原因是babel配置顺序导致，详情参见：

https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy#note-order-of-plugins-matters