### PR TITLE
在RN中的tabbar中，app.js中配置的第一个page应是默认打开的tab

### DIFF
--- a/packages/taro-router-rn/src/initRouter.js
+++ b/packages/taro-router-rn/src/initRouter.js
@@ -67,6 +67,7 @@ function getTabBarRootStack ({pageList, Taro, tabBar, navigationOptions}) {
   const RouteConfigs = getTabRouteConfig({pageList, Taro, tabBar, navigationOptions})
   // TODO tabBar.position
   return createBottomTabNavigator(RouteConfigs, {
+    initialRouteName: pageList[0][0], // app.json里pages的顺序，第一项是默认打开页
     navigationOptions: ({navigation}) => ({ // 这里得到的是 tab 的 navigation
       tabBarIcon: ({focused, tintColor}) => {
         const {routeName} = navigation.state


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

参考微信小程序中的规则，如果配置了tabBar，那么在app.json的pages中配置的第一个页面应该是默认打开的tab。参考链接：

https://developers.weixin.qq.com/community/develop/doc/fe350f3043e47e58fb7abac7c668ef8b

https://reactnavigation.org/docs/en/bottom-tab-navigator.html#bottomtabnavigatorconfig

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
