### PR TITLE
fix(cli): app.js的配置支持传入变量

### DIFF
--- a/packages/taro-cli/src/weapp.js
+++ b/packages/taro-cli/src/weapp.js
@@ -164,6 +164,9 @@ function traverseObjectNode (node, obj) {
   if (node.type === 'NullLiteral') {
     return null
   }
+  if (node.type === 'Identifier') {
+    return node
+  }
   return node.value
 }
 


### PR DESCRIPTION
现在的app.js的配置是不允许传参数的，代码：
![image](https://user-images.githubusercontent.com/10922642/55146022-cc7d3e80-517e-11e9-9523-f7420893652d.png)
报错：
![image](https://user-images.githubusercontent.com/10922642/55146038-d737d380-517e-11e9-9ac5-145eaaabfd04.png)
原因貌似是因为没有处理Identifier类型，导致`return node.value`为`undefined`。