### PR TITLE
增加快应用子组件定制规则，减少快应用端的预览错误

### DIFF
--- a/packages/taro-cli/package.json
+++ b/packages/taro-cli/package.json
@@ -107,6 +107,7 @@
     "prop-types": "^15.6.2",
     "request": "^2.88.0",
     "resolve": "^1.6.0",
+    "sax": "^1.2.4",
     "semver": "^5.5.0",
     "shelljs": "^0.8.1",
     "stylelint": "9.3.0",

--- a/packages/taro-cli/src/mini/page.ts
+++ b/packages/taro-cli/src/mini/page.ts
@@ -42,6 +42,7 @@ import { compileDepStyles } from './compileStyle'
 import { transfromNativeComponents, processNativeWxml } from './native'
 import { buildDepComponents } from './component'
 import { parseAst } from './astProcess'
+import rewriterTemplate from '../quickapp/template-rewriter'
 
 // 小程序页面编译
 export async function buildSinglePage (page: string) {
@@ -193,7 +194,7 @@ export async function buildSinglePage (page: string) {
         script: resCode,
         style: styleRelativePath,
         imports: new Set([...importTaroSelfComponents, ...importCustomComponents, ...importUsingComponent]),
-        template: pageWXMLContent
+        template: rewriterTemplate(pageWXMLContent)
       })
       fs.writeFileSync(outputPageWXMLPath, uxTxt)
       printLog(processTypeEnum.GENERATE, '页面文件', `${outputDirName}/${page}${outputFilesTypes.TEMPL}`)

--- a/packages/taro-cli/src/quickapp/template-rewriter.ts
+++ b/packages/taro-cli/src/quickapp/template-rewriter.ts
@@ -1,0 +1,13 @@
+import parseXml from './template/parser'
+import rewriteNode from './template/node'
+import serialize from './template/serialize'
+
+export default function rewriterTemplate(code : string): string {
+    // 解析Code
+    const viewNodes = parseXml(`<root>${code}</root>`).children
+    // 解析视图组件
+    const retNodes = rewriteNode(viewNodes)
+    // 生成xml代码
+    const templateCode = serialize(retNodes)
+    return templateCode
+}

--- a/packages/taro-cli/src/quickapp/template/constant.ts
+++ b/packages/taro-cli/src/quickapp/template/constant.ts
@@ -1,0 +1,14 @@
+
+interface Location {
+    line: number;
+    column: number;
+}
+
+export interface NodeType {
+    attributes: object;
+    children: object[];
+    isSelfClosing: boolean;
+    location: Location;
+    name: string;
+    parent?: object;
+}

--- a/packages/taro-cli/src/quickapp/template/node.ts
+++ b/packages/taro-cli/src/quickapp/template/node.ts
@@ -1,0 +1,45 @@
+import parserTag from './tag'
+import {uniqTypeof} from './utils'
+import { NodeType } from './constant'
+
+const walk = (node) => {
+    // 获取quickapp需处理的组件名称
+    const tags = parserTag('.', {})
+    const component = tags[node.name]
+    if (component) {
+        // 组件不支持子组件，则将子组件注释
+        if (component.subcomponent && (node.children && node.children.length)) {
+            node.$delete = true
+            node.url = component.url || 'https://doc.quickapp.cn/widgets/common-events.html'
+            return
+        }
+
+        if (uniqTypeof(component.name) === 'function') {
+            node.name = component.name(node)
+            const children = node.children
+            children && children.forEach(childNode => {
+                if (childNode.parent && childNode.parent.name) {
+                    childNode.parent.name = node.name
+                }
+            })
+        } else {
+            node.name = component.name
+        }
+    }
+    const children = node.children
+    if (children.length) {
+        children.forEach(childNode => {
+            walk(childNode)
+        })
+    }
+}
+
+export default function rewriteNode (nodes) {
+    const retNodes: NodeType[] = []
+    nodes.forEach(node => {
+        retNodes.push(node)
+    })
+    retNodes.forEach(node => walk(node))
+    return retNodes
+
+}

