### PR TITLE
fix(h5): 修复H5 ScrollView 组件无法捕捉到onTouchMove事件的bug，fix #2770

### DIFF
--- a/packages/taro-components/src/components/scroll-view/index.js
+++ b/packages/taro-components/src/components/scroll-view/index.js
@@ -41,9 +41,9 @@ class ScrollView extends Nerv.Component {
     super(...arguments)
   }
 
-  onTouchMove = e => {
-    e.stopPropagation()
-  }
+  // onTouchMove = e => {
+  //   e.stopPropagation()
+  // }
 
   componentDidMount () {
     setTimeout(() => {
@@ -178,7 +178,8 @@ class ScrollView extends Nerv.Component {
         {...omit(this.props, ['className', 'scrollTop', 'scrollLeft'])}
         className={cls}
         onScroll={_onScroll}
-        onTouchMove={this.onTouchMove}>
+        // onTouchMove={this.onTouchMove}
+      >
         {this.props.children}
       </div>
     )


### PR DESCRIPTION
#2770 

**这个 PR 是什么类型?** (至少选择一个)

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Typings
- [ ] Docs
- [ ] Code style update
- [ ] Other, please describe:

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**其它需要 Reviewer 或社区知晓的内容：**
