### PR TITLE
fix: 解决babel插件path.hub 中无法获取文件名

### DIFF
--- a/packages/taro-transformer-wx/__tests__/babel.spec.ts
+++ b/packages/taro-transformer-wx/__tests__/babel.spec.ts
@@ -1,0 +1,44 @@
+import transform from '../src';
+import { buildComponent, baseCode, baseOptions } from './utils';
+const options = require('../src/options');
+
+// babel-traverse 无法生成 Hub
+// 导致 Path#getSource|buildCodeFrameError 都无法直接使用
+// 模拟 babel 插件
+const pluginHelper = (result: any) => {
+  return () => {
+    return {
+      visitor: {
+        Program(path) {
+          result.hub = path.hub;
+        }
+      }
+    };
+  };
+};
+
+const injectPlugin = plugin => {
+  const buildBabelTransformOptions = options.buildBabelTransformOptions;
+
+  options.buildBabelTransformOptions = () => {
+    const opts = buildBabelTransformOptions();
+
+    opts.plugins.push(plugin);
+    return opts;
+  };
+};
+
+describe('babel plugin', () => {
+  test('path state', () => {
+    const result: any = {};
+    const plugin = pluginHelper(result);
+    injectPlugin(plugin);
+    const { code, ast, template } = transform({
+      ...baseOptions,
+      sourcePath: __filename,
+      code: buildComponent(baseCode)
+    });
+
+    expect(result.hub.file.opts.filename).toBe(__filename);
+  });
+});

--- a/packages/taro-transformer-wx/src/options.ts
+++ b/packages/taro-transformer-wx/src/options.ts
@@ -38,6 +38,7 @@ export const buildBabelTransformOptions: () => TransformOptions = () => {
     plugins.push(buildVistor())
   }
   return {
+    filename: transformOptions.sourcePath,
     parserOpts: {
       sourceType: 'module',
       plugins: [


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

>  // babel-traverse 无法生成 Hub
  // 导致 Path#getSource|buildCodeFrameError 都无法直接使用
  // 原因大概是 babylon.parse 没有生成 File 实例导致 scope 和 path 原型上都没有 `file`
  // 将来升级到 babel@7 可以直接用 parse 而不是 transform

https://github.com/NervJS/taro/blob/master/packages/taro-transformer-wx/src/index.ts#L236-L239

主要解决taro-transformer-wx 在执行transform的时候，babel 插件不能通过 state.opts.file.filename 获取当前正在转换的文件名。

目前需要通过 __tests__/babel.spec.ts 中的hack 方法来实现。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [x] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [x] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
