### PR TITLE
feat: 项目配置中支持添加 pathAlias 配置 import 路径自定义别名

### DIFF
--- a/packages/taro-cli/src/h5.js
+++ b/packages/taro-cli/src/h5.js
@@ -315,8 +315,16 @@ function processEntry (code, filePath) {
       enter (astPath) {
         const node = astPath.node
         const source = node.source
-        const value = source.value
         const specifiers = node.specifiers
+        let value = source.value
+        const pathAlias = projectConfig.pathAlias || {}
+        if (Util.isAliasPath(value, Object.keys(pathAlias))) {
+          let reg = new RegExp(`^(${Object.keys(pathAlias).join('|')})/`)
+          value = value.replace(reg, function (matched, $1) {
+            return './' + path.relative(path.dirname(filePath), sourceDir) + pathAlias[$1] + '/'
+          })
+          source.value = value
+        }
         if (!Util.isNpmPkg(value)) {
           if (value.indexOf('.') === 0) {
             const pathArr = value.split('/')
@@ -545,8 +553,16 @@ function processOthers (code, filePath) {
       enter (astPath) {
         const node = astPath.node
         const source = node.source
-        const value = source.value
+        let value = source.value
         const specifiers = node.specifiers
+        const pathAlias = projectConfig.pathAlias || {}
+        if (Util.isAliasPath(value, Object.keys(pathAlias))) {
+          let reg = new RegExp(`^(${Object.keys(pathAlias).join('|')})/`)
+          value = value.replace(reg, function (matched, $1) {
+            return path.relative(path.dirname(filePath), sourceDir) + pathAlias[$1] + '/'
+          })
+          source.value = value
+        }
         if (!Util.isNpmPkg(value)) {
           if (Util.REG_SCRIPTS.test(value)) {
             const dirname = path.dirname(value)

--- a/packages/taro-cli/src/util/index.js
+++ b/packages/taro-cli/src/util/index.js
@@ -185,6 +185,14 @@ exports.isNpmPkg = function (name) {
   return true
 }
 
+exports.isAliasPath = function(name, prefixs = []) {
+  if (prefixs.length === 0){
+    return false
+  }
+  return new RegExp(`^(${prefixs.join('|')})/`).test(name)
+}
+
+
 exports.promoteRelativePath = function (fPath) {
   const fPathArr = fPath.split(path.sep)
   let dotCount = 0

--- a/packages/taro-cli/src/util/index.js
+++ b/packages/taro-cli/src/util/index.js
@@ -185,13 +185,12 @@ exports.isNpmPkg = function (name) {
   return true
 }
 
-exports.isAliasPath = function(name, prefixs = []) {
-  if (prefixs.length === 0){
+exports.isAliasPath = function (name, prefixs = []) {
+  if (prefixs.length === 0) {
     return false
   }
   return new RegExp(`^(${prefixs.join('|')})/`).test(name)
 }
-
 
 exports.promoteRelativePath = function (fPath) {
   const fPathArr = fPath.split(path.sep)

--- a/packages/taro-cli/src/weapp.js
+++ b/packages/taro-cli/src/weapp.js
@@ -386,8 +386,8 @@ function parseAst (type, ast, depComponents, sourceFilePath, filePath, npmSkip =
       let pathAlias = projectConfig.pathAlias || {}
       if (Util.isAliasPath(value, Object.keys(pathAlias))) {
         let reg = new RegExp(`^(${Object.keys(pathAlias).join('|')})/`)
-        value = value.replace(reg,function(matched,$1){
-          return './'+path.relative(path.dirname(sourceFilePath), sourceDir)+ pathAlias[$1] + '/'
+        value = value.replace(reg, function (matched, $1) {
+          return './' + path.relative(path.dirname(sourceFilePath), sourceDir) + pathAlias[$1] + '/'
         })
         source.value = value
       }

--- a/packages/taro-cli/src/weapp.js
+++ b/packages/taro-cli/src/weapp.js
@@ -382,6 +382,15 @@ function parseAst (type, ast, depComponents, sourceFilePath, filePath, npmSkip =
       const source = node.source
       let value = source.value
       const specifiers = node.specifiers
+      // 替换用户自定义前缀
+      let pathAlias = projectConfig.pathAlias || {}
+      if (Util.isAliasPath(value, Object.keys(pathAlias))) {
+        let reg = new RegExp(`^(${Object.keys(pathAlias).join('|')})/`)
+        value = value.replace(reg,function(matched,$1){
+          return './'+path.relative(path.dirname(sourceFilePath), sourceDir)+ pathAlias[$1] + '/'
+        })
+        source.value = value
+      }
       if (Util.isNpmPkg(value) && notExistNpmList.indexOf(value) < 0) {
         if (value === taroJsComponents) {
           astPath.remove()


### PR DESCRIPTION
支持在项目配置中加入 pathAlias 选项，实现import的自定义前缀别名
在项目 config/index.js 中加入类似下面配置
```
pathAlias: {
    '@': '',
    '@base': 'base',
  },
```

可在页面中以如下方式引入文件
`import UserService from '@/services/UserService'`
