### PR TITLE
fix:默认开启node_modules监控

### DIFF
--- a/packages/taro-webpack-runner/src/config/devServer.conf.ts
+++ b/packages/taro-webpack-runner/src/config/devServer.conf.ts
@@ -12,6 +12,6 @@ export default {
   overlay: true,
   port: 10086,
   quiet: true,
-  watchContentBase: true,
-  watchOptions: { ignored: /node_modules/ }
+  watchContentBase: true
+  // watchOptions: { ignored: /node_modules/ }
 }


### PR DESCRIPTION
为了调试方便，建议：默认开启node_modules监控