### PR TITLE
给Taro.getUserInfo接口添加回调函数

### DIFF
--- a/packages/taro/types/index.d.ts
+++ b/packages/taro/types/index.d.ts
@@ -8795,7 +8795,22 @@ declare namespace Taro {
        * @since 1.9.90
        */
       timeout?: number
+      success?: ParamPropSuccess
+      fail?: ParamPropFail
+      complete?: ParamPropComplete
     }
+    /**
+     * 获取用户信息接口调用成功的回调函数
+     */
+    type ParamPropSuccess = (res: Promised) => void
+    /**
+     * 获取用户信息接口调用失败的回调函数
+     */
+    type ParamPropFail = (err: Promised) => void
+    /**
+     * 获取用户信息接口调用结束的回调函数（调用成功、失败都会执行）
+     */
+    type ParamPropComplete = (err: Promised) => void
   }
   /**
    * 获取用户信息，withCredentials 为 true 时需要先调用 [Taro.login](https://developers.weixin.qq.com/miniprogram/dev/api/api-login.html#wxloginobject) 接口。


### PR DESCRIPTION
getUserInfo接口的ts文件中之前没有success, fail, complete这三个回调，导致写代码的时候编辑器报错，功能不受影响。已经将回调加上