### PR TITLE
Replace deprecated rule jsx-space-before-closing

### DIFF
--- a/packages/eslint-config-taro/rules/jsx.js
+++ b/packages/eslint-config-taro/rules/jsx.js
@@ -228,9 +228,8 @@ module.exports = {
     // }],
 
     // Enforce spaces before the closing bracket of self-closing JSX elements
-    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-space-before-closing.md
-    // Deprecated in favor of jsx-tag-spacing
-    'react/jsx-space-before-closing': ['error', 'always'],
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-tag-spacing.md
+    'react/jsx-tag-spacing': ["error", { "beforeSelfClosing": "always" }],
 
     // // Prevent usage of Array index in keys
     // // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-array-index-key.md


### PR DESCRIPTION
This eslint rule from `eslint-plugin-react`, `react/jsx-space-before-closing` is deprecated。

When I run `taro init myApp & cd myApp` then run `eslint src`, terminal will tips `The react/jsx-space-before-closing rule is deprecated. Please use the react/jsx-tag-spacing rule with the "beforeSelfClosing" option instead.`