### PR TITLE
fix: 将 taro-cli 加入项目开发依赖，并加入 update script

### DIFF
--- a/packages/taro-cli/templates/default/pkg
+++ b/packages/taro-cli/templates/default/pkg
@@ -16,7 +16,7 @@
     "dev:alipay": "npm run build:alipay -- --watch",
     "dev:tt": "npm run build:tt -- --watch",
     "dev:h5": "npm run build:h5 -- --watch",
-    "dev:rn": "npm run build:rn -- --watch"c
+    "dev:rn": "npm run build:rn -- --watch"
   },
   "author": "",
   "license": "MIT",

--- a/packages/taro-cli/templates/default/pkg
+++ b/packages/taro-cli/templates/default/pkg
@@ -4,6 +4,7 @@
   "private": true,
   "description": "<%= description %>",
   "scripts": {
+    "update": "taro update project",
     "build:weapp": "taro build --type weapp",
     "build:swan": "taro build --type swan",
     "build:alipay": "taro build --type alipay",
@@ -15,7 +16,7 @@
     "dev:alipay": "npm run build:alipay -- --watch",
     "dev:tt": "npm run build:tt -- --watch",
     "dev:h5": "npm run build:h5 -- --watch",
-    "dev:rn": "npm run build:rn -- --watch"
+    "dev:rn": "npm run build:rn -- --watch"c
   },
   "author": "",
   "license": "MIT",
@@ -34,6 +35,7 @@
   "devDependencies": {
     "@types/react": "^16.4.6",
     "@types/webpack-env": "^1.13.6",
+    "@tarojs/cli": "^<%= version %>",
     "@tarojs/plugin-babel": "^<%= version %>",
     "@tarojs/plugin-csso": "^<%= version %>",<% if (css !== 'none') {%>
     "@tarojs/plugin-<%= css %>": "^<%= version %>",<%}%>

--- a/packages/taro-cli/templates/mobx/pkg
+++ b/packages/taro-cli/templates/mobx/pkg
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@types/react": "16.3.14",
     "@types/webpack-env": "^1.13.6",
+    "@tarojs/cli": "^<%= version %>",
     "@tarojs/plugin-babel": "^<%= version %>",
     "@tarojs/plugin-csso": "^<%= version %>",<% if (css !== 'none') {%>
     "@tarojs/plugin-<%= css %>": "^<%= version %>",<%}%>

--- a/packages/taro-cli/templates/mobx/pkg
+++ b/packages/taro-cli/templates/mobx/pkg
@@ -5,6 +5,7 @@
   "description": "<%= description %>",
   "main": "index.js",
   "scripts": {
+    "update": "taro update project",
     "build:weapp": "taro build --type weapp",
     "build:swan": "taro build --type swan",
     "build:alipay": "taro build --type alipay",

--- a/packages/taro-cli/templates/redux/pkg
+++ b/packages/taro-cli/templates/redux/pkg
@@ -4,6 +4,7 @@
   "private": true,
   "description": "<%= description %>",
   "scripts": {
+    "update": "taro update project",
     "build:weapp": "taro build --type weapp",
     "build:swan": "taro build --type swan",
     "build:alipay": "taro build --type alipay",

--- a/packages/taro-cli/templates/redux/pkg
+++ b/packages/taro-cli/templates/redux/pkg
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@types/react": "^16.4.8",
     "@types/webpack-env": "^1.13.6",
+    "@tarojs/cli": "^<%= version %>",
     "@tarojs/plugin-babel": "^<%= version %>",
     "@tarojs/plugin-csso": "^<%= version %>",<% if (css !== 'none') {%>
     "@tarojs/plugin-<%= css %>": "^<%= version %>",<%}%>


### PR DESCRIPTION
多个 taro 项目依赖的 taro 版本不一致的时候，项目的稳定性会受到全局包的影响，这不适合多人协作的项目，应该加入到项目目录下的开发依赖中