### PR TITLE
refactor(cli): 创建文件夹统一使用 fs.ensureDirSync

### DIFF
--- a/packages/taro-cli/src/build.js
+++ b/packages/taro-cli/src/build.js
@@ -8,13 +8,12 @@ const CONFIG = require('./config')
 
 const appPath = process.cwd()
 
-
 function build (args, buildConfig) {
   const { type, watch } = buildConfig
   const configDir = require(path.join(appPath, Util.PROJECT_CONFIG))(_.merge)
   const outputPath = path.join(appPath, configDir.outputRoot || CONFIG.OUTPUT_DIR)
   if (!fs.existsSync(outputPath)) {
-    fs.mkdirSync(outputPath)
+    fs.ensureDirSync(outputPath)
   } else {
     if (type !== Util.BUILD_TYPES.H5) {
       Util.emptyDirectory(outputPath)

--- a/packages/taro-cli/src/convertor.js
+++ b/packages/taro-cli/src/convertor.js
@@ -116,7 +116,7 @@ class Convertor {
     if (fs.existsSync(this.convertRoot)) {
       emptyDirectory(this.convertRoot, { excludes: ['node_modules'] })
     } else {
-      fs.mkdirpSync(this.convertRoot)
+      fs.ensureDirSync(this.convertRoot)
     }
   }
 

--- a/packages/taro-cli/src/util/index.js
+++ b/packages/taro-cli/src/util/index.js
@@ -263,7 +263,7 @@ exports.getRootPath = function () {
 exports.getTaroPath = function () {
   const taroPath = path.join(exports.homedir(), '.taro')
   if (!fs.existsSync(taroPath)) {
-    fs.mkdirSync(taroPath)
+    fs.ensureDirSync(taroPath)
   }
   return taroPath
 }

--- a/packages/taro-cli/templates/default/index.js
+++ b/packages/taro-cli/templates/default/index.js
@@ -26,10 +26,10 @@ module.exports = function (creater, params, helper, cb) {
   }
   const currentStyleExt = styleExtMap[css] || 'css'
 
-  fs.mkdirSync(projectPath)
-  fs.mkdirSync(sourceDir)
-  fs.mkdirSync(configDir)
-  fs.mkdirSync(path.join(sourceDir, 'pages'))
+  fs.ensureDirSync(projectPath)
+  fs.ensureDirSync(sourceDir)
+  fs.ensureDirSync(configDir)
+  fs.ensureDirSync(path.join(sourceDir, 'pages'))
 
   creater.template(template, 'pkg', path.join(projectPath, 'package.json'), {
     description,

--- a/packages/taro-cli/templates/mobx/index.js
+++ b/packages/taro-cli/templates/mobx/index.js
@@ -26,10 +26,10 @@ module.exports = function (creater, params, helper, cb) {
   }
   const currentStyleExt = styleExtMap[css] || 'css'
 
-  fs.mkdirSync(projectPath)
-  fs.mkdirSync(sourceDir)
-  fs.mkdirSync(configDir)
-  fs.mkdirSync(path.join(sourceDir, 'pages'))
+  fs.ensureDirSync(projectPath)
+  fs.ensureDirSync(sourceDir)
+  fs.ensureDirSync(configDir)
+  fs.ensureDirSync(path.join(sourceDir, 'pages'))
 
   creater.template(template, 'pkg', path.join(projectPath, 'package.json'), {
     description,

--- a/packages/taro-cli/templates/redux/index.js
+++ b/packages/taro-cli/templates/redux/index.js
@@ -30,14 +30,14 @@ module.exports = function (creater, params, helper, cb) {
   }
   const currentStyleExt = styleExtMap[css] || 'css'
 
-  fs.mkdirSync(projectPath)
-  fs.mkdirSync(sourceDir)
-  fs.mkdirSync(configDir)
-  fs.mkdirSync(path.join(sourceDir, 'pages'))
-  fs.mkdirSync(constantsDir)
-  fs.mkdirSync(actionsDir)
-  fs.mkdirSync(reducersDir)
-  fs.mkdirSync(storeDir)
+  fs.ensureDirSync(projectPath)
+  fs.ensureDirSync(sourceDir)
+  fs.ensureDirSync(configDir)
+  fs.ensureDirSync(path.join(sourceDir, 'pages'))
+  fs.ensureDirSync(constantsDir)
+  fs.ensureDirSync(actionsDir)
+  fs.ensureDirSync(reducersDir)
+  fs.ensureDirSync(storeDir)
 
   creater.template(template, 'pkg', path.join(projectPath, 'package.json'), {
     description,

--- a/packages/taro-cli/templates/wxcloud/index.js
+++ b/packages/taro-cli/templates/wxcloud/index.js
@@ -30,12 +30,12 @@ module.exports = function (creater, params, helper, cb) {
   }
   const currentStyleExt = styleExtMap[css] || 'css'
 
-  fs.mkdirSync(projectPath)
-  fs.mkdirSync(projectClientPath)
-  fs.mkdirSync(projectCloudPath)
-  fs.mkdirSync(sourceDir)
-  fs.mkdirSync(configDir)
-  fs.mkdirSync(path.join(sourceDir, 'pages'))
+  fs.ensureDirSync(projectPath)
+  fs.ensureDirSync(projectClientPath)
+  fs.ensureDirSync(projectCloudPath)
+  fs.ensureDirSync(sourceDir)
+  fs.ensureDirSync(configDir)
+  fs.ensureDirSync(path.join(sourceDir, 'pages'))
 
   creater.template(template, path.join(clientDirName, 'pkg'), path.join(projectClientPath, 'package.json'), {
     description,


### PR DESCRIPTION
1. taro-cli/src/build.js 中使用 `fs.mkdirSync(outputPath)` 可能有问题，如果 outputRoot 是包含子目录的，如 `dist/weapp`，编译会报错
2. fs. mkdirpSync、fs.ensureDirSync 内部实现都是 fs.mkdirsSync，既然项目中多数都用 fs.ensureDirSync 了，那没必要单独某个地方用 fs. mkdirpSync
3. 既然第 2 点可行，那其他地方也顺便统一都改掉哈