### PR TITLE
为Taro.uploadFile添加请求成功的回调

### DIFF
--- a/packages/taro/types/index.d.ts
+++ b/packages/taro/types/index.d.ts
@@ -734,6 +734,10 @@ declare namespace Taro {
        * HTTP 请求中其他额外的 form data
        */
       formData?: any
+      /**
+       * 上传成功的回调
+       */
+      success?: (res?: uploadFile.Promised) => void
     }
   }
   /**


### PR DESCRIPTION
ts中，当使用Taro.uploadFile时，指定Task的progress后，由于Param中缺少success的定义，使得出现编译错误
如果使用Promise的话则无法获得上传进度，为了解决报错在Param中增加success回调的定义