### PR TITLE
fix(taro-components): 修复 swiper pagination 匹配错乱问题

### DIFF
--- a/packages/taro-components/src/components/swiper/index.js
+++ b/packages/taro-components/src/components/swiper/index.js
@@ -37,7 +37,7 @@ class Swiper extends Nerv.Component {
 
     const opt = {
       // 指示器
-      pagination: { el: '.swiper-pagination' },
+      pagination: { el: `.taro-swiper-${this._id} .swiper-pagination` },
       direction: vertical ? 'vertical' : 'horizontal',
       loop: circular,
       slidesPerView: parseInt(displayMultipleItems, 10),
@@ -107,7 +107,7 @@ class Swiper extends Nerv.Component {
           dangerouslySetInnerHTML={{
             __html: `<style type='text/css'>
             .taro-swiper-${this._id} .swiper-pagination-bullet { background: ${defaultIndicatorColor} }
-            .taro-swiper-${this._id} .swiper-pagination-bullet-active { background: ${defaultIndicatorActiveColor} } 
+            .taro-swiper-${this._id} .swiper-pagination-bullet-active { background: ${defaultIndicatorActiveColor} }
             </style>`
           }}
         />


### PR DESCRIPTION
当上下级页面同时存在 swiper 组件时，swiper pagination 出现匹配错误的问题，修改 pagination el CSS selector 以准确匹配