### PR TITLE
fix(taro-router-rn): navigateBack 增加默认参数

### DIFF
--- a/packages/taro-router-rn/src/TaroProvider.js
+++ b/packages/taro-router-rn/src/TaroProvider.js
@@ -101,7 +101,7 @@ class TaroProvider extends React.Component {
     complete && complete()
   }
 
-  wxNavigateBack (params) {
+  wxNavigateBack (params = {}) {
     if (typeof params !== 'object') {
       console.warn('Taro.NavigateBack 参数必须为 object')
       return


### PR DESCRIPTION
taro/types/index.d.ts 中对 navigateBack 的定义是：
function navigateBack(OBJECT?: navigateBack.Param): Promise<any>

参数是可选的，其他两端不传参时不报错，RN 会报错，统一一下