### PR TITLE
fix(taro): 为 Taro.request 类型定义添加 abort 方法，完善注释 #3654

### DIFF
--- a/docs/apis/network/request/request.md
+++ b/docs/apis/network/request/request.md
@@ -3,8 +3,9 @@ title: Taro.request(OBJECT)
 sidebar_label: request
 ---
 
-
 发起网络请求，支持 `Promise` 化使用。
+
+> 暂不支持使用 [RequestTask.onHeadersReceived(function callback)](https://developers.weixin.qq.com/miniprogram/dev/api/network/request/RequestTask.onHeadersReceived.html) 和 [RequestTask.offHeadersReceived(function callback)](https://developers.weixin.qq.com/miniprogram/dev/api/network/request/RequestTask.offHeadersReceived.html) 方法。
 
 **OBJECT 参数说明：**
 
@@ -56,12 +57,27 @@ Taro.request({
   .then(res => console.log(res.data))
 ```
 
+## 小程序端使用 RequestTask.abort()
 
+```jsx
+const requestTask = Taro.request({
+  url: 'test.php', //仅为示例，并非真实的接口地址
+  data: {
+    x: '' ,
+    y: ''
+  },
+  header: {
+    'content-type': 'application/json'
+  },
+  success (res) {
+    console.log(res.data)
+  }
+})
+requestTask.abort() // 取消请求任务
+```
 
 ## API支持度
-
 
 | API | 微信小程序 | H5 | React Native | 支付宝小程序 | 百度小程序 | 头条小程序 | QQ 轻应用 |
 | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
 | Taro.request | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
-

--- a/packages/taro/types/index.d.ts
+++ b/packages/taro/types/index.d.ts
@@ -898,6 +898,17 @@ declare namespace Taro {
        */
       header: any
     }
+    /**
+     * 网络请求任务对象
+     * @see https://developers.weixin.qq.com/miniprogram/dev/api/network/request/RequestTask.html
+     */
+    interface requestTask<T> extends Promise<request.Promised<T>> {
+      /**
+       * 中断请求任务
+       * @see https://developers.weixin.qq.com/miniprogram/dev/api/network/request/RequestTask.abort.html
+       */
+      abort(): void
+    }
     type Param < P extends any | string | ArrayBuffer = any > = {
       /**
        * 开发者服务器接口地址
@@ -1028,10 +1039,10 @@ declare namespace Taro {
    * 发起网络请求。**使用前请先阅读[说明](https://developers.weixin.qq.com/miniprogram/dev/api/network/request/wx.request.html)**。
    *
    * **返回值：**
+   * 
+   * @returns {request.requestTask} 返回一个 `requestTask` 对象，通过 `requestTask`，可中断请求任务。
    *
    * @since 1.4.0
-   *
-   * 返回一个 `requestTask` 对象，通过 `requestTask`，可中断请求任务。
    *
    * **Bug & Tip：**
    *
@@ -1040,44 +1051,54 @@ declare namespace Taro {
    * 3.  `bug`: 开发者工具 `0.10.102800` 版本，`header` 的 `content-type` 设置异常；
    *
    * **示例代码：**
+   * 
+   * @example
+   * // 回调函数(Callback)用法：
+   * const requestTask = Taro.request({
+   *   url: 'test.php', //仅为示例，并非真实的接口地址
+   *   data: {
+   *     x: '' ,
+   *     y: ''
+   *   },
+   *   header: {
+   *     'content-type': 'application/json' // 默认值
+   *   },
+   *   success: function(res) {
+   *     console.log(res.data)
+   *   }
+   * })
+   * requestTask.abort()
+   * 
+   * // Promise 用法：
+   * const requestTask = Taro.request({
+   *   url: 'test.php', //仅为示例，并非真实的接口地址
+   *   data: {
+   *     x: '' ,
+   *     y: ''
+   *   },
+   *   header: {
+   *     'content-type': 'application/json' // 默认值
+   *   },
+   *   success: function(res) {
+   *     console.log(res.data)
+   *   }
+   * })
+   * requestTask.then(res => {
+   *   console.log(res.data)
+   * })
+   * requestTask.abort()
+   * 
+   * // async/await 用法：
+   * const requestTask = Taro.request(params)
+   * const res = await requestTask
+   * requestTask.abort()
+   * 
+   * // 不需要 abort 的 async/await 用法：
+   * const res = await Taro.request(params)
    *
-   ```javascript
-   Taro.request({
-     url: 'test.php', //仅为示例，并非真实的接口地址
-     data: {
-        x: '' ,
-        y: ''
-     },
-     header: {
-         'content-type': 'application/json' // 默认值
-     },
-     success: function(res) {
-       console.log(res.data)
-     }
-   })
-   ```
-   *
-   * **示例代码：**
-   *
-   ```javascript
-   const requestTask = Taro.request({
-     url: 'test.php', //仅为示例，并非真实的接口地址
-     data: {
-        x: '' ,
-        y: ''
-     },
-     header: {
-         'content-type': 'application/json'
-     },
-     success: function(res) {
-       console.log(res.data)
-     }
-   })
-         requestTask.abort() // 取消请求任务
-   ```
    * @see https://developers.weixin.qq.com/miniprogram/dev/api/network/request/wx.request.html
    */
-  function request<T = any, U = any>(OBJECT: request.Param<U>): Promise<request.Promised<T>>
+  function request<T = any, U = any>(OBJECT: request.Param<U>): request.requestTask<T>
 
   type arrayBuffer = Uint8Array | Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array | ArrayBuffer
 


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

2ada5a2 为 Taro.request 添加了 abort 方法(#3654)，更新 Taro.request 的类型定义，完善了注释和示例代码。

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [x] TypeScript 类型定义修改(Typings)
- [x] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

暂不知道其他端是否支持 abort

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
