### PR TITLE
fix(taro-cli): fix taro weapp watch entry file

### DIFF
--- a/packages/taro-cli/src/weapp.js
+++ b/packages/taro-cli/src/weapp.js
@@ -2046,7 +2046,7 @@ function watchFiles () {
       const extname = path.extname(filePath)
       // 编译JS文件
       if (Util.REG_SCRIPT.test(extname) || Util.REG_TYPESCRIPT.test(extname)) {
-        if (filePath.indexOf(entryFileName) >= 0) {
+        if (path.basename(filePath, extname) === entryFileName) {
           Util.printLog(Util.pocessTypeEnum.MODIFY, '入口文件', `${sourceDirName}/${entryFileName}.js`)
           const config = await buildEntry()
           // TODO 此处待优化


### PR DESCRIPTION
修改微信小程序监听文件修改时，判断是否是entryFile的bug。原判断如果文件路径中任何一个地方出现了`app`字符串，那么都会认为是entryFile。例如 `xxx/xx/logApproval/xxx`这个path，会被错误的认为是entryFile