### PR TITLE
feat(cli): 跨平台开发方式支持目录判断

### DIFF
--- a/packages/taro-cli/src/util/index.js
+++ b/packages/taro-cli/src/util/index.js
@@ -370,6 +370,9 @@ exports.resolveScriptPath = function (p) {
       if (fs.existsSync(`${p}${path.sep}index.${taroEnv}${item}`)) {
         return `${p}${path.sep}index.${taroEnv}${item}`
       }
+      if (fs.existsSync(`${p.replace(/\/index$/, `.${taroEnv}/index`)}${item}`)) {
+        return `${p.replace(/\/index$/, `.${taroEnv}/index`)}${item}`
+      }
     }
     if (fs.existsSync(`${p}${item}`)) {
       return `${p}${item}`


### PR DESCRIPTION
目前 taro 的判断方式是根据文件来的，如 test.js、test.weapp.js，这对多端文件来说很 ok
但是在组件的组织上，这种方式不是很友好

```
comp
  index.alipay.js
  index.js
  index.weapp.js
```

如果组件中包含子组件等，目录就相当混乱了

```
comp
  index.alipay.js
  index.js
  index.weapp.js
  item.alipay.js
  item.js
  item.weapp.js
```

希望能达到如下效果：

```
comp
  index.js
  item.js
comp.alipay
  index.js
  item.js
comp.weapp
  index.js
  item.js
```
