### PR TITLE
fix(taro-weapp): 在 diffObjToPath 时，如果目标数组为空，强制进行一次 setData 将其清空

### DIFF
--- a/packages/taro-weapp/src/util.js
+++ b/packages/taro-weapp/src/util.js
@@ -167,7 +167,7 @@ export function diffObjToPath (to, from, res = {}, keyPrev = '') {
         if (arrTo !== arrFrom) {
           res[targetKey] = toItem
         } else if (arrTo && arrFrom) {
-          if (toItem.length < fromItem.length) {
+          if (toItem.length === 0 || toItem.length < fromItem.length) {
             res[targetKey] = toItem
           } else {
             // 数组


### PR DESCRIPTION
非 Page 类型组件 C，父级组件 P 通过 Props 传递 Array 类型的参数。在一些复杂状态的情况下，会出现赋值时，组件 C 记住了上一次 Array 的数组内容，而传递一个空 Array 进去时没有正确更新进去。此时因为信息不同步，`diffObjToPath` 的 `toItem` 和 `fromItem` 一致，但实际渲染这个 Array 时，是存在数据的。

针对这个情况，这一补丁针对 `toItem` 是 Array 并且是 length 为 0 的情况下，强制通知 setData 进行一次更新这个 Array 类型的数据（强制进行清空）。