### PR TITLE
fix(component): 修复 Picker 组件未设置默认 mode 属性的 bug

### DIFF
--- a/packages/taro-components/src/components/picker/index.js
+++ b/packages/taro-components/src/components/picker/index.js
@@ -22,6 +22,11 @@ import './style/index.scss'
 // 4. timePicker 样式问题：不在指定时间范围时，选项样式置灰。缩窄两列间宽度。
 
 export default class Picker extends Nerv.Component {
+  /** @type {PickerProps} */
+  static defaultProps = {
+    mode: 'selector'
+  }
+
   constructor (props) {
     super(props)
 


### PR DESCRIPTION
目前微信小程序组件是 mode 默认为 selector，如果未传 mode="selector"，那么 onChange 时会错误。

因为：
`const eventObj = getEventObj(e, 'change', {
        value: this.index.length > 1 && this.props.mode !== 'selector' ? this.index : this.index[0]
      })
`
