### PR TITLE
fix4204 支持快应用图标的拷贝

### DIFF
--- a/packages/taro-cli/src/mini/index.ts
+++ b/packages/taro-cli/src/mini/index.ts
@@ -11,6 +11,7 @@ import {
   getInstalledNpmPkgVersion,
   getPkgVersion,
   copyFiles,
+  copyFileSync,
   unzip,
   shouldUseYarn,
   shouldUseCnpm
@@ -103,7 +104,7 @@ function readQuickAppManifest () {
 }
 
 function generateQuickAppManifest (quickappJSON: any) {
-  const { appConfig, pageConfigs, outputDir, projectConfig } = getBuildData()
+  const { appPath, appConfig, pageConfigs, outputDir, projectConfig } = getBuildData()
   // 生成 router
   const pages = (appConfig.pages as string[]).concat()
   const routerPages = {}
@@ -148,6 +149,23 @@ function generateQuickAppManifest (quickappJSON: any) {
   if (appConfig.window && appConfig.window.navigationStyle === 'custom') {
     quickappJSON.display.titleBar = false
     delete quickappJSON.display.navigationStyle
+  }
+  //拷贝快应用图标
+  let iconPath = quickappJSON.icon
+  if (iconPath) {
+    if (iconPath.indexOf('/') === 0) {
+      iconPath = '.' + iconPath
+    }
+    const absIconPath = path.resolve(appPath, 'src', iconPath)
+    if (!fs.existsSync(absIconPath)) {
+      console.log(chalk.red('快应用图标不存在!'))
+    } else {
+      //创建目录
+      const to = path.join(outputDir, path.dirname(iconPath))
+      fs.ensureDirSync(to)
+      //拷贝图标
+      copyFileSync(absIconPath, to)
+    }
   }
   fs.writeFileSync(path.join(outputDir, 'manifest.json'), JSON.stringify(quickappJSON, null, 2))
 }


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

fix4204 支持快应用图标的拷贝

**这个 PR 是什么类型?** (至少选择一个)

- [X ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [X ] 提交到 master 分支
- [ X] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [X ] 所有测试用例已经通过
- [X ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [X ] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [X ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
