### PR TITLE
fix: 🐛 修复RN下获取statusBarHeight不准确的问题

### DIFF
--- a/packages/taro-rn/src/api/system/index.js
+++ b/packages/taro-rn/src/api/system/index.js
@@ -2,8 +2,7 @@ import {
   Platform,
   Dimensions,
   StatusBar,
-  PixelRatio,
-  DeviceInfo
+  PixelRatio
 } from 'react-native'
 
 export function getSystemInfo (opts = {}) {
@@ -23,6 +22,30 @@ export function getSystemInfo (opts = {}) {
   }
 }
 
+const isIPhoneX = (function () {
+  const X_WIDTH = 375
+  const X_HEIGHT = 812
+  const XS_MAX_WIDTH = 414
+  const XS_MAX_HEIGHT = 896
+
+  const getResolvedDimensions = () => {
+    const { width, height } = Dimensions.get('window')
+    if (width === 0 && height === 0) return Dimensions.get('window')
+    return { width, height }
+  }
+
+  const { height: D_HEIGHT, width: D_WIDTH } = getResolvedDimensions()
+
+  if (Platform.OS === 'web') return false
+
+  return (
+    (D_HEIGHT === X_HEIGHT && D_WIDTH === X_WIDTH) ||
+    (D_HEIGHT === X_WIDTH && D_WIDTH === X_HEIGHT) ||
+    ((D_HEIGHT === XS_MAX_HEIGHT && D_WIDTH === XS_MAX_WIDTH) ||
+      (D_HEIGHT === XS_MAX_WIDTH && D_WIDTH === XS_MAX_HEIGHT))
+  )
+})()
+
 export function getSystemInfoSync () {
   const res = {}
 
@@ -31,7 +54,7 @@ export function getSystemInfoSync () {
   const os = Platform.OS
   const version = Platform.Version
   const isAndroid = Platform.OS === 'android'
-  const statusBarHeight = isAndroid ? StatusBar.currentHeight : DeviceInfo.isIPhoneX_deprecated ? 44 : 20
+  const statusBarHeight = isAndroid ? StatusBar.currentHeight : isIPhoneX ? 44 : 20
   const screenWidth = Dimensions.get('screen').width
   const screenHeight = Dimensions.get('screen').height
   const windowWidth = Dimensions.get('window').width


### PR DESCRIPTION
✅ Closes: #3036

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
RN端能够准确获取到所有苹果机型的状态栏高度，和小程序保持一致。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #3036 
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）