--- a/packages/taro-cli/src/quickapp/template/parser.ts
+++ b/packages/taro-cli/src/quickapp/template/parser.ts
@@ -1,0 +1,52 @@
+const sax = require('sax')
+import { NodeType } from './constant'
+
+export default function parseCode (code: string): NodeType {
+    const parser = sax.parser(false, {
+        trim: true,
+        lowercase: true,
+        position: true
+    })
+
+    let root
+    let currentParent
+    const stack: any[] = []
+
+    parser.onerror = function(e) {
+        console.log(e)
+    }
+
+    parser.oncdata = function(t) {
+        currentParent && (currentParent.content = t.trim() || '')
+    }
+
+    parser.ontext = function(t) {
+        currentParent && (currentParent.content = t.trim() || '')
+    }
+
+    parser.onopentag = function (node) {
+        node.children = []
+        node.location = {
+            line: this.line,
+            column: this.column
+        }
+        if (!root) {
+            root = node
+        }
+        if (currentParent) {
+            node.parent = currentParent
+            currentParent.children.push(node)
+        }
+        currentParent = node
+        stack.push(currentParent)
+    }
+
+    parser.onclosetag = function() {
+        stack.length -= 1
+        currentParent = stack[stack.length - 1]
+    }
+
+    parser.write(code).close()
+    
+    return root
+}

--- a/packages/taro-cli/src/quickapp/template/serialize.ts
+++ b/packages/taro-cli/src/quickapp/template/serialize.ts
@@ -1,0 +1,50 @@
+import { addComment } from "./utils";
+
+const ATTRS_NAME = ['checked', 'disabled']
+
+const createAttrsCode = (attrs) => {
+    if (!attrs) {
+        return ''
+    }
+    let attrsCode = ''
+    const attrsKey = Object.keys(attrs)
+    if (attrsKey.length) {
+        attrsCode = ' ' + attrsKey.map(name => {
+            if (!attrs[name] && ~ATTRS_NAME.indexOf(name)) {
+                return `${name}='true'`
+            }
+            return name === 'else' ? `${name}` : `${name}='${attrs[name]}'`
+        }).join(' ')
+    }
+    return attrsCode
+}
+
+const createNodeCode = (name, children, content, attrsCode, $delete, url) => {
+    let childrenNodes = children.map(childNode => {
+        return walk(childNode)
+    }).join('')
+    // 针对不支持子组件的组件，子组件需注释
+    childrenNodes = $delete ? addComment(childrenNodes, url) : childrenNodes
+    return `<${name}${attrsCode}>${content || ''}${childrenNodes}</${name}>`
+}
+
+const walk = (node) => {
+    const attrsCode = createAttrsCode(node.attributes)
+    const nodeCode = createNodeCode(
+        node.name, 
+        node.children, 
+        node.content, 
+        attrsCode, 
+        node.$delete, 
+        node.url
+    )
+    return nodeCode
+}
+
+export default function serialize(nodes) {
+    if (!Array.isArray(nodes)) {
+        nodes = [nodes]
+    }
+    const code = nodes.map(node => walk(node)).join('\r\n')
+    return code
+}

--- a/packages/taro-cli/src/quickapp/template/tag/index.ts
+++ b/packages/taro-cli/src/quickapp/template/tag/index.ts
@@ -1,0 +1,23 @@
+import * as fs from 'fs-extra'
+import * as path from 'path'
+
+export default function parseTag (dir: string, tags={}) {
+    dir = dir || '.'
+    const dirPath = path.join(__dirname, dir)
+    const walk = (file) => {
+        const filePath = path.join(dirPath, file)
+        if (fs.statSync(filePath).isFile()) {
+            if (path.extname(filePath) === '.js') {
+                const tagName = path.basename(path.dirname(filePath))
+                if (tagName !== 'tag') {
+                    const component = require(filePath)['default']
+                    tags[tagName] = component
+                }
+            }
+        } else {
+            parseTag(path.join(dir, file), tags)
+        }
+    }
+    fs.readdirSync(dirPath).forEach(walk)
+    return tags
+}

