### PR TITLE
fix(weapp): 修复urlQuery为空时，生成错误的params，close #3266

### DIFF
--- a/packages/taro-alipay/src/native-api.js
+++ b/packages/taro-alipay/src/native-api.js
@@ -283,8 +283,10 @@ function processApis (taro) {
             if (component.componentWillPreload) {
               const cacheKey = getUniqueKey()
               const MarkIndex = obj.url.indexOf('?')
-              const params = queryToJson(obj.url.substring(MarkIndex + 1, obj.url.length))
-              obj.url += (MarkIndex > -1 ? '&' : '?') + `${preloadPrivateKey}=${cacheKey}`
+              const hasMark = MarkIndex > -1
+              const urlQueryStr = hasMark ? obj.url.substring(MarkIndex + 1, obj.url.length) : ''
+              const params = queryToJson(urlQueryStr)
+              obj.url += (hasMark ? '&' : '?') + `${preloadPrivateKey}=${cacheKey}`
               cacheDataSet(cacheKey, component.componentWillPreload(params))
               cacheDataSet(preloadInitedComponent, component)
             }

--- a/packages/taro-qq/src/native-api.js
+++ b/packages/taro-qq/src/native-api.js
@@ -112,8 +112,10 @@ function processApis (taro) {
             if (component.componentWillPreload) {
               const cacheKey = getUniqueKey()
               const MarkIndex = obj.url.indexOf('?')
-              const params = queryToJson(obj.url.substring(MarkIndex + 1, obj.url.length))
-              obj.url += (MarkIndex > -1 ? '&' : '?') + `${preloadPrivateKey}=${cacheKey}`
+              const hasMark = MarkIndex > -1
+              const urlQueryStr = hasMark ? obj.url.substring(MarkIndex + 1, obj.url.length) : ''
+              const params = queryToJson(urlQueryStr)
+              obj.url += (hasMark ? '&' : '?') + `${preloadPrivateKey}=${cacheKey}`
               cacheDataSet(cacheKey, component.componentWillPreload(params))
               cacheDataSet(preloadInitedComponent, component)
             }
@@ -123,9 +125,11 @@ function processApis (taro) {
         if (useDataCacheApis[key]) {
           const url = obj['url'] = obj['url'] || ''
           const MarkIndex = url.indexOf('?')
-          const params = queryToJson(url.substring(MarkIndex + 1, url.length))
+          const hasMark = MarkIndex > -1
+          const urlQueryStr = hasMark ? url.substring(MarkIndex + 1, url.length) : ''
+          const params = queryToJson(urlQueryStr)
           const cacheKey = getUniqueKey()
-          obj.url += (MarkIndex > -1 ? '&' : '?') + `${routerParamsPrivateKey}=${cacheKey}`
+          obj.url += (hasMark ? '&' : '?') + `${routerParamsPrivateKey}=${cacheKey}`
           cacheDataSet(cacheKey, params)
         }
 

--- a/packages/taro-tt/src/native-api.js
+++ b/packages/taro-tt/src/native-api.js
@@ -113,8 +113,10 @@ function processApis (taro) {
             if (component.componentWillPreload) {
               const cacheKey = getUniqueKey()
               const MarkIndex = obj.url.indexOf('?')
-              const params = queryToJson(obj.url.substring(MarkIndex + 1, obj.url.length))
-              obj.url += (MarkIndex > -1 ? '&' : '?') + `${preloadPrivateKey}=${cacheKey}`
+              const hasMark = MarkIndex > -1
+              const urlQueryStr = hasMark ? obj.url.substring(MarkIndex + 1, obj.url.length) : ''
+              const params = queryToJson(urlQueryStr)
+              obj.url += (hasMark ? '&' : '?') + `${preloadPrivateKey}=${cacheKey}`
               cacheDataSet(cacheKey, component.componentWillPreload(params))
               cacheDataSet(preloadInitedComponent, component)
             }

--- a/packages/taro-weapp/src/native-api.js
+++ b/packages/taro-weapp/src/native-api.js
@@ -112,9 +112,10 @@ function processApis (taro) {
             if (component.componentWillPreload) {
               const cacheKey = getUniqueKey()
               const MarkIndex = obj.url.indexOf('?')
-              const urlQueryStr = MarkIndex > -1 ? obj.url.substring(MarkIndex + 1, obj.url.length) : ''
+              const hasMark = MarkIndex > -1
+              const urlQueryStr = hasMark ? obj.url.substring(MarkIndex + 1, obj.url.length) : ''
               const params = queryToJson(urlQueryStr)
-              obj.url += (MarkIndex > -1 ? '&' : '?') + `${preloadPrivateKey}=${cacheKey}`
+              obj.url += (hasMark ? '&' : '?') + `${preloadPrivateKey}=${cacheKey}`
               cacheDataSet(cacheKey, component.componentWillPreload(params))
               cacheDataSet(preloadInitedComponent, component)
             }
@@ -124,10 +125,11 @@ function processApis (taro) {
         if (useDataCacheApis[key]) {
           const url = obj['url'] = obj['url'] || ''
           const MarkIndex = url.indexOf('?')
-          const urlQueryStr = MarkIndex > -1 ? url.substring(MarkIndex + 1, url.length) : ''
+          const hasMark = MarkIndex > -1
+          const urlQueryStr = hasMark ? url.substring(MarkIndex + 1, url.length) : ''
           const params = queryToJson(urlQueryStr)
           const cacheKey = getUniqueKey()
-          obj.url += (MarkIndex > -1 ? '&' : '?') + `${routerParamsPrivateKey}=${cacheKey}`
+          obj.url += (hasMark ? '&' : '?') + `${routerParamsPrivateKey}=${cacheKey}`
           cacheDataSet(cacheKey, params)
         }
 

--- a/packages/taro-weapp/src/native-api.js
+++ b/packages/taro-weapp/src/native-api.js
@@ -112,7 +112,8 @@ function processApis (taro) {
             if (component.componentWillPreload) {
               const cacheKey = getUniqueKey()
               const MarkIndex = obj.url.indexOf('?')
-              const params = queryToJson(obj.url.substring(MarkIndex + 1, obj.url.length))
+              const urlQueryStr = MarkIndex > -1 ? obj.url.substring(MarkIndex + 1, obj.url.length) : ''
+              const params = queryToJson(urlQueryStr)
               obj.url += (MarkIndex > -1 ? '&' : '?') + `${preloadPrivateKey}=${cacheKey}`
               cacheDataSet(cacheKey, component.componentWillPreload(params))
               cacheDataSet(preloadInitedComponent, component)
@@ -123,7 +124,8 @@ function processApis (taro) {
         if (useDataCacheApis[key]) {
           const url = obj['url'] = obj['url'] || ''
           const MarkIndex = url.indexOf('?')
-          const params = queryToJson(url.substring(MarkIndex + 1, url.length))
+          const urlQueryStr = MarkIndex > -1 ? url.substring(MarkIndex + 1, url.length) : ''
+          const params = queryToJson(urlQueryStr)
           const cacheKey = getUniqueKey()
           obj.url += (MarkIndex > -1 ? '&' : '?') + `${routerParamsPrivateKey}=${cacheKey}`
           cacheDataSet(cacheKey, params)


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

weapp中不带参数切换页面，`this.$router.params`中会多出一个与`path`同名的字段。详见(#3266 )
发现是这里=》[code](https://github.com/NervJS/taro/blob/master/packages/taro-weapp/src/native-api.js#L126)，取query的时候，如果没有query就将path传进去了，导致`queryToJson`这个函数返回了错误的结果。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) #3266 
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [ ] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [ ] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

