### PR TITLE
fix(components): 缺少file-loader导致构建失败

### DIFF
--- a/packages/taro-components/package.json
+++ b/packages/taro-components/package.json
@@ -53,6 +53,7 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^22.4.4",
     "babel-loader": "^8.0.5",
+    "file-loader": "^3.0.1",
     "jest": "^22.4.4",
     "nerv-test-utils": "^1.2.18",
     "webpack": "^3.11.0",

--- a/packages/taro-components/webpack.prod.config.js
+++ b/packages/taro-components/webpack.prod.config.js
@@ -64,6 +64,12 @@ module.exports = {
       {
         test: /\.css$/,
         loaders: ['style-loader', 'css-loader']
+      },
+      {
+        test: /\.(png)$/,
+        use: [
+          'file-loader'
+        ]
       }
     ]
   }


### PR DESCRIPTION
@taro/components中在video组件中引入了png图片，未在webpack中配置响应的loader，导致build失败。

错误信息如下
```
ERROR in ./src/components/video/images/play.png
Module parse failed: Unexpected character '�' (1:0)
You may need an appropriate loader to handle this file type.
(Source code omitted for this binary file)
 @ /Users/zane/projects/taro/node_modules/css-loader!/Users/zane/projects/taro/node_modules/sass-loader/lib/loader.js!./src/components/video/style/index.scss 7:3007-3036
 @ ./src/components/video/style/index.scss
 @ ./src/components/video/index.js
 @ ./src/index.js
```
