### PR TITLE
优化 taro-plugin-stylus 配置代码

### DIFF
--- a/packages/taro-plugin-stylus/index.js
+++ b/packages/taro-plugin-stylus/index.js
@@ -13,7 +13,7 @@ module.exports = function compileStylus (content, file, config) {
       content = fs.readFileSync(file).toString()
     }
     const opath = path.parse(file)
-    config.paths = [opath.dir]
+    config.paths = [opath.dir].concat(config.paths || [])
     config.filename = opath.base
     const instance = stylus(content, { filename: file })
     for (const k in config) {

--- a/packages/taro-plugin-stylus/tests/fixtures/base/style.styl
+++ b/packages/taro-plugin-stylus/tests/fixtures/base/style.styl
@@ -1,0 +1,1 @@
+primary = #fff;

--- a/packages/taro-plugin-stylus/tests/fixtures/test.styl
+++ b/packages/taro-plugin-stylus/tests/fixtures/test.styl
@@ -1,0 +1,5 @@
+@import 'style';
+
+body {
+    color: primary;
+}

--- a/packages/taro-plugin-stylus/tests/index.test.js
+++ b/packages/taro-plugin-stylus/tests/index.test.js
@@ -1,0 +1,12 @@
+const compile = require('../index')
+const assert = require('assert')
+const path = require('path')
+
+const file = path.join(__dirname, 'fixtures', 'test.styl')
+// eslint-disable-next-line no-debugger
+
+compile(null, file, {
+  paths: [path.join(__dirname, 'fixtures', 'base')]
+}).then(({ css }) => {
+  assert.equal(css, 'body {\n  color: #fff;\n}\n', 'ok')
+})


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

对 taro-plugin-stylus 做了修改，合并全局配置中的目录引用，在stylus样式引用其他文件时，可以在不用alias或者一级级的向上引用的情况下直接使用，但是需要避免文件重名。

使用方法：

例如，有文件如下

```
- src
  - asset
     base.styl
 - pages
    - index
       style.styl
```

在配置文件中设置
```
config/index.js

 {
   plugins:  {
     stylus: {
       paths: [ path.join(__dirname, '../src/asset')]
     }
   }
}

```

样式文件pages/index/style.styl中可直接使用
```
❌ 不需要再一级级的引入
@import "../../../asset/base.styl"

✅ 直接使用
@import "base.styl"

### 其他样式
```


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
