### PR TITLE
taro-cli/src/build.js的configDir引入前置导致config/index获取process.env.NODE_ENV为undefined

### DIFF
--- a/packages/taro-cli/src/build.js
+++ b/packages/taro-cli/src/build.js
@@ -7,10 +7,11 @@ const Util = require('./util')
 const CONFIG = require('./config')
 
 const appPath = process.cwd()
-const configDir = require(path.join(appPath, Util.PROJECT_CONFIG))(_.merge)
+
 
 function build (args, buildConfig) {
   const { type, watch } = buildConfig
+  const configDir = require(path.join(appPath, Util.PROJECT_CONFIG))(_.merge)
   const outputPath = path.join(appPath, configDir.outputRoot || CONFIG.OUTPUT_DIR)
   if (!fs.existsSync(outputPath)) {
     fs.mkdirSync(outputPath)


### PR DESCRIPTION

**问题描述**
configDir引入前置导致config/index获取process.env.NODE_ENV为undefined.模板为例子,配置只输出production环境

**复现步骤**
npm run build:weapp
npm run dev:weapp
配置只输出production配置

```js
// 这里可以贴代码

```

**期望行为**
对应命令钩子输出对应构建配置

**报错信息**

[这里请贴上你的**完整**报错截图或文字]

**系统信息**

  Taro CLI 1.2.13 environment info:
    System:
      OS: macOS 10.14
      Shell: 5.3 - /bin/zsh
    Binaries:
      Node: 11.1.0 - /usr/local/bin/node
      Yarn: 1.12.3 - /usr/local/bin/yarn
      npm: 6.4.1 - /usr/local/bin/npm

**补充信息**
[可选]
下面有修改代码
