### PR TITLE
fix(taro): 支付宝、百度、快应用、字节跳动中调用 forceUpdate 时，不应执行 shouldComponentUpdate

### DIFF
--- a/packages/taro-alipay/src/component.js
+++ b/packages/taro-alipay/src/component.js
@@ -25,6 +25,7 @@ class BaseComponent {
   nextProps = {}
   _dirty = true
   _disable = true
+  _isForceUpdate = false
   _pendingStates = []
   _pendingCallbacks = []
   $componentType = ''
@@ -93,6 +94,7 @@ class BaseComponent {
     if (typeof callback === 'function') {
       (this._pendingCallbacks = this._pendingCallbacks || []).push(callback)
     }
+    this._isForceUpdate = true
     updateComponent(this)
   }
 

--- a/packages/taro-quickapp/src/component.js
+++ b/packages/taro-quickapp/src/component.js
@@ -84,6 +84,7 @@ export default class BaseComponent {
     if (typeof callback === 'function') {
       (this._pendingCallbacks = this._pendingCallbacks || []).push(callback)
     }
+    this._isForceUpdate = true
     updateComponent(this)
   }
 

--- a/packages/taro-quickapp/src/lifecycle.js
+++ b/packages/taro-quickapp/src/lifecycle.js
@@ -103,6 +103,7 @@ export function updateComponent (component) {
   let skip = false
   if (component.__mounted) {
     if (isFunction(component.shouldComponentUpdate) &&
+      !component._isForceUpdate &&
       component.shouldComponentUpdate(props, state) === false) {
       skip = true
     } else if (!hasNewLifecycle(component) && isFunction(component.componentWillUpdate)) {
@@ -112,6 +113,7 @@ export function updateComponent (component) {
   component.props = props
   component.state = state
   component._dirty = false
+  component._isForceUpdate = false
   if (!skip) {
     doUpdate(component, prevProps, prevState)
   }

--- a/packages/taro-swan/src/component.js
+++ b/packages/taro-swan/src/component.js
@@ -25,6 +25,7 @@ class BaseComponent {
   nextProps = {}
   _dirty = true
   _disable = true
+  _isForceUpdate = false
   _pendingStates = []
   _pendingCallbacks = []
   $componentType = ''
@@ -87,6 +88,7 @@ class BaseComponent {
     if (typeof callback === 'function') {
       (this._pendingCallbacks = this._pendingCallbacks || []).push(callback)
     }
+    this._isForceUpdate = true
     updateComponent(this)
   }
 

--- a/packages/taro-tt/src/component.js
+++ b/packages/taro-tt/src/component.js
@@ -25,6 +25,7 @@ class BaseComponent {
   nextProps = {}
   _dirty = true
   _disable = true
+  _isForceUpdate = false
   _pendingStates = []
   _pendingCallbacks = []
   $componentType = ''
@@ -88,6 +89,7 @@ class BaseComponent {
     if (typeof callback === 'function') {
       (this._pendingCallbacks = this._pendingCallbacks || []).push(callback)
     }
+    this._isForceUpdate = true
     updateComponent(this)
   }
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

支付宝、百度、快应用、字节跳动中调用 forceUpdate 时，不应执行 shouldComponentUpdate

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [ ] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [ ] QQ 轻应用
- [x] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
