### PR TITLE
docs: 修复CheckboxGroup微信端链接错误

### DIFF
--- a/docs/components/forms/checkbox.md
+++ b/docs/components/forms/checkbox.md
@@ -15,7 +15,7 @@ sidebar_label: Checkbox
 
 >其他相关属性请看各小程序官方文档
 
-[微信小程序 CheckboxGroup](https://developers.weixin.qq.com/miniprogram/dev/component/button.html)。
+[微信小程序 CheckboxGroup](https://developers.weixin.qq.com/miniprogram/dev/component/checkbox-group.html)。
 
 [百度小程序 CheckboxGroup](https://smartprogram.baidu.com/docs/develop/component/formlist/#checkbox)。
 


### PR DESCRIPTION
文档中`CheckboxGroup`组件对应的微信端链接指向的是`button`。