### PR TITLE
feat(css modules): generateScopedName 支持设为函数

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 <a name=""></a>
-# [](https://github.com/NervJS/taro/compare/v1.2.11...v) (2019-01-29)
+# [](https://github.com/NervJS/taro/compare/v1.2.12...v) (2019-01-30)
+
+
+
+<a name="1.2.12"></a>
+## [1.2.12](https://github.com/NervJS/taro/compare/v1.2.11...v1.2.12) (2019-01-30)
+
+
+### Bug Fixes
+
+* **cli:** 去掉一个多余的unescape行为 ([1f510a1](https://github.com/NervJS/taro/commit/1f510a1))
+* **components:** 在sideEffects中标记样式文件 ([1bf341c](https://github.com/NervJS/taro/commit/1bf341c))
+* **router:** 修复页面生命周期重复触发的问题 ([d6c7606](https://github.com/NervJS/taro/commit/d6c7606))
 
 
 

--- a/packages/taro-cli/src/weapp.js
+++ b/packages/taro-cli/src/weapp.js
@@ -982,20 +982,20 @@ async function compileScriptFile (content, sourceFilePath, outputFilePath, adapt
   return res.code
 }
 
-async function checkCliAndFrameworkVersion () {
-  const frameworkName = `@tarojs/taro-${buildAdapter}`
-  const frameworkVersion = Util.getInstalledNpmPkgVersion(frameworkName, nodeModulesPath)
-  if (frameworkVersion) {
-    if (frameworkVersion !== Util.getPkgVersion()) {
-      Util.printLog(Util.pocessTypeEnum.ERROR, '版本问题', `Taro CLI 与本地安装的小程序框架 ${frameworkName} 版本不一致，请确保一致`)
-      console.log(`Taro CLI: ${Util.getPkgVersion()}`)
-      console.log(`${frameworkName}: ${frameworkVersion}`)
-      process.exit(1)
-    }
-  } else {
-    Util.printLog(Util.pocessTypeEnum.WARNING, '依赖安装', chalk.red(`项目依赖 ${frameworkName} 未安装，或安装有误！`))
-  }
-}
+// async function checkCliAndFrameworkVersion () {
+//   const frameworkName = `@tarojs/taro-${buildAdapter}`
+//   const frameworkVersion = Util.getInstalledNpmPkgVersion(frameworkName, nodeModulesPath)
+//   if (frameworkVersion) {
+//     if (frameworkVersion !== Util.getPkgVersion()) {
+//       Util.printLog(Util.pocessTypeEnum.ERROR, '版本问题', `Taro CLI 与本地安装的小程序框架 ${frameworkName} 版本不一致，请确保一致`)
+//       console.log(`Taro CLI: ${Util.getPkgVersion()}`)
+//       console.log(`${frameworkName}: ${frameworkVersion}`)
+//       process.exit(1)
+//     }
+//   } else {
+//     Util.printLog(Util.pocessTypeEnum.WARNING, '依赖安装', chalk.red(`项目依赖 ${frameworkName} 未安装，或安装有误！`))
+//   }
+// }
 
 function buildProjectConfig () {
   let projectConfigFileName = `project.${buildAdapter}.json`
@@ -1475,7 +1475,9 @@ function processStyleUseCssModule (styleObj) {
   const context = process.cwd()
   let scopedName
   if (generateScopedName) {
-    scopedName = genericNames(generateScopedName, { context })
+    scopedName = typeof generateScopedName === 'function'
+      ? (local, filename) => generateScopedName(local, path.relative(context, filename))
+      : genericNames(generateScopedName, { context })
   } else {
     scopedName = (local, filename) => Scope.generateScopedName(local, path.relative(context, filename))
   }

--- a/packages/taro-cli/src/weapp.js
+++ b/packages/taro-cli/src/weapp.js
@@ -1476,7 +1476,7 @@ function processStyleUseCssModule (styleObj) {
   let scopedName
   if (generateScopedName) {
     scopedName = typeof generateScopedName === 'function'
-      ? (local, filename) => generateScopedName(local, path.relative(context, filename))
+      ? (local, filename) => generateScopedName(local, filename)
       : genericNames(generateScopedName, { context })
   } else {
     scopedName = (local, filename) => Scope.generateScopedName(local, path.relative(context, filename))

--- a/packages/taro-webpack-runner/src/util/chain.ts
+++ b/packages/taro-webpack-runner/src/util/chain.ts
@@ -186,6 +186,8 @@ const getModule = ({
 
   const cssModuleOptions: PostcssOption.cssModules = recursiveMerge({}, defaultCssModuleOption, postcssOption.cssModules)
 
+  const { namingPattern, generateScopedName } = cssModuleOptions.config!
+
   const cssOptions = [
     {
       importLoaders: 1,
@@ -195,12 +197,16 @@ const getModule = ({
     cssLoaderOption
   ]
   const cssOptionsWithModule = [
-    {
-      importLoaders: 1,
-      sourceMap: enableSourceMap,
-      modules: cssModuleOptions.config!.namingPattern === 'module' ? true : 'global',
-      localIdentName: cssModuleOptions.config!.generateScopedName
-    },
+    Object.assign(
+      {
+        importLoaders: 1,
+        sourceMap: enableSourceMap,
+        modules: namingPattern === 'module' ? true : 'global'
+      },
+      typeof generateScopedName === 'function'
+        ? { getLocalIdent: (context, _, localName) => generateScopedName(localName, context.resourcePath) }
+        : { localIdentName: generateScopedName }
+    ),
     cssLoaderOption
   ]
   /**

--- a/packages/taro-webpack-runner/src/util/types.ts
+++ b/packages/taro-webpack-runner/src/util/types.ts
@@ -16,7 +16,7 @@ type TogglableOptions<T = Option> = {
 export namespace PostcssOption {
   export type cssModules = TogglableOptions<{
     namingPattern: 'global' | string;
-    generateScopedName: string;
+    generateScopedName: string | ((localName: string, absoluteFilePath: string) => string);
   }>;
 }
 


### PR DESCRIPTION
generateScopedName 设为函数在某些需要高度自定义的场景下是极有用的，比如 UI 组件库。

顺便注释了暂不用的 checkCliAndFrameworkVersion 方法，因为 pre-commit 里的 eslint 不通过。