### PR TITLE
npm命令行参数透传到process.env

### DIFF
--- a/packages/taro-cli/bin/taro-build
+++ b/packages/taro-cli/bin/taro-build
@@ -46,6 +46,13 @@ if (env) {
   }
 }
 
+if(args.length){
+  for(let i in args){
+    if(i%2) process.env[args[i-1]] = args[i]
+    else process.env[args[i]] = true
+  }
+}
+
 const projectConf = require(projectConfPath)(_.merge)
 console.log(chalk.green(`开始编译项目 ${chalk.bold(projectConf.projectName)}`))
 


### PR DESCRIPTION
https://github.com/NervJS/taro/pull/2010#issue-246500816

> 第一个修改不准备这么干，暂时可以通过在 `config` 配置文件中这么处理
> 
> ```js
> // config/index.js
> env: {
>   NODE_ENV: '"development"',
>   xx: JSON.stringify(process.env.xx)
> },
> ```
> 
> 随后在代码里就能通过 `process.env. xx` 访问到环境变量了
> 

是这样，我希望在 NODE_ENV 之外还有一个值能帮助我判断需要加载哪个配置文件
它是属于另外一个维度，而且我并不想修改或扩展 NODE_ENV 变量，因为我不知道别的什么地方在用它

```js
// package.json

"scripts": {
	"build:weapp-run": "taro build --type weapp -- running"
}

// config/index.js

module.exports = function (merge) {
  if (process.env.NODE_ENV === 'development') {
    if(process.env.npm_lifecycle_script.indexOf('running') !== -1) {
      return merge({}, config, require('./dev'), require('./running'))
    }
    return merge({}, config, require('./dev'))
  }
  if(process.env.npm_lifecycle_script.indexOf('running') !== -1){
    return merge({}, config, require('./prod'), require('./running'))
  }
  return merge({}, config, require('./prod'))
}
```

如上，目前我通过 npm_lifecycle_script 去判断，感觉不是很优雅，或者有其他实现的建议吗？