### PR TITLE
fix(taro-components-rn): 修复Input组件不支持onChange事件

### DIFF
--- a/packages/taro-components-rn/src/components/Input/PropsType.tsx
+++ b/packages/taro-components-rn/src/components/Input/PropsType.tsx
@@ -33,6 +33,7 @@ export interface InputProps {
   selectionStart: number;
   selectionEnd: number;
   onInput?: (evt: Event) => void;
+  onChange?: (evt: Event) => void;
   onFocus?: (evt: Event) => void;
   onBlur?: (evt: Event) => void;
   onKeyDown?: (evt: Partial<Event> & { which?: number }) => void;

--- a/packages/taro-components-rn/src/components/Input/index.tsx
+++ b/packages/taro-components-rn/src/components/Input/index.tsx
@@ -78,11 +78,12 @@ class _Input extends React.Component<InputProps, InputState> {
   lineCount: number = 0
 
   onChangeText = (text: string): void => {
-    const { onInput } = this.props
+    const { onInput, onChange } = this.props
     const { returnValue } = this.state
     this.tmpValue = text || ''
-    if (onInput) {
-      const result = onInput({
+    const InputEvent = onInput || onChange;
+    if (InputEvent) {
+      const result = InputEvent({
         target: { value: text },
         detail: { value: text }
       })

--- a/packages/taro-rn/src/api/interface/toast.js
+++ b/packages/taro-rn/src/api/interface/toast.js
@@ -118,7 +118,7 @@ function showToast (options) {
       </View>
     </View>
   } else if (icon === 'loading') {
-    ToastView = <WXLoading />
+    ToastView = <WXLoading title={title} />
   } else if (icon === 'none') {
     ToastView = <View style={styles.container}>
       <View style={styles.textGrayBlock}>


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
修复RN端Input组件不支持onChange事件，保持和其他端一致性。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
无。