### PR TITLE
fix(taro): 小程序端事件绑定时无法传递参数, close: #1946, #1820

### DIFF
--- a/packages/taro-alipay/src/create-component.js
+++ b/packages/taro-alipay/src/create-component.js
@@ -95,7 +95,7 @@ function processEvent (eventHandlerName, obj) {
         keyLower = keyLower.replace(/^on/, '').toLocaleLowerCase()
         if (keyLower.indexOf(eventType) >= 0) {
           const argName = keyLower.replace(eventType, '')
-          if (/^(a[a-z]|so)$/.test(argName)) {
+          if (/^(a[a-z]+|so)$/.test(argName)) {
             bindArgs[argName] = dataset[key]
           }
         }

--- a/packages/taro-swan/src/create-component.js
+++ b/packages/taro-swan/src/create-component.js
@@ -94,7 +94,7 @@ function processEvent (eventHandlerName, obj) {
         keyLower = keyLower.replace(/^e/, '')
         if (keyLower.indexOf(eventType) >= 0) {
           const argName = keyLower.replace(eventType, '')
-          if (/^(a[a-z]|so)$/.test(argName)) {
+          if (/^(a[a-z]+|so)$/.test(argName)) {
             bindArgs[argName] = dataset[key]
           }
         }

--- a/packages/taro-tt/src/create-component.js
+++ b/packages/taro-tt/src/create-component.js
@@ -97,7 +97,7 @@ function processEvent (eventHandlerName, obj) {
         keyLower = keyLower.replace(/^e/, '')
         if (keyLower.indexOf(eventType) >= 0) {
           const argName = keyLower.replace(eventType, '')
-          if (/^(a[a-z]|so)$/.test(argName)) {
+          if (/^(a[a-z]+|so)$/.test(argName)) {
             bindArgs[argName] = dataset[key]
           }
         }

--- a/packages/taro-weapp/src/create-component.js
+++ b/packages/taro-weapp/src/create-component.js
@@ -126,7 +126,7 @@ function processEvent (eventHandlerName, obj) {
         keyLower = keyLower.replace(/^e/, '')
         if (keyLower.indexOf(eventType) >= 0) {
           const argName = keyLower.replace(eventType, '')
-          if (/^(a[a-z]|so)$/.test(argName)) {
+          if (/^(a[a-z]+|so)$/.test(argName)) {
             bindArgs[argName] = dataset[key]
           }
         }


### PR DESCRIPTION
修复：
 [事件无法正常传递参数](https://github.com/NervJS/taro/issues/1946)
 [函数传参无法取到](https://github.com/NervJS/taro/issues/1820)