### PR TITLE
feat(components):使组件接受 duration 属性

### DIFF
--- a/packages/taro-components/src/components/video/index.js
+++ b/packages/taro-components/src/components/video/index.js
@@ -444,7 +444,7 @@ class Video extends Component {
       danmuBtn
     } = this.props
     const { enableDanmu, isFirst, isMute, isFullScreen } = this.state
-    const duration = formatTime(this.state.duration)
+    const duration = formatTime(this.props.duration || this.state.duration || null)
 
     const videoProps = {
       id,
@@ -478,7 +478,7 @@ class Video extends Component {
         onTouchStart={this.onTouchStartContainer}
         onClick={this.onClickContainer}>
         <video {...videoProps}>暂时不支持播放该视频</video>
-        <Controls controls={controls} currentTime={this.currentTime} duration={this.state.duration} isPlaying={this.state.isPlaying} pauseFunc={this.pause} playFunc={this.play} seekFunc={this.seek} showPlayBtn={showPlayBtn} showProgress={showProgress} ref={this.getControlsRef}>
+        <Controls controls={controls} currentTime={this.currentTime} duration={this.props.duration || this.state.duration || null} isPlaying={this.state.isPlaying} pauseFunc={this.pause} playFunc={this.play} seekFunc={this.seek} showPlayBtn={showPlayBtn} showProgress={showProgress} ref={this.getControlsRef}>
           {showMuteBtn && (
             <div
               className={classnames('taro-video-mute', {


### PR DESCRIPTION
**这个 PR 做了什么?** 

文档上虽说支持duration属性，但实际上并没有处理相关字段，这里补充了相关代码


**这个 PR 是什么类型?** 

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
目前 Video 下的 Controls 已知若没有设置 duration ， 会导致无法拖动进度条。核心原因是因为上个版本在 onLoadedMetadata 方法中新加的判断 #3526，导致没有办法算进度。求大佬跟进😎