### PR TITLE
chore(taro-swan): remove unnecessary judge

### DIFF
--- a/packages/taro-swan/src/create-component.js
+++ b/packages/taro-swan/src/create-component.js
@@ -220,7 +220,7 @@ function initComponent (ComponentClass, isPage) {
     const nextProps = filterProps(ComponentClass.properties, ComponentClass.defaultProps, this.$component.props, this.data)
     this.$component.props = nextProps
   }
-  if (hasPageInited || isPage) {
+  if (hasPageInited) {
     updateComponent(this.$component)
   }
 }


### PR DESCRIPTION
The value of `hasPageInited` always equal `ture` when variable `isPage` equal `true`. Then the value of `hasPageInited || isPage` always equal `hasPageInited` , so `isPage` is unnecessary.