### PR TITLE
refactor(types): BaseEvent 类型优化

### DIFF
--- a/packages/taro-components/types/common.d.ts
+++ b/packages/taro-components/types/common.d.ts
@@ -70,44 +70,55 @@ interface EventProps {
   /**
    * 手指触摸后，超过350ms再离开，如果指定了事件回调函数并触发了这个事件，tap事件将不被触发
    */
-  onLongPress?: (event: BaseEvent) => any,
+  onLongPress?: (event: CommonEvent) => any,
 
   /**
    * 手指触摸后，超过350ms再离开（推荐使用longpress事件代替）
    */
-  onLongClick?: (event: BaseEvent) => any,
+  onLongClick?: (event: CommonEvent) => any,
 
   /**
    * 会在 WXSS transition 或 wx.createAnimation 动画结束后触发
    */
-  onTransitionEnd?: (event: BaseEvent) => any,
+  onTransitionEnd?: (event: CommonEvent) => any,
 
   /**
    * 会在一个 WXSS animation 动画开始时触发
    */
-  onAnimationStart?: (event: BaseEvent) => any,
+  onAnimationStart?: (event: CommonEvent) => any,
 
   /**
    * 会在一个 WXSS animation 一次迭代结束时触发
    */
-  onAnimationIteration?: (event: BaseEvent) => any,
+  onAnimationIteration?: (event: CommonEvent) => any,
 
   /**
    * 会在一个 WXSS animation 动画完成时触发
    */
-  onAnimationEnd?: (event: BaseEvent) => any,
+  onAnimationEnd?: (event: CommonEvent) => any,
 
   /**
    * 在支持 3D Touch 的 iPhone 设备，重按时会触发
    */
-  onTouchForceChange?: (event: BaseEvent) => any
+  onTouchForceChange?: (event: CommonEvent) => any
 }
 
-export type BaseEventFunction = (event: BaseEvent) => any
+export type BaseEventOrigFunction<T> = (event: BaseEventOrig<T>) => any
 
+export type BaseEventFunction = BaseEventOrigFunction<any>
+                                              
 export type TouchEventFunction = (event: ITouchEvent) => any
 
-interface BaseEvent {
+/**
+ * @deprecated 建议弃用，逐步使用CommonEvent替换
+ */
+export type BaseEvent = BaseEventOrig<any>
+    
+export type CommonEvent = BaseEventOrig<any>
+
+export type CommonEventFunction = BaseEventOrigFunction<any>
+
+interface BaseEventOrig<T> {
   /**
    * 事件类型
    */
@@ -131,7 +142,7 @@ interface BaseEvent {
   /**
    * 额外的信息
    */
-  detail: any,
+  detail: T,
   
   /**
   * 阻止元素发生默认的行为
@@ -144,7 +155,7 @@ interface BaseEvent {
   stopPropagation: () => void
 }
 
-interface ITouchEvent extends BaseEvent {
+interface ITouchEvent extends BaseEventOrig<any> {
   /**
    * 触摸事件，当前停留在屏幕中的触摸点信息的数组
    */


### PR DESCRIPTION
BaseEvent 类型优化，方便BaseEvent中的detail字段类型编写
建议使用CommonEvent代替BaseEvent，当全部BaseEvent被替换成CommonEvent后，重置BaseEventOrig为BaseEvent
BaseEventFunction同理