### PR TITLE
fix(alipay): 函数 Page 组件没有触发effect cleanup

### DIFF
--- a/packages/taro-alipay/src/create-component.js
+++ b/packages/taro-alipay/src/create-component.js
@@ -288,6 +288,13 @@ function createComponent (ComponentClass, isPage) {
         componentTrigger(this.$component, 'componentWillUnmount')
         const component = this.$component
         const events = component.$$renderPropsEvents
+        
+        component.hooks.forEach((hook) => {
+          if (isFunction(hook.cleanup)) {
+            hook.cleanup()
+          }
+        })
+        
         if (isArray(events)) {
           events.forEach(e => eventCenter.off(e))
         }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

支付宝小程序函数式 Page 组件在页面卸载后不执行 useEffect 的回调。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #4068
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [x] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
