### PR TITLE
fix(index.d.ts): 添加缺失的 $preload 类型定义

### DIFF
--- a/packages/taro/types/index.d.ts
+++ b/packages/taro/types/index.d.ts
@@ -373,6 +373,18 @@ declare namespace Taro {
       preload: any
     }
 
+    /**
+     * 使用 `this.$preload` 函数进行页面跳转传参
+     * @example this.$preload('key', 'val');
+     * @example this.$preload({
+                  x: 1,
+                  y: 2
+                });
+     * @see https://nervjs.github.io/taro/docs/best-practice.html
+     */
+    $preload(key: string, value: any): void;
+    $preload(key: object): void;
+
     setState<K extends keyof S>(
         state: ((prevState: Readonly<S>, props: P) => (Pick<S, K> | S)) | (Pick<S, K> | S),
         callback?: () => any
@@ -11504,7 +11516,7 @@ declare namespace Taro {
       interface uploadFile {
         /**
          * upload file
-         * @param param 
+         * @param param
          */
         (param: IUploadFileParam): IUploadFileTask
       }
@@ -11529,7 +11541,7 @@ declare namespace Taro {
       interface downloadFile {
         /**
          * download file
-         * @param param 
+         * @param param
          */
         (param: IDownloadFileParam): IDownloadFileTask
       }


### PR DESCRIPTION
为 class Componen 添加了 $preload 函数类型定义
虽然 $preload 函数源码没有 `$preload(key: object): void;` 的重载
https://github.com/NervJS/taro/blob/2222051cca68fd2afecbfa045eb208703fd40b3f/packages/taro-weapp/src/component.js#L86

提交里还包含两行 Lint 删除的空格