### PR TITLE
在解析jsx时遇到return null会返回一个view对象，而快应用只支持div

### DIFF
--- a/packages/taro-transformer-wx/src/create-html-element.ts
+++ b/packages/taro-transformer-wx/src/create-html-element.ts
@@ -89,6 +89,9 @@ export const createHTMLElement = (options: Options, isFirstEmit = false) => {
         }
       }
     }
+    if (name === 'view') {
+      options.name = 'div'
+    }
   }
 
   const isVoidTag = voidHtmlTags.has(options.name)


### PR DESCRIPTION
这个 PR 做了什么? (简要描述所做更改)
#4377 
在解析jsx时遇到return null会返回一个view对象，而快应用只支持div
这个 PR 是什么类型? (至少选择一个)

错误修复(Bugfix) issue id #4377
新功能(Feature)
代码重构(Refactor)
TypeScript 类型定义修改(Typings)
文档修改(Docs)
代码风格更新(Code style update)
其他，请描述(Other, please describe):
这个 PR 满足以下需求:

提交到 master 分支
Commit 信息遵循 Angular Style Commit Message Conventions
所有测试用例已经通过
代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
在本地测试可用，不会影响到其它功能
这个 PR 涉及以下平台:

微信小程序
支付宝小程序
百度小程序
头条小程序
QQ 轻应用
快应用平台（QuickApp）
Web 平台（H5）
移动端（React-Native）
其它需要 Reviewer 或社区知晓的内容：