### PR TITLE
fix: 解决taro init从命令行输入参数无效的问题

### DIFF
--- a/packages/taro-cli/bin/taro-init
+++ b/packages/taro-cli/bin/taro-init
@@ -5,14 +5,27 @@ const program = require('commander')
 const Project = require('../src/project')
 
 program
-  .option('--name', '项目名称')
-  .option('--description', '项目介绍')
-  .option('--typescript', '是否使用 TypeScript')
-  .option('--template', '项目模板')
+  .option('--name [name]', '项目名称')
+  .option('--description [description]', '项目介绍')
+  .option('--typescript', '使用TypeScript')
+  .option('--no-typescript', '不使用TypeScript')
+  .option('--template [template]', '项目模板(default/redux/mobx)')
+  .option('--css [css]', 'CSS预处理器(sass/less/stylus/none)')
   .parse(process.argv)
 
 const args = program.args
-const { template, description, name, typescript } = program
+const { template, description, name, css } = program
+let typescript = ''
+
+/**
+ * 非标准做法
+ * 为了兼容不指定typescript参数时，在inquirer中询问是否使用typescript的情况
+ */
+if (program.rawArgs.indexOf('--typescript') !== -1) {
+  typescript = true
+} else if (program.rawArgs.indexOf('--no-typescript') !== -1) {
+  typescript = false
+}
 
 const projectName = args[0] || name
 
@@ -20,7 +33,8 @@ const project = new Project({
   projectName,
   template,
   description,
-  typescript
+  typescript,
+  css
 })
 
 project.create()

--- a/packages/taro-cli/src/project.js
+++ b/packages/taro-cli/src/project.js
@@ -21,6 +21,7 @@ class Project extends Creator {
       throw new Error('Node.js 版本过低，推荐升级 Node.js 至 v8.0.0+')
     }
     this.rootPath = this._rootPath
+
     this.conf = Object.assign({
       projectName: null,
       template: null,
@@ -109,12 +110,14 @@ class Project extends Creator {
       value: 'none'
     }]
 
-    prompts.push({
-      type: 'list',
-      name: 'css',
-      message: '请选择 CSS 预处理器（Sass/Less/Stylus）',
-      choices: cssChoices
-    })
+    if (typeof conf.css !== 'string') {
+      prompts.push({
+        type: 'list',
+        name: 'css',
+        message: '请选择 CSS 预处理器（Sass/Less/Stylus）',
+        choices: cssChoices
+      })
+    }
 
     const templateChoices = [{
       name: '默认模板',


### PR DESCRIPTION
解决taro init中的其他参数无法在命令行中指定的问题。
但因为参数typescript需要是boolean值，为了兼容不指定typescript参数时，在inquirer中再进行询问的情况，做了不优雅的兼容处理（如有更好的写法欢迎提出）。