### PR TITLE
fix(mobx): 1.2.7 mobx-h5 丢失文件

### DIFF
--- a/packages/taro-mobx-h5/package.json
+++ b/packages/taro-mobx-h5/package.json
@@ -15,7 +15,8 @@
   },
   "main": "index.js",
   "files": [
-    "index.js"
+    "index.js",
+    "Provider.js"
   ],
   "peerDependencies": {
     "nervjs": "^1.3.0"


### PR DESCRIPTION
@tarojs/mobx-h5@1.2.7 缺少文件:  Provider.js