### PR TITLE
feat(taro-components): 为CanvasProps新增属性定义type, 支持微信小程序使用webgl的额外props

### DIFF
--- a/packages/taro-components/types/Canvas.d.ts
+++ b/packages/taro-components/types/Canvas.d.ts
@@ -8,6 +8,11 @@ export interface CanvasProps extends StandardProps {
   canvasId: string,
 
   /**
+   * 小程序 canvas 组件使用webgl，需要添加type="webgl"，才能通过 SelectorQuery 取到 canvas 节点
+   */
+  type?: string,
+
+  /**
    * 当在 canvas 中移动时且有绑定手势事件时，禁止屏幕滚动以及下拉刷新
    *
    * 默认值：`false`


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

为CanvasProps新增属性定义type, 支持微信小程序使用webgl的额外props

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [x] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
