### PR TITLE
Fix4126 2242 微信小程序转换支持绝对路径和非常规路径

### DIFF
--- a/packages/taro-cli/src/convertor/helper.ts
+++ b/packages/taro-cli/src/convertor/helper.ts
@@ -14,16 +14,53 @@ import {
   REG_TYPESCRIPT
 } from '../util/constants'
 
+function getRelativePath (
+  rootPath: string,
+  sourceFilePath: string,
+  oriPath: string,
+) {
+  //处理以/开头的绝对路径，比如 /a/b
+  if (path.isAbsolute(oriPath)) {
+    if (oriPath.indexOf('/') !== 0) {
+      return ''
+    }
+    const vpath = path.resolve(rootPath, oriPath.substr(1))
+    if (!fs.existsSync(vpath)) {
+      return ''
+    }
+    let relativePath = path.relative(path.dirname(sourceFilePath), vpath)
+    relativePath = promoteRelativePath(relativePath)
+    if (relativePath.indexOf('.') !== 0) {
+      return './' + relativePath
+    }
+    return relativePath
+  }
+  //处理非正常路径，比如 a/b
+  if (oriPath.indexOf('.') !== 0) {
+    const vpath = path.resolve(sourceFilePath, '..', oriPath)
+    if (fs.existsSync(vpath)) {
+      return './' + oriPath
+    }
+  }
+  return oriPath
+}
+
 export function analyzeImportUrl (
+  rootPath: string,
   sourceFilePath: string,
   scriptFiles: Set<string>,
   source: t.StringLiteral,
   value: string
 ) {
   const valueExtname = path.extname(value)
-  if (path.isAbsolute(value)) {
-    printLog(processTypeEnum.ERROR, '引用文件', `文件 ${sourceFilePath} 中引用 ${value} 是绝对路径！`)
+  const rpath = getRelativePath(rootPath, sourceFilePath, value)
+  if (!rpath) {
+    printLog(processTypeEnum.ERROR, '引用文件', `文件 ${sourceFilePath} 中引用 ${value} 不存在！`)
     return
+  }
+  if (rpath !== value) {
+    value = rpath
+    source.value = rpath
   }
   if (value.indexOf('.') === 0) {
     if (REG_SCRIPT.test(valueExtname) || REG_TYPESCRIPT.test(valueExtname)) {

--- a/packages/taro-cli/src/convertor/index.ts
+++ b/packages/taro-cli/src/convertor/index.ts
@@ -72,7 +72,8 @@ interface ITaroizeOptions {
   json?: string,
   script?: string,
   wxml?: string,
-  path?: string
+  path?: string,
+  rootPath?: string
 }
 
 export default class Convertor {
@@ -218,7 +219,7 @@ export default class Convertor {
               const node = astPath.node
               const source = node.source
               const value = source.value
-              analyzeImportUrl(sourceFilePath, scriptFiles, source, value)
+              analyzeImportUrl(self.root, sourceFilePath, scriptFiles, source, value)
             },
             CallExpression (astPath) {
               const node = astPath.node
@@ -228,7 +229,7 @@ export default class Convertor {
                 if (callee.name === 'require') {
                   const args = node.arguments as Array<t.StringLiteral>
                   const value = args[0].value
-                  analyzeImportUrl(sourceFilePath, scriptFiles, args[0], value)
+                  analyzeImportUrl(self.root, sourceFilePath, scriptFiles, args[0], value)
                 } else if (WX_GLOBAL_FN.has(callee.name)) {
                   calleePath.replaceWith(
                     t.memberExpression(t.identifier('Taro'), callee as t.Identifier)
@@ -442,7 +443,8 @@ export default class Convertor {
       const taroizeResult = taroize({
         json: entryJSON,
         script: entryJS,
-        path: path.dirname(this.entryJSPath)
+        path: this.root,
+        rootPath: this.root
       })
       const { ast, scriptFiles } = this.parseAst({
         ast: taroizeResult.ast,
@@ -546,6 +548,7 @@ export default class Convertor {
           pageStyle = String(fs.readFileSync(pageStylePath))
         }
         param.path = path.dirname(pageJSPath)
+        param.rootPath = this.root
         const taroizeResult = taroize(param)
         const { ast, scriptFiles } = this.parseAst({
           ast: taroizeResult.ast,
@@ -624,6 +627,7 @@ export default class Convertor {
           componentStyle = String(fs.readFileSync(componentStylePath))
         }
         param.path = path.dirname(componentJSPath)
+        param.rootPath = this.root
         const taroizeResult = taroize(param)
         const { ast, scriptFiles } = this.parseAst({
           ast: taroizeResult.ast,

--- a/packages/taroize/src/index.ts
+++ b/packages/taroize/src/index.ts
@@ -10,10 +10,12 @@ interface Option {
   script?: string,
   wxml?: string,
   path: string
+  rootPath: string
 }
 
 export function parse (option: Option) {
   resetGlobals()
+  setting.rootPath = option.rootPath
   const { wxml, wxses, imports, refIds } = parseWXML(option.path, option.wxml)
   const json = parseJSON(option.json)
   setting.sourceCode = option.script!

--- a/packages/taroize/src/utils.ts
+++ b/packages/taroize/src/utils.ts
@@ -134,7 +134,8 @@ export function buildImportStatement (source: string, specifiers: string[] = [],
 }
 
 export const setting = {
-  sourceCode: ''
+  sourceCode: '',
+  rootPath: ''
 }
 
 export function codeFrameError (node, msg: string) {


### PR DESCRIPTION
这个 PR 做了什么? (简要描述所做更改)
taroize增加绝对路径的支持
在js中支持以下写法：
require('a.js')  require('a/b.js')  require('/a/b/c.js')
在wxml中支持以下写法：
import src="/a/b/c.wxml"
这个 PR 是什么类型? (至少选择一个)

错误修复(Bugfix)
新功能(Feature)
代码重构(Refactor)
TypeScript 类型定义修改(Typings)
文档修改(Docs)
代码风格更新(Code style update)
其他，请描述(Other, please describe):

这个 PR 满足以下需求:

提交到 master 分支
Commit 信息遵循 Angular Style Commit Message Conventions
所有测试用例已经通过
代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
在本地测试可用，不会影响到其它功能
这个 PR 涉及以下平台:

微信小程序
支付宝小程序
百度小程序
头条小程序
QQ 轻应用
快应用平台（QuickApp）
Web 平台（H5）
移动端（React-Native）
其它需要 Reviewer 或社区知晓的内容：