### PR TITLE
fix(taro-router-rn): 页面根节点 height: 100% 无效

### DIFF
--- a/packages/taro-router-rn/src/RefreshProvider.js
+++ b/packages/taro-router-rn/src/RefreshProvider.js
@@ -17,6 +17,7 @@ class RefreshProvider extends React.Component {
       return (
         <ScrollView
           style={{flex: 1}}
+          contentContainerStyle={{ flex: 1 }}
           scrollEventThrottle={5}
           alwaysBounceVertical={false}
           onScroll={this.onScroll}


### PR DESCRIPTION
ScrollView 这个节点要是没有加 contentContainerStyle 的话，会导致页面根节点无法继承高度
进而在页面根节点上设置 flex: 1、height: 100% 时都无法实现全屏