### PR TITLE
feat(scss): support global scss inject

### DIFF
--- a/packages/taro-plugin-sass/index.js
+++ b/packages/taro-plugin-sass/index.js
@@ -1,10 +1,33 @@
 const sass = require('dart-sass')
+const Bundler = require('scss-bundle').Bundler
 
 module.exports = function compileSass (content, file, config) {
-  return new Promise((resolve, reject) => {
+  return new Promise(async (resolve, reject) => {
+    let bundledContent = ''
+    // check resource & projectDirectory property
+    // projectDirectory used for resolving tilde imports
+    if (config.resource && config.projectDirectory) {
+      const { resource, projectDirectory } = config
+      const getBundleContent = async (url) => {
+        const bundler = new Bundler(undefined, projectDirectory)
+        const res = await bundler.Bundle(url)
+        bundledContent += res.bundledContent
+      }
+      try {
+        if (typeof resource === 'string') {
+          await getBundleContent(resource)
+        } else if (Array.isArray(resource)) {
+          for (let url of resource) {
+            await getBundleContent(url)
+          }
+        }
+      } catch (e) {
+        reject(e)
+      }
+    }
     const opts = Object.assign(config, {
       file,
-      data: content
+      data: bundledContent ? bundledContent + content : content
     })
     var result
     try {

--- a/packages/taro-plugin-sass/package.json
+++ b/packages/taro-plugin-sass/package.json
@@ -16,6 +16,7 @@
   "author": "luckyadam",
   "license": "MIT",
   "dependencies": {
-    "dart-sass": "^1.17.4"
+    "dart-sass": "^1.17.4",
+    "scss-bundle": "^2.5.1"
   }
 }


### PR DESCRIPTION
In order to be able to inject scss variables globally
import scss-bundle to get bundledContent
```
plugin: {
   sass: {
      resource:  'path/to/global.scss',
      // OR 
      // resource:  ['path/to/global.theme.scss', 'path/to/global.mixin.scss',]
      projectDirectory: '/path/to/project/directory'
  }
}
```
resource: The absolute path of the global scss file that needs to be injected(support array).
projectDirectory: Absolute project location, where node_modules are located. 

Take effect when resource  & projectDirectory is set.
 Reference #425 