### PR TITLE
feat: 使iOS支持Taro.setClipboardData

### DIFF
--- a/packages/taro-h5/src/api/clipboard/index.js
+++ b/packages/taro-h5/src/api/clipboard/index.js
@@ -9,6 +9,19 @@ import { setStorage, getStorage } from '../storage/index'
 
 const CLIPBOARD_STORAGE_NAME = 'taro_clipboard'
 
+// 判断是不是ios端
+const isOS = () => {
+  return navigator.userAgent.match(/ipad|iphone/i)
+};
+// 创建文本元素
+const createTextArea = text => {
+  const textArea = document.createElement('textArea')
+  textArea.innerHTML = text
+  textArea.value = text
+  document.body.appendChild(textArea)
+  return textArea
+};
+
 document.addEventListener('copy', () => {
   setStorage({
     key: CLIPBOARD_STORAGE_NAME,
@@ -59,6 +72,25 @@ export const setClipboardData = ({ data, success, fail, complete }) => {
           input.setSelectionRange(0, input.value.length)
           document.execCommand('copy')
           document.body.removeChild(input)
+          }
+      } else if (isOS()) {
+        const textArea = createTextArea(data);
+        const range = document.createRange();
+        range.selectNodeContents(textArea);
+        const selection = window.getSelection();
+        if (selection) {
+          selection.removeAllRanges();
+          selection.addRange(range);
+        }
+        textArea.setSelectionRange(0, 999999);
+        try {
+          if (!document.execCommand('Copy')) {
+            throw new Error('复制失败');
+          }
+        } catch (err) {
+          throw new Error(err);
+        } finally {
+          document.body.removeChild(textArea);
         }
       }
       const res = {


### PR DESCRIPTION
**这个 PR 做了什么?** 

原有的setClipboardData不支持iOS，本次提交使iOS支持Taro.setClipboardData。

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
