### PR TITLE
fix: 添加QQ小程序分享功能缺失的参数属性showShareItems

### DIFF
--- a/packages/taro/types/index.d.ts
+++ b/packages/taro/types/index.d.ts
@@ -9285,7 +9285,12 @@ declare namespace Taro {
       /**
        * 是否使用带 shareTicket 的转发[详情](https://developers.weixin.qq.com/miniprogram/dev/framework/open-ability/share.html)
        */
-      withShareTicket?: boolean
+      withShareTicket?: boolean,
+      /**
+      * QQ小程序分享功能，支持分享到QQ、QQ空间、微信好友、微信朋友圈
+      * 支持的值： ['qq', 'qzone', 'wechatFriends', 'wechatMoment']
+      */
+      showShareItems?: string[]
     }
   }
   /**


### PR DESCRIPTION

**这个 PR 做了什么?** (简要描述所做更改)
QQ小程序的分享功能支持传递showShareItems设置支持的分享类型，这个PR给showShareMessage的参数补全了这一属性


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [x] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
