### PR TITLE
fix(taro-weapp): 兼容低基础库

### DIFF
--- a/packages/taro-weapp/src/native-api.js
+++ b/packages/taro-weapp/src/native-api.js
@@ -90,6 +90,10 @@ function processApis (taro) {
   const preloadPrivateKey = '__preload_'
   const preloadInitedComponent = '$preloadComponent'
   Object.keys(weApis).forEach(key => {
+    // 兼容低基础库
+    if (typeof wx[key] === 'undefined') {
+      taro[key] = () => {}
+    }
     if (!onAndSyncApis[key] && !noPromiseApis[key]) {
       taro[key] = (options, ...args) => {
         options = options || {}


### PR DESCRIPTION
兼容微信低版本基础库

修复之前调用`Taro.getUpdateManager()`会导致在低版本库的时候报错，因为低版本库`wx.getUpdateManager`为undefined。

修复之后可以直接使用
```js
const updateManager = Taro.getUpdateManager();
if (typeof updateManager === 'undefined') {
   return;
}
```

