### PR TITLE
fix(h5): 解决getCurrentPages有时候只能获取长度但没有内容的问题

### DIFF
--- a/packages/taro-router/src/router/router.tsx
+++ b/packages/taro-router/src/router/router.tsx
@@ -102,7 +102,12 @@ class Router extends Taro.Component<Props, State> {
   }
 
   collectComponent = (comp, k) => {
-    this.currentPages[k] = comp
+    if(this.currentPages[k]){
+      this.currentPages[k] = comp;
+    }
+    else{
+      this.currentPages.push(comp);
+    }
   }
 
   componentDidMount () {
@@ -138,9 +143,7 @@ class Router extends Taro.Component<Props, State> {
   }
 
   render () {
-    const router = this
     const currentLocation = Taro._$router
-    router.currentPages.length = this.state.routeStack.length
     return (
       <div
         className="taro_router"


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
在一些生命周期中获取getCurrentPages函数时（如页面跳转时的上一页面销毁/隐藏事件）会有只有长度没有内容的Page对象存在
```
...
render () {
    const router = this
    const currentLocation = Taro._$router
    router.currentPages.length = this.state.routeStack.length//创建组件前先同步下长度？
    return (
      <div
        className="taro_router"
        style={"min-height: 100%"}>
...
```
从源码中看到会在render时同步一下长度，但当前this.state.routeStack已经包含下一个页面，所以导致数据不一致
**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**