### PR TITLE
fix(taroize): 小程序转换Taro生命周期丢失

### DIFF
--- a/packages/taroize/src/script.ts
+++ b/packages/taroize/src/script.ts
@@ -303,6 +303,10 @@ function parsePage (
       }
       if (PageLifecycle.has(name)) {
         const lifecycle = PageLifecycle.get(name)!
+        if (prop.isObjectMethod()) {
+          const body = prop.get('body')
+          return t.classMethod('method', t.identifier(lifecycle), params, body.node)
+        }
         const node = value.node
         const method = t.isFunctionExpression(node) || t.isArrowFunctionExpression(node)
           ? t.classProperty(t.identifier(lifecycle), t.arrowFunctionExpression(params, node.body, isAsync))


### PR DESCRIPTION
## 小程序转换为Taro时生命周期丢失

小程序代码：

```js
Page({
  data: {},
  onLoad() {
    console.log(1)
  }
}）

```

转换后的结果（注意生命周期body没了）：

```js
class _C extends Taro.Component {
  state = {}
  componentWillMount
}
```


  


