### PR TITLE
fix: transform scss file with hyphen(-) in the filename

### DIFF
--- a/packages/babel-plugin-transform-jsx-to-stylesheet/src/__tests__/index.js
+++ b/packages/babel-plugin-transform-jsx-to-stylesheet/src/__tests__/index.js
@@ -260,6 +260,27 @@ class App extends Component {
 }`)
   })
 
+  it('transform scss file with hyphen(-) in the filename', () => {
+    expect(getTransfromCode(`
+import { createElement, Component } from 'rax';
+import './app-style.scss';
+
+class App extends Component {
+  render() {
+    return <div className="header" />;
+  }
+}`)).toBe(`
+import { createElement, Component } from 'rax';
+import app_styleStyleSheet from './app-style.scss';
+
+var _styleSheet = app_styleStyleSheet;
+class App extends Component {
+  render() {
+    return <div style={_styleSheet["header"]} />;
+  }
+}`)
+  })
+
   it('transform constant elements in render', () => {
     expect(getTransfromCode(`
 import { createElement, render } from 'rax';

--- a/packages/babel-plugin-transform-jsx-to-stylesheet/src/index.js
+++ b/packages/babel-plugin-transform-jsx-to-stylesheet/src/index.js
@@ -255,7 +255,7 @@ function ${GET_STYLE_FUNC_NAME}(classNameExpression) {
           if (cssFileCount === 0) {
             const cssFileBaseName = path.basename(jsFilePath, path.extname(jsFilePath))
             // 引入样式对应的变量名
-            const styleSheetIdentifierValue = `${cssFileBaseName + NAME_SUFFIX}`
+            const styleSheetIdentifierValue = `${cssFileBaseName.replace(/-/g, '_') + NAME_SUFFIX}`
             const styleSheetIdentifierPath = `./${cssFileBaseName}_styles`
             const styleSheetIdentifier = t.identifier(styleSheetIdentifierValue)
 


### PR DESCRIPTION
出错示例：
**index-app.js**（文件名带连字符）中引入了 xxx.css，最终会编译成：
`import index-appStyleSheet from "./index-app_styles"`

**index-appStyleSheet** 带了连字符，不是个合法的变量命名，因而报错

ps: 
如果要完善点的话，应该对最终的 styleSheetIdentifierValue 做 js 变量名的校验，不知项目中是否已有相关的工具函数，有的话可以拿来用下，否则就处理连字符应该也就足够了（文件名中有连字符还是很常见的）
