### PR TITLE
fix (taro-cli): 修改了templates/mobx/globaldts 删除import React 行

### DIFF
--- a/packages/taro-cli/templates/mobx/globaldts
+++ b/packages/taro-cli/templates/mobx/globaldts
@@ -1,5 +1,3 @@
-import React from 'react';
-
 declare module "*.png";
 declare module "*.gif";
 declare module "*.jpg";
@@ -11,10 +9,8 @@ declare module "*.scss";
 declare module "*.sass";
 declare module "*.styl";
 
-declare global {
-  namespace JSX {
-      interface IntrinsicElements {
-          'import': React.DetailedHTMLProps<React.EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement>
-      }
-  }
+declare namespace JSX {
+    interface IntrinsicElements {
+        'import': React.DetailedHTMLProps<React.EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement>
+    }
 }


### PR DESCRIPTION
typescript环境下global.d.ts使用import了关键字，导致其变成一个普通模块，|
无法作为全局环境声明。修改导出JSX namespace 方式

Fixes #2437