### PR TITLE
更新文档（事件处理）

### DIFF
--- a/docs/event.md
+++ b/docs/event.md
@@ -50,7 +50,7 @@ class Toggle extends React.Component {
 
 ## 向事件处理程序传递参数
 
-通常我们会为事件处理程序传递额外的参数。例如，若是 `id` 是你要删除那一行的 `id`，以下两种方式都可以向事件处理程序传递参数：
+通常我们会为事件处理程序传递额外的参数。例如，传入欲删除行的 `id`：
 
 ```jsx
 <button onClick={this.deleteRow.bind(this, id)}>Delete Row</button>


### PR DESCRIPTION
「以下两种方式都可以向事件处理程序传递参数」似乎抄自React文档，
但Taro其实只支持 `bind` 这一种方式，
下面的代码示例也只有一种方式。
所以我把这句话去掉了，以免造成困惑。