### PR TITLE
docs(h5): update H5 error docs, 配置示例中的 libEntry 修正为 dllEntry

### DIFF
--- a/docs/config-detail.md
+++ b/docs/config-detail.md
@@ -388,7 +388,7 @@ dll编译过程的`entry`配置项，决定了dll文件的内容，可参考[web
 h5: {
   /* 其他配置 */
   ...,
-  libEntry: {
+  dllEntry: {
     lib: ['nervjs', '@tarojs/taro-h5', '@tarojs/router', '@tarojs/components']
   }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/27054472/50321685-09e18880-050d-11e9-810f-f44eb3858162.png)
