### PR TITLE
feat(h5): 使scroll-view组件在h5中支持scrollIntoView属性

### DIFF
--- a/packages/taro-components/src/components/scroll-view/index.js
+++ b/packages/taro-components/src/components/scroll-view/index.js
@@ -103,6 +103,17 @@ class ScrollView extends Nerv.Component {
       }
       this._scrollLeft = nextProps.scrollLeft
     }
+    // scrollIntoView
+    if (
+      props.scrollIntoView &&
+      typeof props.scrollIntoView === 'string' &&
+      document.querySelector(`#${props.scrollIntoView}`)
+    )
+      document.querySelector(`#${props.scrollIntoView}`).scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+        inline: 'start',
+      });
   }
 
   render() {

--- a/packages/taro-components/src/components/scroll-view/index.js
+++ b/packages/taro-components/src/components/scroll-view/index.js
@@ -107,6 +107,8 @@ class ScrollView extends Nerv.Component {
     if (
       props.scrollIntoView &&
       typeof props.scrollIntoView === 'string' &&
+      document &&
+      document.querySelector &&
       document.querySelector(`#${props.scrollIntoView}`)
     )
       document.querySelector(`#${props.scrollIntoView}`).scrollIntoView({

--- a/packages/taro-components/src/components/scroll-view/index.js
+++ b/packages/taro-components/src/components/scroll-view/index.js
@@ -105,13 +105,13 @@ class ScrollView extends Nerv.Component {
     }
     // scrollIntoView
     if (
-      props.scrollIntoView &&
-      typeof props.scrollIntoView === 'string' &&
+      nextProps.scrollIntoView &&
+      typeof nextProps.scrollIntoView === 'string' &&
       document &&
       document.querySelector &&
-      document.querySelector(`#${props.scrollIntoView}`)
+      document.querySelector(`#${nextProps.scrollIntoView}`)
     )
-      document.querySelector(`#${props.scrollIntoView}`).scrollIntoView({
+      document.querySelector(`#${nextProps.scrollIntoView}`).scrollIntoView({
         behavior: 'smooth',
         block: 'center',
         inline: 'start',


### PR DESCRIPTION
**这个 PR 做了什么?** 
虽然说在官网的文档上说h5支持scrollIntoView，但实际上翻看源码，scroll-view并没有处理’scrollIntoView‘这个字段，这里直接通过querySelector获取相关元素并绑定相关API，实际效果与微信小程序端相同。（当然，这个只在h5生效）
![image](https://user-images.githubusercontent.com/18693417/62374245-20a19080-b56e-11e9-8adf-bcc0f509ba68.png)

**这个 PR 是什么类型?** (至少选择一个)
- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**
- [x] 提交到 master 分支
- [x] 所有测试用例已经通过
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
兼容IE8及以上