### PR TITLE
bugfix: RN的Audio组件在WillUnmount的时候要Unloads the media from memory

### DIFF
--- a/packages/taro-components-rn/src/components/Audio/index.tsx
+++ b/packages/taro-components-rn/src/components/Audio/index.tsx
@@ -212,6 +212,7 @@ class _Audio extends React.Component<Props, State> {
       'connectionChange',
       this._onConnectionChange.bind(this)
     )
+    soundObject.unloadAsync()
   }
 
   render() {


### PR DESCRIPTION
修复RN的Audio组件在页面退出时还会继续播放，重新进入时Audio组件没有重新加载的bug