### PR TITLE
feat(webpack-runner): dev-server配置host为0.0.0.0时, 默认以本地ip打开

### DIFF
--- a/packages/taro-webpack-runner/src/index.ts
+++ b/packages/taro-webpack-runner/src/index.ts
@@ -8,7 +8,7 @@ import buildConf from './config/build.conf'
 import devConf from './config/dev.conf'
 import baseDevServerOption from './config/devServer.conf'
 import prodConf from './config/prod.conf'
-import { addLeadingSlash, addTrailingSlash, recursiveMerge } from './util'
+import { addLeadingSlash, addTrailingSlash, recursiveMerge, formatOpenHost } from './util'
 import { bindDevLogger, bindProdLogger, printBuildError } from './util/logHelper'
 import { BuildConfig } from './util/types'
 import { makeConfig } from './util/chain';
@@ -121,7 +121,13 @@ const buildDev = async (appPath: string, config: BuildConfig): Promise<any> => {
 
       /* 补充处理devServer.open配置 */
       if (devServerOptions.open) {
-        opn(devUrl)
+        const openUrl = formatUrl({
+          protocol: devServerOptions.https ? 'https' : 'http',
+          hostname: formatOpenHost(devServerOptions.host),
+          port: devServerOptions.port,
+          pathname
+        })
+        opn(openUrl)
       }
     })
   })

--- a/packages/taro-webpack-runner/src/util/index.ts
+++ b/packages/taro-webpack-runner/src/util/index.ts
@@ -1,5 +1,6 @@
 import * as path from 'path'
-import { mergeWith } from 'lodash';
+import { mergeWith } from 'lodash'
+import { networkInterfaces } from 'os'
 
 const isEmptyObject = function (obj) {
   if (obj == null) {
@@ -61,6 +62,31 @@ const isNpmPackage = (name: string) => !/^(\.|\/)/.test(name)
 const addLeadingSlash = (url: string) => url.charAt(0) === '/' ? url : '/' + url
 const addTrailingSlash = (url: string) => url.charAt(url.length - 1) === '/' ? url : url + '/'
 
+const formatOpenHost = host => {
+  let result = host
+  // 配置host为0.0.0.0时,可以转换为ip打开, 其他以配置host默认打开
+  if (result === '0.0.0.0') {
+    // 设置localhost为初值, 防止没正确获取到host时以0.0.0.0打开
+    result = 'localhost'
+    const interfaces = networkInterfaces()
+    for (const devName in interfaces) {
+      const isEnd = interfaces[devName].some(item => {
+        // 取IPv4, 不为127.0.0.1的内网ip
+        if (item.family === 'IPv4' && item.address !== '127.0.0.1' && !item.internal) {
+          result = item.address
+          return true
+        }
+        return false
+      })
+      // 若获取到ip, 结束遍历
+      if (isEnd) {
+        break
+      }
+    }
+  }
+  return result
+}
+
 export {
   emptyObj,
   emptyTogglableObj,
@@ -71,5 +97,6 @@ export {
   formatTime,
   recursiveMerge,
   addLeadingSlash,
-  addTrailingSlash
+  addTrailingSlash,
+  formatOpenHost
 }


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
 实现H5开发环境,配置devServer.host为0.0.0.0时默认以本地ip地址打开网页; 若配置为其它地址则以配置的host打开网页


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
