### PR TITLE
fix(taro-cli+taro-plugin-babel):修复babel插件内无法访问编译文件路径问题(#2168) 

### DIFF
--- a/packages/taro-cli/src/weapp.js
+++ b/packages/taro-cli/src/weapp.js
@@ -964,7 +964,7 @@ const shouldTransformAgain = (function () {
 })()
 
 async function compileScriptFile (content, sourceFilePath, outputFilePath, adapter) {
-  const compileScriptRes = await npmProcess.callPlugin('babel', content, entryFilePath, babelConfig)
+  const compileScriptRes = await npmProcess.callPlugin('babel', content, sourceFilePath, babelConfig)
   const code = compileScriptRes.code
   if (!shouldTransformAgain) {
     return code

--- a/packages/taro-plugin-babel/index.js
+++ b/packages/taro-plugin-babel/index.js
@@ -3,6 +3,8 @@ const { transform } = require('babel-core')
 module.exports = function babel (content, file, config) {
   let p
   try {
+    if (!config) config = {}
+    config.filename = file
     const res = transform(content, config)
     p = Promise.resolve(res)
   } catch (e) {


### PR DESCRIPTION
1. 修复 taro-plugin-babel  中调用 babel.transform 时未传递 config.filename 导致插件中无法访问 state.file.opts.filename问题
2. 修复 taro-cli/weapp.js 中调用 plugin-babel 时 file 参数始终传递 entryFilePath 而非 sourceFilePath ，导致插件内无法正确拿到文件路径问题