### PR TITLE
fix(weapp): 修复云开发 api 初始化

### DIFF
--- a/packages/taro-weapp/src/native-api.js
+++ b/packages/taro-weapp/src/native-api.js
@@ -201,7 +201,7 @@ function canIUseWebp () {
 }
 
 function wxCloud (taro) {
-  const wxC = wx.cloud
+  const wxC = wx.cloud || {}
   const wxcloud = {}
   const apiList = [
     'init',


### PR DESCRIPTION
基础库版本低于 2.2.3 时会报错，因为 wx.cloud 是 undefined，应该做下兼容处理