### PR TITLE
修复RN环境下，子页面的navigationOptions无法覆盖默认headerTitle的问题

### DIFF
--- a/packages/taro-router-rn/src/getWrappedScreen.js
+++ b/packages/taro-router-rn/src/getWrappedScreen.js
@@ -42,9 +42,9 @@ function getWrappedScreen (Screen, Taro, globalNavigationOptions = {}) {
 
       // 如果页面组件也定义了navigationOptions，那么就合并页面那边的返回值
       if (Screen.navigationOptions !== undefined) {
-        const target = Screen.navigationOptions({navigation})
-        Object.assign(target, options)
-        return target
+        const customOptions = Screen.navigationOptions({ navigation });
+        Object.assign(options, customOptions);
+        return options;
       }
       return options
     }


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

修复了在页面中无法自定义导航的headerTitle问题。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
