### PR TITLE
fix(showActionSheet): fix未设置webkitTransform导致菜单不能弹出的bug

### DIFF
--- a/packages/taro-h5/src/api/interactive/actionSheet.js
+++ b/packages/taro-h5/src/api/interactive/actionSheet.js
@@ -1,4 +1,4 @@
-import { inlineStyle } from '../utils'
+import { inlineStyle, setTransform } from '../utils'
 
 export default class ActionSheet {
   constructor () {
@@ -13,7 +13,7 @@ export default class ActionSheet {
     }
   }
 
-  getstyle (name) {
+  getStyle () {
     return {
       maskStyle: {
         'position': 'fixed',
@@ -59,7 +59,7 @@ export default class ActionSheet {
 
   create (options = {}) {
     // style
-    const { maskStyle, actionSheetStyle, menuStyle, cellStyle, cancelStyle } = this.getstyle()
+    const { maskStyle, actionSheetStyle, menuStyle, cellStyle, cancelStyle } = this.getStyle()
 
     // configuration
     Object.assign(this.options, options)
@@ -121,7 +121,7 @@ export default class ActionSheet {
     document.body.appendChild(this.el)
     setTimeout(() => {
       this.el.style.opacity = '1'
-      this.actionSheet.style.transform = 'translate(0, 0)'
+      setTransform(this.actionSheet, 'translate(0, 0)')
     }, 0)
 
     return new Promise((resolve, reject) => {
@@ -139,7 +139,7 @@ export default class ActionSheet {
     Object.assign(config, options)
 
     // cells
-    const { cellStyle } = this.getstyle()
+    const { cellStyle } = this.getStyle()
 
     options.itemList.forEach((item, index) => {
       if (this.cells[index]) {
@@ -175,7 +175,7 @@ export default class ActionSheet {
     this.el.style.display = 'block'
     setTimeout(() => {
       this.el.style.opacity = '1'
-      this.actionSheet.style.transform = 'translate(0, 0)'
+      setTransform(this.actionSheet, 'translate(0, 0)')
     }, 0)
 
     return new Promise((resolve, reject) => {
@@ -198,7 +198,7 @@ export default class ActionSheet {
   hide () {
     setTimeout(() => {
       this.el.style.opacity = '0'
-      this.actionSheet.style.transform = 'translate(0, 100%)'
+      setTransform(this.actionSheet, 'translate(0, 100%)')
       setTimeout(() => { this.el.style.display = 'none' }, 200)
     }, 0)
   }

--- a/packages/taro-h5/src/api/utils.js
+++ b/packages/taro-h5/src/api/utils.js
@@ -30,6 +30,12 @@ function inlineStyle (style) {
   return res
 }
 
+
+function setTransform (el, val) {
+  el.style.webkitTransform = val
+  el.style.transform = val
+}
+
 function errorHandler (fail, complete) {
   return function (res) {
     typeof fail === 'function' && fail(res)
@@ -52,6 +58,7 @@ export {
   shouleBeObject,
   getParameterError,
   inlineStyle,
+  setTransform,
   errorHandler,
   serializeParams
 }


### PR DESCRIPTION
修改前, 只设置了 style.transform, 未设置 style.webkitTransform, 在旧浏览器中会出现菜单不能弹出的bug.