--- a/packages/taro-cli/src/quickapp/template/tag/span/index.ts
+++ b/packages/taro-cli/src/quickapp/template/tag/span/index.ts
@@ -1,0 +1,8 @@
+export default {
+    name (node) {
+        if (node.parent && node.parent.name === 'div') {
+            return 'text'
+        }
+        return node.name
+    }
+}

--- a/packages/taro-cli/src/quickapp/template/tag/taro-camera/index.ts
+++ b/packages/taro-cli/src/quickapp/template/tag/taro-camera/index.ts
@@ -1,0 +1,5 @@
+export default {
+    name: 'taro-camera',
+    subcomponent: 'I:',
+    url: 'https://doc.quickapp.cn/widgets/camera.html'
+}

--- a/packages/taro-cli/src/quickapp/template/tag/taro-canvas/index.ts
+++ b/packages/taro-cli/src/quickapp/template/tag/taro-canvas/index.ts
@@ -1,0 +1,5 @@
+export default {
+    name: 'taro-canvas',
+    subcomponent: 'I:',
+    url: 'https://doc.quickapp.cn/widgets/canvas.html'
+}

--- a/packages/taro-cli/src/quickapp/template/tag/taro-image/index.ts
+++ b/packages/taro-cli/src/quickapp/template/tag/taro-image/index.ts
@@ -1,0 +1,5 @@
+export default {
+    name: 'taro-image',
+    subcomponent: 'I:',
+    url: 'https://doc.quickapp.cn/widgets/image.html'
+}

--- a/packages/taro-cli/src/quickapp/template/tag/taro-input/index.ts
+++ b/packages/taro-cli/src/quickapp/template/tag/taro-input/index.ts
@@ -1,0 +1,5 @@
+export default {
+    name: 'taro-input',
+    subcomponent: 'I:',
+    url: 'https://doc.quickapp.cn/widgets/input.html'
+}

--- a/packages/taro-cli/src/quickapp/template/tag/taro-label/index.ts
+++ b/packages/taro-cli/src/quickapp/template/tag/taro-label/index.ts
@@ -1,0 +1,5 @@
+export default {
+    name: 'taro-label',
+    subcomponent: 'I:',
+    url: 'https://doc.quickapp.cn/widgets/label.html'
+}

--- a/packages/taro-cli/src/quickapp/template/tag/taro-map/index.ts
+++ b/packages/taro-cli/src/quickapp/template/tag/taro-map/index.ts
@@ -1,0 +1,5 @@
+export default {
+    name: 'taro-map',
+    subcomponent: 'I:',
+    url: 'https://doc.quickapp.cn/widgets/map.html'
+}

--- a/packages/taro-cli/src/quickapp/template/tag/taro-picker/index.ts
+++ b/packages/taro-cli/src/quickapp/template/tag/taro-picker/index.ts
@@ -1,0 +1,5 @@
+export default {
+    name: 'taro-picker',
+    subcomponent: 'I:',
+    url: 'https://doc.quickapp.cn/widgets/picker.html'
+}

--- a/packages/taro-cli/src/quickapp/template/tag/taro-textarea/index.ts
+++ b/packages/taro-cli/src/quickapp/template/tag/taro-textarea/index.ts
@@ -1,0 +1,5 @@
+export default {
+    name: 'taro-textarea',
+    subcomponent: 'I:',
+    url: 'https://doc.quickapp.cn/widgets/textarea.html'
+}

--- a/packages/taro-cli/src/quickapp/template/tag/taro-video/index.ts
+++ b/packages/taro-cli/src/quickapp/template/tag/taro-video/index.ts
@@ -1,0 +1,5 @@
+export default {
+    name: 'taro-video',
+    subcomponent: 'I:',
+    url: 'https://doc.quickapp.cn/widgets/video.html'
+}

