### PR TITLE
feat: add the type definition of FunctionComponent and Taro.memo

### DIFF
--- a/packages/taro/types/index.d.ts
+++ b/packages/taro/types/index.d.ts
@@ -104,6 +104,10 @@ declare namespace Taro {
     $scope?: any
   }
 
+  interface FunctionComponent<P = {}> {
+    (props: Readonly<P>): JSX.Element
+  }
+
   interface PageConfig {
     /**
      * 导航栏背景颜色，HexColor
@@ -385,6 +389,11 @@ declare namespace Taro {
   }
 
   class PureComponent<P = {}, S = {}> extends Component<P, S> { }
+
+  function memo(
+    FunctionComponent: FunctionComponent,
+    compare?: (oldProps: any, newProps: any) => Boolean
+  ): FunctionComponent
 
   // Events
   class Events {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

添加 FunctionComponent 和 Taro.memo 的类型定义。

**这个 PR 是什么类型?** (至少选择一个)

- [x] TypeScript 类型定义修改(Typings)


**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

