### PR TITLE
fix4375 解决快应用中路由跳转API不支持相对路径的问题

### DIFF
--- a/packages/taro-quickapp/src/api/router/index.js
+++ b/packages/taro-quickapp/src/api/router/index.js
@@ -1,5 +1,5 @@
 import router from '@system.router'
-
+import * as path from 'path'
 import appGlobal from '../../global'
 import { addLeadingSlash, getUniqueKey } from '../../util'
 import { cacheDataGet, cacheDataSet } from '../../data-cache'
@@ -47,7 +47,12 @@ function qappNavigate (options = {}, method = 'push') {
     }
     params = getUrlParams(url)
     const markIndex = url.indexOf('?')
-    const parseUrl = addLeadingSlash(url.substr(0, markIndex >= 0 ? markIndex : url.length))
+    const componentPath = appGlobal.componentPath || ''
+    const parseUrl = url.substr(0, markIndex >= 0 ? markIndex : url.length).replace(/^(.\/)/g, '')
+    if (componentPath && /^(..\/)/g.test(parseUrl)) {
+      parseUrl = path.join(componentPath, parseUrl)
+    }
+    parseUrl = addLeadingSlash(parseUrl)
     appGlobal.taroRouterParamsCache = appGlobal.taroRouterParamsCache || {}
     appGlobal.taroRouterParamsCache[parseUrl] = params
 
@@ -65,7 +70,7 @@ function qappNavigate (options = {}, method = 'push') {
     }
     try {
       router[method]({
-        uri: url.substr(0, url.lastIndexOf('/')),
+        uri: parseUrl.substr(0, parseUrl.lastIndexOf('/')),
         params
       })
       success && success(res)

--- a/packages/taro-quickapp/src/api/router/index.js
+++ b/packages/taro-quickapp/src/api/router/index.js
@@ -1,5 +1,4 @@
 import router from '@system.router'
-import * as path from 'path'
 import appGlobal from '../../global'
 import { addLeadingSlash, getUniqueKey } from '../../util'
 import { cacheDataGet, cacheDataSet } from '../../data-cache'
@@ -48,9 +47,19 @@ function qappNavigate (options = {}, method = 'push') {
     params = getUrlParams(url)
     const markIndex = url.indexOf('?')
     const componentPath = appGlobal.componentPath || ''
-    const parseUrl = url.substr(0, markIndex >= 0 ? markIndex : url.length).replace(/^(.\/)/g, '')
-    if (componentPath && /^(..\/)/g.test(parseUrl)) {
-      parseUrl = path.join(componentPath, parseUrl)
+    let parseUrl = url.substr(0, markIndex >= 0 ? markIndex : url.length)
+    const RelativeReg = /\.\.\//g
+    if (componentPath && RelativeReg.test(parseUrl)) {
+      //当前页面路径最后一级是文件，在计算路径时去除
+      var componentRootDir = componentPath.substr(0, componentPath.lastIndexOf('/'))
+      var pathArr = parseUrl.split('/')
+      //计算..出现的次数，每出现一次就往上一层
+      for(let path of pathArr) {
+        if (path === '..') {
+          componentRootDir = componentRootDir.substr(0, componentRootDir.lastIndexOf('/'))
+        }
+      }
+      parseUrl = componentRootDir + '/' + parseUrl.replace(RelativeReg, '')
     }
     parseUrl = addLeadingSlash(parseUrl)
     appGlobal.taroRouterParamsCache = appGlobal.taroRouterParamsCache || {}

--- a/packages/taro-quickapp/src/create-component.js
+++ b/packages/taro-quickapp/src/create-component.js
@@ -383,6 +383,7 @@ export default function createComponent (ComponentClass, isPage) {
         }
       }
     })
+    appGlobal.componentPath = isPage
     addLeadingSlash(isPage) && cacheDataSet(addLeadingSlash(isPage), ComponentClass)
   }
   bindStaticFns(componentConf, ComponentClass)


### PR DESCRIPTION
这个 PR 做了什么? (简要描述所做更改)

#4375
实现思路：通过当前页面的绝对路径对路由API的url参数进行绝对化

这个 PR 是什么类型? (至少选择一个)

错误修复(Bugfix) issue id #4375
新功能(Feature)
代码重构(Refactor)
TypeScript 类型定义修改(Typings)
文档修改(Docs)
代码风格更新(Code style update)
其他，请描述(Other, please describe):
这个 PR 满足以下需求:

提交到 master 分支
Commit 信息遵循 Angular Style Commit Message Conventions
所有测试用例已经通过
代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
在本地测试可用，不会影响到其它功能
这个 PR 涉及以下平台:

微信小程序
支付宝小程序
百度小程序
头条小程序
QQ 轻应用
快应用平台（QuickApp）
Web 平台（H5）
移动端（React-Native）
其它需要 Reviewer 或社区知晓的内容：