### PR TITLE
fix(taro-components): fix richText component

### DIFF
--- a/packages/taro-components/src/components/rich-text/index.js
+++ b/packages/taro-components/src/components/rich-text/index.js
@@ -17,14 +17,19 @@ class RichText extends Nerv.Component {
         style: ''
       }
       if (item.hasOwnProperty('attrs')) {
-        obj.className = item.attrs.class || ''
-        obj.style = item.attrs.style || ''
+        for (const key in item.attrs) {
+          if (key === 'class') {
+            obj.className = item.attrs[key] || ''
+          } else {
+            obj[key] = item.attrs[key] || ''
+          }
+        }
       }
       return Nerv.createElement(item.name, obj, child)
     }
   }
 
-  renderChildrens (arr) {
+  renderChildrens (arr = []) {
     if (arr.length === 0) return
     return arr.map((list, i) => {
       if (list.type === 'text') {


### PR DESCRIPTION
主要修改了两个地方：
1. RichText这个组件，nodes的type如果不是text的话，children这个属性在微信小程序的doc里是可选的，所以item.children就可能为undefined，所以加个默认值空数组。
2. 对于有些node类型，例如image，它的attrs不仅仅限于class和style，还有src、width、height等。由于情况比较多，所以这块建议直接把这些属性拿过来，统统赋给props