--- a/packages/taro-cli/src/quickapp/template/tag/text/index.ts
+++ b/packages/taro-cli/src/quickapp/template/tag/text/index.ts
@@ -1,0 +1,8 @@
+export default {
+    name (node) {
+        if (node.parent && ['text', 'span'].includes(node.parent.name)) {
+            return 'span'
+        }
+        return node.name
+    }
+}

--- a/packages/taro-cli/src/quickapp/template/utils.ts
+++ b/packages/taro-cli/src/quickapp/template/utils.ts
@@ -1,0 +1,22 @@
+
+const comment = (msg, url) => 'Taro comment: ' + msg + '.' + (url ? '[兼容写法参考](' + url + ')' : '')
+
+// 注释子组件
+export const addComment = (childNode, url) => `<!--${comment('unsupported subcomponent', url)}${childNode}-->`
+
+export const uniqTypeof = (name: string) => {
+    const typeMap = {
+        '[object Boolean]': 'boolean',
+        '[object String]': 'string',
+        '[object Number]': 'number',
+        '[object Function]': 'function',
+        '[object Array]': 'array',
+        '[object Date]': 'date',
+        '[object RegExp]': 'regExp',
+        '[object Null]': 'null',
+        '[object Undefined]': 'undefined',
+        '[object Symbol]': 'symbol',
+        '[object Object]': 'object',
+    }
+    return typeMap[Object.prototype.toString.call(name)]
+} 


### PR DESCRIPTION
这个 PR 做了什么? (简要描述所做更改)
 快应用支持30+组件，不同组件对子组件支持存在差异，针对这些差异点进行了父子组件转换规则定制，可减少快应用预览错误点
 组件转换包含以下两类：
 1、不支持子组件：label、camera、video等组件不支持子组件，若代码中包含子组件，则直接注释
 2、只支持特定子组件：text组件只支持a和span子组件，若代码中包含其它子组件，则转换成span
 技术选型：
 使用sax解析xml代码，依据快应用规范遍历替换或注释子组件，最后转换为字符串
 
 Eg: Taro组件写法
	<Label className="label">
		<Checkbox hidden="true" value={item.name} />
	</Label>
	<Text class="gs-text">
		<Text>
			公司简介
			<Text>
			  技术服务
			  <Text>快点计划</Text>
			</Text>
		</Text>
		<Text>售后服务</Text>
	</Text>
	
 转换为快应用组件后：
	<taro-label class="label">
        <!--Taro comment: unsupported subcomponent.[兼容写法参考](https://doc.quickapp.cn/widgets/label.html)<checkbox hidden='true' value='{{item.name}}'></checkbox>-->
    </taro-label>
	<text class="gs-text">
		<span>
		  公司简介
		  <span>
			技术服务
			<span>快计划</span>
		  </span>
		</span>
		<span>售后服务</span>
	</text>

 技术参考：
 1、https://github.com/isaacs/sax-js
 2、https://github.com/dcloudio/uni-migration
 
这个 PR 是什么类型? (至少选择一个)

错误修复(Bugfix) issue id
X新功能(Feature)
代码重构(Refactor)
TypeScript 类型定义修改(Typings)
文档修改(Docs)
代码风格更新(Code style update)
其他，请描述(Other, please describe):
这个 PR 满足以下需求:

提交到 master 分支
Commit 信息遵循 Angular Style Commit Message Conventions
所有测试用例已经通过
代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
在本地测试可用，不会影响到其它功能
这个 PR 涉及以下平台:

微信小程序
支付宝小程序
百度小程序
头条小程序
QQ 轻应用
X快应用平台（QuickApp）
Web 平台（H5）
移动端（React-Native）
其它需要 Reviewer 或社区知晓的内容：