### PR TITLE
db.collection(xx).count().then,db.collection(xx).get().then

### DIFF
--- a/packages/taro/types/index.d.ts
+++ b/packages/taro/types/index.d.ts
@@ -11562,9 +11562,9 @@ declare namespace Taro {
 
         field(object: object): Query
 
-        get(options?: IGetDocumentOptions): Promise<IQueryResult> | void
+        get(options?: IGetDocumentOptions): Promise<IQueryResult> & void
 
-        count(options?: ICountDocumentOptions): Promise<ICountResult> | void
+        count(options?: ICountDocumentOptions): Promise<ICountResult> & void
       }
 
       export interface DatabaseCommand {


### PR DESCRIPTION
云开发 数据库【 类型“void”上不存在属性“then”】