### PR TITLE
fix(docs): Component extend from React.Component

### DIFF
--- a/docs/event.md
+++ b/docs/event.md
@@ -25,7 +25,7 @@ Taro 中稍稍有点不同：
 在 Taro 中另一个不同是你不能使用 `catchEvent` 的方式阻止事件冒泡。你必须明确的使用 `stopPropagation`。例如，阻止事件冒泡你可以这样写：
 
 ```jsx
-class Toggle extends React.Component {
+class Toggle extends Component {
   constructor (props) {
     super(props)
     this.state = {isToggleOn: true}


### PR DESCRIPTION
In "event.md", the sample component extend from React.Component. It should be extend from Taro.Component.

在“event.md”中，示例中的组件继承于React.Component，它应该继承于Taro.Component。