### PR TITLE
fix(taro-components-rn): 修复Input组件不支持onChange事件，没有保持端一致性

### DIFF
--- a/packages/taro-components-rn/src/components/Input/PropsType.tsx
+++ b/packages/taro-components-rn/src/components/Input/PropsType.tsx
@@ -33,6 +33,7 @@ export interface InputProps {
   selectionStart: number;
   selectionEnd: number;
   onInput?: (evt: Event) => void;
+  onChange?: (evt: Event) => void;
   onFocus?: (evt: Event) => void;
   onBlur?: (evt: Event) => void;
   onKeyDown?: (evt: Partial<Event> & { which?: number }) => void;

--- a/packages/taro-components-rn/src/components/Input/index.tsx
+++ b/packages/taro-components-rn/src/components/Input/index.tsx
@@ -78,11 +78,12 @@ class _Input extends React.Component<InputProps, InputState> {
   lineCount: number = 0
 
   onChangeText = (text: string): void => {
-    const { onInput } = this.props
+    const { onInput, onChange } = this.props
     const { returnValue } = this.state
+    const onEvent = onInput || onChange
     this.tmpValue = text || ''
-    if (onInput) {
-      const result = onInput({
+    if (onEvent) {
+      const result = onEvent({
         target: { value: text },
         detail: { value: text }
       })


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复Input组件不支持onChange事件，没有保持端一致性。当我在小程序中使用onChange时，不能平滑过渡到RN。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
