### PR TITLE
fix(taro): interceptors 没有正确处理异常

### DIFF
--- a/packages/taro/src/interceptor/chain.js
+++ b/packages/taro/src/interceptor/chain.js
@@ -12,7 +12,7 @@ export default class Chain {
     }
     const nextInterceptor = this._getNextInterceptor()
     const nextChain = this._getNextChain()
-    return nextInterceptor(nextChain)
+    return nextInterceptor(nextChain).catch(err => Promise.reject(err))
   }
 
   _getNextInterceptor () {

--- a/packages/taro/src/interceptor/interceptors.js
+++ b/packages/taro/src/interceptor/interceptors.js
@@ -12,6 +12,10 @@ export function timeoutInterceptor (chain) {
         clearTimeout(timeout)
         resolve(res)
       })
+      .catch(err => {
+        timeout && clearTimeout(timeout)
+        reject(err)
+      })
   })
 }
 


### PR DESCRIPTION
1. timeoutInterceptor 在请求异常时没有清除计时器
2. interceptor 中建议加一个默认的 catch 处理，否则加了 interceptor 又没有处理 catch，Taro.request 将无法触发 catch （如果觉得加默认处理不合适，那得在文档里注明下 interceptor 中要对 catch 处理哈）