### PR TITLE
fix(eslint): 修复render props传入单个JSX元素或箭头函数报错的问题

### DIFF
--- a/packages/eslint-plugin-taro/rules/render-props.js
+++ b/packages/eslint-plugin-taro/rules/render-props.js
@@ -36,9 +36,9 @@ module.exports = {
             })
             return
           }
-          if (node.value.expression.type !== 'JSXElement' || node.value.expression.type !== 'ArrowFunctionExpression') {
+          if (node.value.expression.type !== 'JSXElement' && node.value.expression.type !== 'ArrowFunctionExpression') {
             context.report({
-              message: '以 render 开头命名的 props 只能传入单个 JSX 元素元素或箭头函数',
+              message: '以 render 开头命名的 props 只能传入单个 JSX 元素或箭头函数',
               node
             })
           }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?**
 修复render props传入单个JSX元素或箭头函数报错的问题

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [x] 其他，请描述(Other, please describe): eslint 规则

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
