### PR TITLE
校验华为原子化服务配置文件ability.xml中的intent和parameter合法性

### DIFF
--- a/packages/taro-cli/package.json
+++ b/packages/taro-cli/package.json
@@ -112,6 +112,7 @@
     "vinyl": "^2.1.0",
     "vinyl-fs": "^3.0.2",
     "xxhashjs": "^0.2.2",
+    "xml2js": "^0.4.19",
     "yauzl": "2.10.0"
   },
   "devDependencies": {

--- a/packages/taro-cli/src/doctor/abilityXMLValidator.ts
+++ b/packages/taro-cli/src/doctor/abilityXMLValidator.ts
@@ -1,9 +1,42 @@
+/*
+本测试用于对华为原子化服务的配置文件ability.xml进行校验。
+ability.xml所需声明内容包括：
+1、ability用于声明应用内服务，intent属性用于叫起该服务；
+2、display为可选项，用于声明服务页面展示信息；
+3、service用于声明提供对应服务的页面；
+4、parameter用于声明启动服务所需要的参数信息。
+
+文件格式样式举例如下：
+*******************************************************************************************************************
+<?xml version="1.0" encoding="utf-8"?>
+<aml version="1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="ability.xsd">
+  <ability intent="ability.intent.ORDER_MOVIE">
+    <display name="电影票预定" icon="Common/ticket.png" description="电影票预定"/>
+    <service link="hap://app/com.huawei.www/movie/order">
+      <parameter linkParameter="movieName" intentParameter="movieName" testValue="狮子王" urlEncoding="false"/>
+    </service>
+  </ability>
+  <ability intent="ability.intents.ORDER_TAXI">
+    <display name="打车" icon="Common/taxi.png" description="打车"/>
+    <service link="hap://app/com.huawei.www/taxi/order">
+      <parameter linkParameter="dstLocation" intentParameter="dstLocation" testValue="南京站" urlEncoding="false"/>
+    </service>
+  </ability>
+</aml>
+******************************************************************************************************************
+
+详细配置规范请参考华为开发者网站：developer.huawei.com
+*/
+
 import * as _ from 'lodash/fp'
 import * as fs from 'fs-extra'
 import * as path from 'path'
 import chalk from 'chalk'
 
 import { IErrorLine } from './interface'
+
+const xml2js = require('xml2js')
 
 const ABILITYXML = ['ability.xml']
 
@@ -24,6 +57,77 @@ export default async function ({ appPath }) {
     errorLines.push({
       desc: '没有检查到 ability.xml, 编写 ability.xml可以让其他应用方便地叫起应用内服务',
       valid: true
+    })
+  } else {
+    const PROJECT_ABILITY_FILE_PATH = path.join(appPath, 'ability.xml')
+    const data = fs.readFileSync(PROJECT_ABILITY_FILE_PATH)
+
+    xml2js.parseString(data, function(err, result){
+      //解析ability.xml配置文件
+      if(err){
+        errorLines.push({
+          desc: 'ability.xml 解析错误，请检查文件格式！',
+          valid: true
+        })
+      }else{
+        //检查ability配置
+        let abilities = result.aml.ability;
+        if(abilities == null){
+          errorLines.push({
+            desc: '没有发现 ability声明, 请检查是否定义完整',
+            valid: true
+          })
+        }else{
+          //检查intent声明合法性
+          const intentRegex = /ability.intent.[0-9A-Z_]+$/; //intent匹配规则
+          const parameterRegex = /^[A-Za-z0-9_]+$/; //parameter匹配规则
+
+          for(let x in abilities){
+            let abilityIndex = parseInt(x)+1;
+
+            //检查intent声明
+            if(!intentRegex.test(abilities[x].$.intent)){
+              errorLines.push({
+                desc: '第'+abilityIndex+'个ability的intent格式错误',
+                valid: true,
+                solution: 'intent 必须声明为格式为ability.intent.xxx的字符串，xxx可以包含数字，大写字母和下划线'
+              })
+            }
+
+            //检查service的parameter声明合法性
+            let services = abilities[x].service;
+
+            if(services == null){
+              errorLines.push({
+              desc: '第'+abilityIndex+'个ability没有发现 service声明, 请检查是否定义完整',
+              valid: true
+              })
+            }else{
+              for(let y in services){
+                let serviceIndex = parseInt(y)+1;
+
+                //校验linkParameter
+                if(!parameterRegex.test(services[y].parameter[0].$.linkParameter)){
+                  errorLines.push({
+                    desc: '第'+abilityIndex+'个ability的第'+serviceIndex+'个service linkParameter 格式错误',
+                    valid: true,
+                    solution: 'linkParameter 只能包含数字，大写字母，小写字母和下划线'
+                  })
+                }
+
+                //校验intentParameter
+                if(!parameterRegex.test(services[y].parameter[0].$.intentParameter)){
+                  errorLines.push({
+                    desc: '第'+abilityIndex+'个ability的第'+serviceIndex+'个service intentParameter 格式错误',
+                    valid: true,
+                    solution: 'intentParameter 只能包含数字，大写字母，小写字母和下划线'
+                  })
+                }
+              }
+            }
+          }
+        }
+      }
     })
   }
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
补充对华为原子化服务配置文件ability.xml中intent和parameter声明的合法性检查。


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [x] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
