### PR TITLE
表单组件props属性完善 Picker组件属性完善

### DIFF
--- a/packages/taro-components/types/Checkbox.d.ts
+++ b/packages/taro-components/types/Checkbox.d.ts
@@ -1,11 +1,7 @@
 import { ComponentType } from 'react'
-import { StandardProps, BaseEventFunction } from './common'
+import { StandardProps, BaseEventFunction, FormItemProps } from './common'
 
-interface CheckboxGroupProps extends StandardProps {
-  /**
-   * 表单组件中加上 name 来作为 key
-   */
-  name: string;
+interface CheckboxGroupProps extends StandardProps, FormItemProps {
   /**
    * <checkbox-group/>中选中项发生改变是触发 change 事件
    *

--- a/packages/taro-components/types/Input.d.ts
+++ b/packages/taro-components/types/Input.d.ts
@@ -133,8 +133,6 @@ interface InputProps extends StandardProps, FormItemProps {
    * event.detail = {value: value}
    */
   onConfirm?: BaseEventFunction
-
-  name?: string
 }
 
 declare const Input: ComponentType<InputProps>

--- a/packages/taro-components/types/Picker.d.ts
+++ b/packages/taro-components/types/Picker.d.ts
@@ -116,7 +116,7 @@ interface PickerRegionProps extends PickerStandardProps {
   /**
    * 仅当 mode = region 时有效，可为每一列的顶部添加一个自定义的项
    */
-  customItem: string
+  customItem?: string
 }
 
 declare const Picker: ComponentType<

--- a/packages/taro-components/types/Radio.d.ts
+++ b/packages/taro-components/types/Radio.d.ts
@@ -1,11 +1,7 @@
 import { ComponentType } from 'react'
-import { StandardProps, BaseEventFunction } from './common'
+import { StandardProps, BaseEventFunction, FormItemProps } from './common'
 
-interface RadioGroupProps extends StandardProps {
-  /**
-   * 表单组件中加上 name 来作为 key
-   */
-  name: string;
+interface RadioGroupProps extends StandardProps, FormItemProps {
   onChange?: BaseEventFunction
 }
 


### PR DESCRIPTION
表单组件的没有name属性的继承了FormItemProps，已重复的去掉了name。
Picker选择地区组件CustomItem改为可为空