### PR TITLE
feat(cli): 引入第三方原生组件支持

### DIFF
--- a/packages/taro-cli/src/mini/native.ts
+++ b/packages/taro-cli/src/mini/native.ts
@@ -4,8 +4,9 @@ import * as path from 'path'
 import { Config as IConfig } from '@tarojs/taro'
 import chalk from 'chalk'
 
-import { REG_WXML_IMPORT, processTypeEnum, taroJsFramework, BUILD_TYPES, REG_SCRIPT, REG_STYLE, REG_UX } from '../util/constants'
+import { REG_WXML_IMPORT, processTypeEnum, taroJsFramework, BUILD_TYPES, REG_SCRIPT, REG_STYLE, REG_UX, NODE_MODULES_REG } from '../util/constants'
 import { isEmptyObject, printLog, resolveScriptPath, copyFileSync, extnameExpRegOf, resolveQuickappFilePath, processUxContent } from '../util'
+import CONFIG from '../config';
 
 import { buildDepComponents } from './component'
 import { compileDepScripts } from './compileScript'
@@ -97,7 +98,12 @@ export function transfromNativeComponents (configFile: string, componentConfig: 
         const componentJSONPath = componentJSPath.replace(extnameExpRegOf(componentJSPath), outputFilesTypes.CONFIG)
         const componentWXMLPath = componentJSPath.replace(extnameExpRegOf(componentJSPath), outputFilesTypes.TEMPL)
         const componentWXSSPath = componentJSPath.replace(extnameExpRegOf(componentJSPath), outputFilesTypes.STYLE)
-        const outputComponentJSPath = componentJSPath.replace(sourceDir, outputDir).replace(extnameExpRegOf(componentJSPath), outputFilesTypes.SCRIPT)
+        let outputComponentJSPath = '';
+        if (NODE_MODULES_REG.test(outputComponentJSPath)) {
+          outputComponentJSPath = componentJSPath.replace(NODE_MODULES_REG, path.resolve(outputDir, CONFIG.NPM_DIR)).replace(extnameExpRegOf(componentJSPath), outputFilesTypes.SCRIPT)
+        } else {
+          outputComponentJSPath = componentJSPath.replace(sourceDir, outputDir).replace(extnameExpRegOf(componentJSPath), outputFilesTypes.SCRIPT)
+        }
         if (fs.existsSync(componentJSPath)) {
           const componentJSContent = fs.readFileSync(componentJSPath).toString()
           if (componentJSContent.indexOf(taroJsFramework) >= 0 && !fs.existsSync(componentWXMLPath)) {


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
支持npm安装第三方原生组件包时，使用usingComponents引用


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
我们为了兼容以前用wepy的小程序，公共包通常用原生组件封装，这个方式是在路径中查找node_modules来判断是不是npm包，使用者需在usingComponents中使用相对路径引用`../../node_modules/component/xxx/xxx`第三方包。

#2926 
