### PR TITLE
typescript redux 模版内 模块导出的 as 语法, eslint 会报错

### DIFF
--- a/packages/taro-cli/templates/redux/pagejs
+++ b/packages/taro-cli/templates/redux/pagejs
@@ -58,7 +58,7 @@ interface Index {
     dispatch(asyncAdd())
   }
 }))
-class Index extends Component {
+class Index extends Component <%if (locals.typescript) {%><PageOwnProps, PageState> <%}%>{
 
   <%if (locals.typescript) {-%>
   /**
@@ -96,15 +96,4 @@ class Index extends Component {
   }
 }
 
-<%if (locals.typescript) {-%>
-// #region 导出注意
-//
-// 经过上面的声明后需要将导出的 Taro.Component 子类修改为子类本身的 props 属性
-// 这样在使用这个子类时 Ts 才不会提示缺少 JSX 类型参数错误
-//
-// #endregion
-
-export default Index as ComponentClass<PageOwnProps, PageState>
-<%} else {-%>
 export default Index
-<%}-%>


### PR DESCRIPTION
> typescript redux 模版

eslint error:
```bash
error  Parsing error: Unexpected token, expected ";"
export default Index as ComponentClass<PageOwnProps, PageState>;
                     ^
```

上面一段是我在 跑 `npx eslint src --ext .ts,.tsx` 时候, `eslint` 报的错误信息
另外, 直接采用 extends Component 混入 props 和 state 更常用, 省了 `import ComponentClass` 和 `as`
而且 props 的 **提示** 和 **lint** 也没有问题
