### PR TITLE
fix(h5): request的get请求数据为复杂结构不能正确发送的问题

### DIFF
--- a/packages/taro-h5/src/api/utils/index.js
+++ b/packages/taro-h5/src/api/utils/index.js
@@ -60,7 +60,11 @@ function serializeParams (params) {
     return ''
   }
   return Object.keys(params)
-    .map(key => (`${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`)).join('&')
+    .map(key => (
+      `${encodeURIComponent(key)}=${typeof (params[key]) ==="object" ?
+        encodeURIComponent(JSON.stringify(params[key])):
+        encodeURIComponent(params[key])}`))
+    .join('&')
 }
 
 function temporarilyNotSupport (apiName) {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
Get请求，发现如果传递的参数是多层的，直接会变成object字符串，参考微信小程序原生功能，对多层对象进行json转string操作。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
