### PR TITLE
flx(taro-components): H5 & Weapp统一pagePath.

### DIFF
--- a/packages/taro-components/src/components/tabbar/index.js
+++ b/packages/taro-components/src/components/tabbar/index.js
@@ -39,6 +39,12 @@ class Tabbar extends Nerv.Component {
       this.customRoutes.push([key, customRoutes[key]])
     }
 
+    list.forEach( item => {
+      if (item.pagePath.indexOf('/') !== 0){
+        item.pagePath = "/" + item.pagePath
+      }
+    })
+
     this.state = {
       list,
       selectedIndex: -1,


### PR DESCRIPTION
# 问题：

```
//    例子.
tabBar: {
    ............................
    ............................
      "list": [
        {
          "pagePath": "pages/xxxx/index",   //问题点
          "text": "Xx",
          ....
        },
    ............................
    ............................
    }
```

当 `pagePath` 为 **pages/xxxx/index** 
小程序环境：正常.
H5 环境：     被隐藏.

当 `pagePath` 为 **/pages/xxxx/index** // 注意：多了个 “/” 字符
小程序环境：报错 （tabBar[0].pagePath should not begin with '/'）
H5环境：正常

处理：
统一格式：**pages/xxxx/index** 
H5拿到 PagePath 后在其头部增加 '/'

