### PR TITLE
 fix(h5): taro-h5的api没有挂载到export default Taro上

### DIFF
--- a/packages/taro-h5/__test__/othersApi-test.js
+++ b/packages/taro-h5/__test__/othersApi-test.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import * as Taro from '../src/api'
+
 describe('others', () => {
   test('should covert arraybuffer to base64', () => {
     const arrayBuffer = new Uint8Array([11, 22, 33])
@@ -13,5 +14,14 @@ describe('others', () => {
     expect(arrayBuffer[0]).toBe(11)
     expect(arrayBuffer[1]).toBe(22)
     expect(arrayBuffer[2]).toBe(33)
+  })
+})
+
+describe('export api', () => {
+  it('export', () => {
+    expect(Taro).to.have.key('setClipBoardData')
+  })
+  it('export default', () => {
+    expect(Taro.default).to.have.key('setClipBoardData')
   })
 })

--- a/packages/taro-h5/src/taro/index.js
+++ b/packages/taro-h5/src/taro/index.js
@@ -44,6 +44,8 @@ import Nerv, {
   useContext
 } from 'nervjs'
 
+import * as api from '../api/index'
+
 import { permanentlyNotSupport } from '../api/utils'
 
 const taro = {
@@ -83,7 +85,8 @@ const taro = {
   useCallback,
   useMemo,
   useImperativeHandle,
-  useContext
+  useContext,
+  ...api
 }
 
 class Component extends Nerv.Component {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

taro-h5的api没有挂载到Taro上

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #3539
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [ ] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
