### PR TITLE
fix(taro-components): 修复circular为true却不会循环播放的问题

### DIFF
--- a/packages/taro-components/src/components/swiper/index.js
+++ b/packages/taro-components/src/components/swiper/index.js
@@ -115,6 +115,8 @@ class Swiper extends Nerv.Component {
       }
       // 是否衔接滚动模式
       if (nextProps.circular) {
+        this.mySwiper.loopDestroy()
+        this.mySwiper.loopCreate()
         this.mySwiper.slideToLoop(parseInt(nextCurrent, 10)) // 更新下标
       } else {
         this.mySwiper.slideTo(parseInt(nextCurrent, 10)) // 更新下标


### PR DESCRIPTION
**这个 PR 做了什么?** 

当swiper数据中的swiperItem为动态加载时，且circular设置为true，当滑到最后一个元素时，此时是无法做到衔接滚动的，这个问题在[Swiper的issue](https://github.com/nolimits4web/swiper/issues/2629)中有提到过，这里添加两行代码使其手动重做循环的DOM块。

**这个 PR 是什么类型?** 

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
这里其实可以优化成:
```
if (
    上一个children和本次children不相同
    &&
    circular
){
    重做循环
}
```
可是不知道怎么比较children😂