### PR TITLE
fix tslint error  类型“void | Promise”上不存在属性“then”

### DIFF
--- a/packages/taro/types/index.d.ts
+++ b/packages/taro/types/index.d.ts
@@ -11796,11 +11796,11 @@ declare namespace Taro {
     }
     function init(OBJECT?: ICloudConfig): void
 
-    function callFunction(param: ICloud.CallFunctionParam): Promise<ICloud.CallFunctionResult> | void
-    function uploadFile(param: ICloud.UploadFileParam): Promise<ICloud.UploadFileResult> | WXNS.IUploadFileTask
-    function downloadFile(param: ICloud.DownloadFileParam): Promise<ICloud.DownloadFileResult> | WXNS.IDownloadFileTask
-    function getTempFileURL(param: ICloud.GetTempFileURLParam): Promise<ICloud.GetTempFileURLResult> | void
-    function deleteFile(param: ICloud.DeleteFileParam): Promise<ICloud.DeleteFileResult> | void
+    function callFunction(param: ICloud.CallFunctionParam): Promise<ICloud.CallFunctionResult> & void
+    function uploadFile(param: ICloud.UploadFileParam): Promise<ICloud.UploadFileResult> & WXNS.IUploadFileTask
+    function downloadFile(param: ICloud.DownloadFileParam): Promise<ICloud.DownloadFileResult> & WXNS.IDownloadFileTask
+    function getTempFileURL(param: ICloud.GetTempFileURLParam): Promise<ICloud.GetTempFileURLResult> & void
+    function deleteFile(param: ICloud.DeleteFileParam): Promise<ICloud.DeleteFileResult> & void
 
     function database(config?: ICloudConfig): DB.Database
   }


### PR DESCRIPTION
修复解决 使用  微信云函数方法:  
 Taro.cloud.callFunction().then()
Taro.cloud.uploadFile().then()
Taro.cloud.downloadFile().then()
Taro.cloud.getTempFileURL().then()
Taro.cloud.deleteFile().then()
tslint 提示 找不到 then属性的问题