### PR TITLE
fix: 修复h5环境下setClipboardData在ios无效, 在android滚动到页面最后的问题

### DIFF
--- a/packages/taro-h5/src/api/clipboard/index.js
+++ b/packages/taro-h5/src/api/clipboard/index.js
@@ -54,11 +54,12 @@ export const setClipboardData = ({ data, success, fail, complete }) => {
         input.style.width = '100px'
         input.style.left = '-10000px'
         document.body.appendChild(input)
-        input.focus()
-        if (input.setSelectionRange) {
-          input.setSelectionRange(0, input.value.length)
-          document.execCommand('copy')
-          document.body.removeChild(input)
+        input.select()
+        input.setSelectionRange(0, 999999)
+        const results = document.execCommand('copy')
+        document.body.removeChild(input)
+        if (!results) {
+          throw new Error('复制失败')
         }
       }
       const res = {


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
主要修复两个问题: 
  1. setClipboardData方法在ios环境下无效的问题；
  2. 在Android手机上, 如果页面超过一屏时, 调用setClipboardData会滚动到页面最底部(判断是input.focus()造成)。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #4611
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
