### PR TITLE
fix: 修复H5环境下previewImage点击穿透的问题

### DIFF
--- a/packages/taro-h5/src/api/image/react-wx-images-viewer/components/ImageContainer.js
+++ b/packages/taro-h5/src/api/image/react-wx-images-viewer/components/ImageContainer.js
@@ -319,7 +319,7 @@ class ImageContainer extends PureComponent {
 
   handleTouchEnd = (event) => {
     // console.info('handleTouchEnd', event.touches.length)
-    event.preventDefault()
+    // event.preventDefault()
 
     if (this.isTwoFingerMode) { // 双指操作结束
       const touchLen = event.touches.length
@@ -368,7 +368,7 @@ class ImageContainer extends PureComponent {
       // console.info('handleTouchEnd one diffTime = %s, diffX = %s, diffy = %s', diffTime, diffX, diffY)
       // 判断为点击则关闭图片浏览组件
       if (diffTime < maxTapTimeValue && Math.abs(diffX) < minTapMoveValue && Math.abs(diffY) < minTapMoveValue) {
-        this.context.onClose()
+        // this.context.onClose()
         return
       }
 
@@ -491,6 +491,11 @@ class ImageContainer extends PureComponent {
     }
   }
 
+  onClose = (event) => {
+    event.preventDefault()
+    this.context.onClose()
+  }
+
   render () {
     const {
       screenWidth,
@@ -529,6 +534,7 @@ class ImageContainer extends PureComponent {
         onTouchStart={this.handleTouchStart}
         onTouchMove={this.handleTouchMove}
         onTouchEnd={this.handleTouchEnd}
+        onClick={this.onClose}
         style={defaultStyle}
       >
         {


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
    bug场景：在点击图片调用previewImage进行预览时, 点击关闭预览若触摸点底部页面有绑定click事件， 由于点击穿透的问题会触发底层click事件，因此点击关闭的触摸点刚刚好在底层需要预览的图片处， 就会导致预览层闪烁无法关闭。
  
  原previewImage接口处理点击穿透是通过onTouchEnd时调用event.preventDefault(), 但是该方法会报错"Unable to preventDefault inside passive event listener"(应该是由于监听touch相关事件时passive属性为true的原因), 故改为使用onClick来控制弹窗关闭, 并阻止点击穿透。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
