### PR TITLE
Correct the path variable name in Location and modify the priority of…

### DIFF
--- a/packages/taro-components/src/components/tabbar/index.js
+++ b/packages/taro-components/src/components/tabbar/index.js
@@ -51,8 +51,8 @@ class Tabbar extends Nerv.Component {
   hashChangeHandler ({ toLocation } = {}) {
     let currentPage
 
-    if (toLocation) {
-      currentPage = toLocation.pathname ? removeLeadingSlash(toLocation.pathname) : this.homePage
+    if (toLocation && toLocation.path) {
+      currentPage = removeLeadingSlash(toLocation.path)
     } else {
       currentPage = this.getCurrentPathname() || this.homePage
     }


### PR DESCRIPTION
The variable name for path in `toLocation` of `routerChange` action was corrected.
The value of `currentPage` should fall back to `getCurrentPathname()` if the previous variable is undefined.