### PR TITLE
fix(video) this.progressBallRef is undefined

### DIFF
--- a/packages/taro-components/src/components/video/controls.js
+++ b/packages/taro-components/src/components/video/controls.js
@@ -53,7 +53,7 @@ class Controls extends Component {
     this.currentTimeRef.innerHTML = formatTime(time)
   }
   setProgressBall (percentage) {
-    this.progressBallRef.style.left = `${percentage * 100}%`
+    if(this.progressBallRef) this.progressBallRef.style.left = `${percentage * 100}%`
   }
 
   toggleVisibility (nextVisible) {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复视频控件没有获取到getProgressBallRef 实例，而导致使用```this.progressBallRef.style.left = ${percentage * 100}%``` 报错
![image](https://user-images.githubusercontent.com/16217324/64314143-7ab7ca80-cfe0-11e9-9a3f-8515e507acc5.png)
![image](https://user-images.githubusercontent.com/16217324/64314149-7db2bb00-cfe0-11e9-887c-d5c724faa9e1.png)


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x ] 所有测试用例已经通过
- [x ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
