### PR TITLE
允许从 this.props 而来的函数名以`dispatch` 开头

### DIFF
--- a/packages/eslint-plugin-taro/__tests__/this-props-function.js
+++ b/packages/eslint-plugin-taro/__tests__/this-props-function.js
@@ -4,7 +4,7 @@ const { parserOptions, testComponent } = require('../utils/utils')
 
 const ruleTester = new RuleTester({ parserOptions, parser: 'babel-eslint' })
 
-const ERROR_MESSAGE = '从 this.props 而来的函数名必须要以 `on` 开头'
+const ERROR_MESSAGE = '从 this.props 而来的函数名必须要以 `on` 或 `dispatch` 开头'
 
 function testInvalid (message, tests) {
   return tests.map(code => ({
@@ -19,6 +19,10 @@ ruleTester.run('no-stateless-component', rule, {
   }, {
     code: testComponent(`this.props.onF()`)
   }, {
+    code: testComponent(`this.dispatch()`)
+  }, {
+    code: testComponent(`this.dispatchF()`)
+  }, {
     code: testComponent(`this.click()`)
   }, {
     code: testComponent(`click()`)
@@ -29,6 +33,8 @@ ruleTester.run('no-stateless-component', rule, {
   }],
   invalid: testInvalid(ERROR_MESSAGE, [
     `this.props.click()`,
-    `this.props.f()`
+    `this.props.f()`,
+    `this.props.onf`,
+    `this.props.dispatchf`
   ])
 })

--- a/packages/eslint-plugin-taro/__tests__/this-props-function.js
+++ b/packages/eslint-plugin-taro/__tests__/this-props-function.js
@@ -34,7 +34,7 @@ ruleTester.run('no-stateless-component', rule, {
   invalid: testInvalid(ERROR_MESSAGE, [
     `this.props.click()`,
     `this.props.f()`,
-    `this.props.onf`,
-    `this.props.dispatchf`
+    `this.props.onf()`,
+    `this.props.dispatchf()`
   ])
 })

--- a/packages/eslint-plugin-taro/rules/this-props-function.js
+++ b/packages/eslint-plugin-taro/rules/this-props-function.js
@@ -17,11 +17,11 @@ module.exports = {
             object.object.type === 'ThisExpression' &&
             object.property.name === 'props' &&
             property.type === 'Identifier' &&
-            !/^on[A-Z_]/.test(property.name) &&
+            !/^(on|dispatch)[A-Z_]/.test(property.name) &&
             property.name !== 'dispatch'
           ) {
             context.report({
-              message: '从 this.props 而来的函数名必须要以 `on` 开头',
+              message: '从 this.props 而来的函数名必须要以 `on` 或 `dispatch` 开头',
               node
             })
           }


### PR DESCRIPTION
例如：

```javascript
const mapDispatchToProps = dispatch =>({
  dispatchA(){
    dispatch(actions.Foo())
  },
  dispatchB(){}
})
```