### PR TITLE
fix(taro-cli):修复初始化 plugins 配置时操作原对象并未能正确去重(#2160)

### DIFF
--- a/packages/taro-cli/src/util/resolve_npm_files.js
+++ b/packages/taro-cli/src/util/resolve_npm_files.js
@@ -39,7 +39,7 @@ const projectConfig = require(configDir)(_.merge)
 const pluginsConfig = projectConfig.plugins || {}
 const outputDirName = projectConfig.outputRoot || CONFIG.OUTPUT_DIR
 
-const babelConfig = _.mergeWith(defaultBabelConfig, pluginsConfig.babel, (objValue, srcValue) => {
+const babelConfig = _.mergeWith({}, defaultBabelConfig, pluginsConfig.babel, (objValue, srcValue) => {
   if (Array.isArray(objValue)) {
     return Array.from(new Set(srcValue.concat(objValue)))
   }

--- a/packages/taro-cli/src/weapp.js
+++ b/packages/taro-cli/src/weapp.js
@@ -949,7 +949,7 @@ function copyFilesFromSrcToOutput (files) {
   })
 }
 
-const babelConfig = _.mergeWith(defaultBabelConfig, pluginsConfig.babel, (objValue, srcValue) => {
+const babelConfig = _.mergeWith({}, defaultBabelConfig, pluginsConfig.babel, (objValue, srcValue) => {
   if (Array.isArray(objValue)) {
     return Array.from(new Set(srcValue.concat(objValue)))
   }

--- a/packages/taro-cli/src/weapp.js
+++ b/packages/taro-cli/src/weapp.js
@@ -964,7 +964,7 @@ const shouldTransformAgain = (function () {
 })()
 
 async function compileScriptFile (content, sourceFilePath, outputFilePath, adapter) {
-  const compileScriptRes = await npmProcess.callPlugin('babel', content, entryFilePath, babelConfig)
+  const compileScriptRes = await npmProcess.callPlugin('babel', content, sourceFilePath, babelConfig)
   const code = compileScriptRes.code
   if (!shouldTransformAgain) {
     return code

--- a/packages/taro-plugin-babel/index.js
+++ b/packages/taro-plugin-babel/index.js
@@ -3,6 +3,8 @@ const { transform } = require('babel-core')
 module.exports = function babel (content, file, config) {
   let p
   try {
+    if (!config) config = {}
+    config.filename = file
     const res = transform(content, config)
     p = Promise.resolve(res)
   } catch (e) {


### PR DESCRIPTION
避免操作原对象可修复此问题