### PR TITLE
input { text-align: inherit }

### DIFF
--- a/packages/taro-components/src/components/input/index.scss
+++ b/packages/taro-components/src/components/input/index.scss
@@ -1,6 +1,7 @@
 input {
   display: block;
   height: 1.4rem;
+  text-align: inherit;
   text-overflow: clip;
   overflow: hidden;
   white-space: nowrap;


### PR DESCRIPTION
小程序的input默认继承祖先元素的text-align
而浏览器的input默认是text-align: start;