### PR TITLE
fix: objectExpression property key'type

### DIFF
--- a/packages/taro-transformer-wx/__tests__/template.spec.ts
+++ b/packages/taro-transformer-wx/__tests__/template.spec.ts
@@ -916,4 +916,45 @@ describe('字符不转义', () => {
       expect(inst.state.anonymousState__temp).toEqual('')
     })
   })
+
+  describe("ObjectExpression property key", () => {
+    test("StringLiteral", () => {
+      const { template, ast, code } = transform({
+        ...baseOptions,
+        isRoot: true,
+        code: buildComponent(`
+          return {
+              'weapp': (
+                  <View>weapp</View>
+              ),
+              'h5': (
+                  <View>h5</View>
+              )
+          }[process.env.TARO_ENV]
+        `)
+      })
+
+      const inst = evalClass(ast, "", true);
+      expect(template).toMatch(`'weapp' === 'weapp'`);
+    })
+    test("Identifier", () => {
+      const { template, ast, code } = transform({
+        ...baseOptions,
+        isRoot: true,
+        code: buildComponent(`
+          return {
+              weapp: (
+                  <View>weapp</View>
+              ),
+              h5: (
+                  <View>h5</View>
+              )
+          }[process.env.TARO_ENV]
+        `)
+      })
+
+      const inst = evalClass(ast, "", true);
+      expect(template).toMatch(`'weapp' === 'weapp'`);
+    })
+  })
 })

--- a/packages/taro-transformer-wx/src/render.ts
+++ b/packages/taro-transformer-wx/src/render.ts
@@ -221,7 +221,8 @@ export class RenderParser {
       }
       const children = properties.map(p => p.node).map((p, index) => {
         const block = buildBlockElement()
-        const tester = t.binaryExpression('===', p.key, rval.node as any)
+        const leftExpression = t.isStringLiteral(p.key) ? p.key : t.stringLiteral(p.key.name)
+        const tester = t.binaryExpression('===', leftExpression, rval.node as any)
         block.children = [t.jSXExpressionContainer(p.value)]
         if (index === 0) {
           newJSXIfAttr(block, tester)


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
修复如果模块中以对象表达式的形式，key  非字符的形式，编译后存在 ${key} is not defined.

**这个 PR 是什么类型?** (至少选择一个)
- [x] 错误修复(Bugfix) 

**这个 PR 满足以下需求:**
- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**
- [x] 微信小程序