### PR TITLE
fixmax_char 统一格式化为一行，否则会有unterminate line end的错误

### DIFF
--- a/packages/taroize/src/wxml.ts
+++ b/packages/taroize/src/wxml.ts
@@ -301,6 +301,7 @@ export function parseWXML (dirPath: string, wxml?: string, parseImport?: boolean
 } {
   try {
     wxml = prettyPrint(wxml, {
+      max_char: 0,
       indent_char: 0,
       unformatted: ['text', 'wxs']
     })


### PR DESCRIPTION
这个 PR 做了什么? (简要描述所做更改)
统一格式化为一行，否则在解析wxml时会有unterminate line end的错误

这个 PR 是什么类型? (至少选择一个)

错误修复(Bugfix) issue id 
新功能(Feature)
代码重构(Refactor)
TypeScript 类型定义修改(Typings)
文档修改(Docs)
代码风格更新(Code style update)
其他，请描述(Other, please describe):
这个 PR 满足以下需求:

提交到 master 分支
Commit 信息遵循 Angular Style Commit Message Conventions
所有测试用例已经通过
代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
在本地测试可用，不会影响到其它功能
这个 PR 涉及以下平台:

微信小程序
支付宝小程序
百度小程序
头条小程序
QQ 轻应用
快应用平台（QuickApp）
Web 平台（H5）
移动端（React-Native）
其它需要 Reviewer 或社区知晓的内容：