### PR TITLE
fix(mobx): 生命周期 getDerivedStateFromProps 不被触发问题修复

### DIFF
--- a/packages/taro-mobx-common/src/index.js
+++ b/packages/taro-mobx-common/src/index.js
@@ -4,10 +4,10 @@ export const onError = fn => errorsReporter.on(fn)
 
 export { PropTypes } from "./propTypes"
 
-export { observer } from './observer'
 export { useLocalStore } from './useLocalStore'
 export { useAsObservableSource } from './useAsObservableSource'
 export { isUsingStaticRendering, useStaticRendering } from './staticRendering'
 
 export { getStore, setStore } from './store'
+export { errorsReporter } from './reporter'
 export { inject, getInjectName, mapStoreToProps } from './inject'

--- a/packages/taro-mobx-common/src/utils.js
+++ b/packages/taro-mobx-common/src/utils.js
@@ -1,13 +1,7 @@
-import Taro from '@tarojs/taro'
-
 export function isPlainObject (value) {
   if (!value || typeof value !== 'object') {
     return false
   }
   const proto = Object.getPrototypeOf(value)
   return !proto || proto === Object.prototype
-}
-
-export function isMiniPlatform () {
-  return !(/^WEB|RN$/i.test(Taro.getEnv()))
 }

--- a/packages/taro-mobx-h5/src/index.js
+++ b/packages/taro-mobx-h5/src/index.js
@@ -3,7 +3,6 @@ import { useState } from '@tarojs/taro-h5'
 import {
   PropTypes,
   onError,
-  observer,
   isUsingStaticRendering,
   useStaticRendering,
   useLocalStore as originUseLocalStore,
@@ -12,6 +11,7 @@ import {
 
 import Provider from './Provider'
 import { inject } from './inject'
+import { observer } from './observer'
 
 function useLocalStore (initializer, current) {
   return originUseLocalStore(initializer, current, useState)

--- a/packages/taro-mobx-h5/src/observer.js
+++ b/packages/taro-mobx-h5/src/observer.js
@@ -1,0 +1,50 @@
+import { Reaction } from 'mobx'
+import { errorsReporter, isUsingStaticRendering } from '@tarojs/mobx-common'
+
+export function observer (component) {
+  if (isUsingStaticRendering()) {
+    return component
+  }
+
+  if (component.isMobxInjector === true) {
+    console.warn(
+      "Mobx observer: You are trying to use 'observer' on a component that already has 'inject'. Please apply 'observer' before applying 'inject'"
+    )
+  }
+
+  const target = component.prototype
+
+  const originComponentWillUnmount = target.componentWillUnmount
+  target.componentWillUnmount = function () {
+    this._reaction.dispose()
+    originComponentWillUnmount && originComponentWillUnmount.call(this)
+  }
+
+  const originRender = target.render
+  target.render = function (...args) {
+    if (!this._reaction) {
+      const initialName = this.displayName || this.name
+      this._reaction = new Reaction(`${initialName}_${Date.now()}`, () => {
+        this.componentWillReact && this.componentWillReact()
+        this.forceUpdate()
+      })
+    }
+
+    let result
+    let exception
+    this._reaction.track(() => {
+      try {
+        result = originRender.call(this, null, null, args[2])
+      } catch (e) {
+        exception = e
+      }
+    })
+    if (exception) {
+      errorsReporter.emit(exception)
+      throw exception
+    }
+    return result
+  }
+
+  return component
+}

--- a/packages/taro-mobx-rn/src/index.js
+++ b/packages/taro-mobx-rn/src/index.js
@@ -3,7 +3,6 @@ import { useState } from '@tarojs/taro-rn'
 import {
   PropTypes,
   onError,
-  observer,
   isUsingStaticRendering,
   useStaticRendering,
   useLocalStore as originUseLocalStore,
@@ -12,6 +11,7 @@ import {
 
 import Provider from './Provider'
 import { inject } from './inject'
+import { observer } from './observer'
 
 function useLocalStore (initializer, current) {
   return originUseLocalStore(initializer, current, useState)

--- a/packages/taro-mobx-rn/src/observer.js
+++ b/packages/taro-mobx-rn/src/observer.js
@@ -1,0 +1,50 @@
+import { Reaction } from 'mobx'
+import { errorsReporter, isUsingStaticRendering } from '@tarojs/mobx-common'
+
+export function observer (component) {
+  if (isUsingStaticRendering()) {
+    return component
+  }
+
+  if (component.isMobxInjector === true) {
+    console.warn(
+      "Mobx observer: You are trying to use 'observer' on a component that already has 'inject'. Please apply 'observer' before applying 'inject'"
+    )
+  }
+
+  const target = component.prototype
+
+  const originComponentWillUnmount = target.componentWillUnmount
+  target.componentWillUnmount = function () {
+    this._reaction.dispose()
+    originComponentWillUnmount && originComponentWillUnmount.call(this)
+  }
+
+  const originRender = target.render
+  target.render = function (...args) {
+    if (!this._reaction) {
+      const initialName = this.displayName || this.name
+      this._reaction = new Reaction(`${initialName}_${Date.now()}`, () => {
+        this.componentWillReact && this.componentWillReact()
+        this.forceUpdate()
+      })
+    }
+
+    let result
+    let exception
+    this._reaction.track(() => {
+      try {
+        result = originRender.call(this, null, null, args[2])
+      } catch (e) {
+        exception = e
+      }
+    })
+    if (exception) {
+      errorsReporter.emit(exception)
+      throw exception
+    }
+    return result
+  }
+
+  return component
+}

--- a/packages/taro-mobx/src/index.js
+++ b/packages/taro-mobx/src/index.js
@@ -5,7 +5,6 @@ import {
   onError,
   getStore,
   setStore,
-  observer,
   isUsingStaticRendering,
   useStaticRendering,
   useLocalStore as originUseLocalStore,
@@ -13,6 +12,7 @@ import {
 } from '@tarojs/mobx-common'
 
 import { inject } from './inject'
+import { observer } from './observer'
 
 class Provider {}
 

--- a/packages/taro-mobx/src/inject.js
+++ b/packages/taro-mobx/src/inject.js
@@ -8,18 +8,10 @@ function createStoreInjector (grabStoresFn, injectNames, Component) {
       super(Object.assign(...arguments, mapStoreToProps(grabStoresFn, props)), isPage)
     }
 
-    componentWillMount () {
+    _constructor () {
       Object.assign(this.props, mapStoreToProps(grabStoresFn, this.props))
-      if (typeof super.componentWillMount === 'function') {
-        super.componentWillMount()
-      }
+      super._constructor && super._constructor(this.props)
     }
-  }
-  const target = Injector.prototype
-  const originCreateData = target._createData
-  target._createData = function (...args) {
-    Object.assign(this.props, mapStoreToProps(grabStoresFn, this.props))
-    return originCreateData.call(this, null, null, args[2])
   }
   return Injector
 }

--- a/packages/taro-mobx/types/index.d.ts
+++ b/packages/taro-mobx/types/index.d.ts
@@ -14,10 +14,9 @@ export function useLocalStore<TStore extends Record<string, any>, TSource extend
 export function useAsObservableSource<TSource>(current: TSource): TSource;
 export type ITaroComponent<P = any> =
    | Taro.ComponentClass<P>
-   | Taro.FunctionComponent<P>
+   | Taro.FunctionComponent<P>;
 
-export function observer<P extends ITaroComponent>(component: P): P
-// export function observer(component);
+export function observer<P extends ITaroComponent>(component: P): P;
 export function inject(...stores: string[]);
 export function inject(fn: (stores: IValueMap, nextProps: IValueMap) => IValueMap);
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复使用 Mobx 的情况下，生命周期 getDerivedStateFromProps 不被触发的问题

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #4176
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [ ] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [x] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [x] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
