### PR TITLE
fix: h5 uses cssModule error

### DIFF
--- a/packages/taro-webpack-runner/src/util/chain.ts
+++ b/packages/taro-webpack-runner/src/util/chain.ts
@@ -201,6 +201,10 @@ const getModule = ({
     },
     cssLoaderOption
   ]
+  if (postcssOption.cssModules && postcssOption.cssModules.config && postcssOption.cssModules.config.generateScopedName) {
+    cssOptions[0].localIdentName = postcssOption.cssModules.config.generateScopedName;
+  }
+  
   /**
    * css-loader 1.0.0版本移除了minimize选项...升级需谨慎
    *
@@ -214,8 +218,7 @@ const getModule = ({
       ident: 'postcss',
       plugins: getPostcssPlugins({
         designWidth,
-        deviceRatio,
-        postcssOption
+        deviceRatio
       })
     }
   ])


### PR DESCRIPTION
如果在自定义配置中启用了cssModules，cssModule 和 cssLoader 都做了一次处理，去掉了一次处理。