### PR TITLE
fix(taro): 修复小程序生命周期 hook 在 rerender 后只触发最后一个

### DIFF
--- a/packages/taro/src/hooks.js
+++ b/packages/taro/src/hooks.js
@@ -37,16 +37,22 @@ export function useState (initialState) {
 
 function usePageLifecycle (callback, lifecycle) {
   const hook = getHooks(Current.index++)
-  let originalLifecycle
-  hook.component = Current.current
-  const component = hook.component
+
   if (!hook.marked) {
     hook.marked = true
-    originalLifecycle = component[lifecycle]
-  }
-  hook.component[lifecycle] = function () {
-    originalLifecycle && originalLifecycle.call(component, ...arguments)
-    return callback && callback.call(component, ...arguments)
+    hook.component = Current.current
+    hook.callback = callback
+
+    const component = hook.component
+    const originalLifecycle = component[lifecycle]
+
+    hook.component[lifecycle] = function () {
+      const callback = hook.callback
+      originalLifecycle && originalLifecycle.call(component, ...arguments)
+      return callback && callback.call(component, ...arguments)
+    }
+  } else {
+    hook.callback = callback
   }
 }
 


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

修复小程序生命周期 hook 在 rerender 后只触发最后一个，下面是复现代码

```jsx
export default function PageHook () {
  console.log('---- rerender ----')
  useDidShow(() => {
    console.log('didShow1 called')
  })
  useDidShow(() => {
    console.log('didShow2 called')
  })
  const [count, setCount] = useState(0)
  return (
    <View>
      <Button onClick={() => setCount(count + 1)}>cout: {count}</Button>
    </View>
  )
}
```
页面载入完成后，点击 button 触发 rerender，切换后台后，console 输出
```
---- rerender ----
didShow1 called
didShow2 called
---- rerender ----
didShow2 called
```
预期结果
```
---- rerender ----
didShow1 called
didShow2 called
---- rerender ----
didShow1 called
didShow2 called
```

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [ ] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [x] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**

之前的逻辑在触发了 rerender 后，赋值给 lifecycle 的新的闭包中 originalLifecycle 一直会为空，所以就变成只有最后一次调用给的 callback 会被触发，这个 pr 改成了初始化完后只修改 callback 的引用。