### PR TITLE
增加对华为原子服务定义文件的规范检查

### DIFF
--- a/packages/taro-cli/bin/taro-doctor
+++ b/packages/taro-cli/bin/taro-doctor
@@ -16,6 +16,11 @@ if (!fs.existsSync(PROJECT_CONF_PATH)) {
 }
 
 const { validators } = require('../dist/doctor').default
+const abilityXMLValidator = require('../dist/doctor/abilityXMLValidator').default
+const QUICKAPP_CONF_PATH = path.join(appPath, 'project.quickapp.json')
+if (fs.existsSync(QUICKAPP_CONF_PATH)) {
+  validators.push(abilityXMLValidator)
+}
 
 const NOTE_ALL_RIGHT = chalk.green('[✓] ')
 const NOTE_VALID = chalk.yellow('[!] ')

--- a/packages/taro-cli/src/doctor/abilityXMLValidator.ts
+++ b/packages/taro-cli/src/doctor/abilityXMLValidator.ts
@@ -1,0 +1,34 @@
+import * as _ from 'lodash/fp'
+import * as fs from 'fs-extra'
+import * as path from 'path'
+import chalk from 'chalk'
+
+import { IErrorLine } from './interface'
+
+const ABILITYXML = ['ability.xml']
+
+export default async function ({ appPath }) {
+  const PROJECT_PACKAGE_PATH = path.join(appPath, 'package.json')
+  const PROJECT_FOLDER_FILES = fs.readdirSync('./')
+  if (!fs.existsSync(PROJECT_PACKAGE_PATH)) {
+    console.log(chalk.red(`找不到${PROJECT_PACKAGE_PATH}，请确定当前目录是Taro项目根目录!`))
+    process.exit(1)
+  }
+
+  const inProjectFolder = filenames => (_.intersectionBy(_.toLower, PROJECT_FOLDER_FILES, filenames)).length > 0
+  const hasAbilityXML = inProjectFolder(ABILITYXML)
+
+  const errorLines: IErrorLine[] = []
+
+  if (!hasAbilityXML) {
+    errorLines.push({
+      desc: '没有检查到 ability.xml, 编写 ability.xml可以让其他应用方便地叫起应用内服务',
+      valid: true
+    })
+  }
+
+  return {
+    desc: '检查原子化服务规范',
+    lines: errorLines
+  }
+}

--- a/packages/taro-cli/src/doctor/index.ts
+++ b/packages/taro-cli/src/doctor/index.ts
@@ -2,12 +2,14 @@ import configValidator from './configValidator';
 import packageValidator from './packageValidator';
 import recommandValidator from './recommandValidator';
 import eslintValidator from './eslintValidator';
+import abilityXMLValidator from './abilityXMLValidator';
 
 export default {
   validators: [
     configValidator,
     packageValidator,
     recommandValidator,
-    eslintValidator
+    eslintValidator,
+    abilityXMLValidator
   ]
 }

--- a/packages/taro-cli/src/doctor/index.ts
+++ b/packages/taro-cli/src/doctor/index.ts
@@ -2,14 +2,12 @@ import configValidator from './configValidator';
 import packageValidator from './packageValidator';
 import recommandValidator from './recommandValidator';
 import eslintValidator from './eslintValidator';
-import abilityXMLValidator from './abilityXMLValidator';
 
 export default {
   validators: [
     configValidator,
     packageValidator,
     recommandValidator,
-    eslintValidator,
-    abilityXMLValidator
+    eslintValidator
   ]
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
华为的快应用中增加了一个用于定义原子服务能力定义的文件ability.xml，本次修改在doctor模块中增加了对ability.xml的规范检查。

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [x] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
