### PR TITLE
fix(rn): toast 或 loading 不对称情况下防止泄漏

### DIFF
--- a/packages/taro-rn/src/api/interface/toast.js
+++ b/packages/taro-rn/src/api/interface/toast.js
@@ -112,6 +112,8 @@ function showToast (options) {
   try {
     // setTimeout fires incorrectly when using chrome debug #4470
     // https://github.com/facebook/react-native/issues/4470
+    global.wxToastRootSiblings && global.wxToastRootSiblings.destroy()
+
     global.wxToastRootSiblings = new RootSiblings(ToastView)
     setTimeout(() => {
       global.wxToastRootSiblings && global.wxToastRootSiblings.update(ToastView)


### PR DESCRIPTION
showLoading 后 直接调用 showToast 会导致 loadingView 泄漏，没有回收