### PR TITLE
从prevProps改为使用nextProps，避免props的提前赋值，及避免component.props = prevProps的操作

### DIFF
--- a/packages/taro-weapp/src/create-component.js
+++ b/packages/taro-weapp/src/create-component.js
@@ -58,7 +58,7 @@ function bindProperties (weappComponentConf, ComponentClass, isPage) {
       if (!this.$component || !this.$component.__isReady) return
 
       const nextProps = filterProps(ComponentClass.defaultProps, {}, this.$component.props, this.data.extraProps)
-      this.$component.props = nextProps
+      this.$component.nextProps = nextProps
       nextTick(() => {
         this.$component._unsafeCallUpdate = true
         updateComponent(this.$component)

--- a/packages/taro-weapp/src/lifecycle.js
+++ b/packages/taro-weapp/src/lifecycle.js
@@ -44,6 +44,10 @@ function callGetSnapshotBeforeUpdate (component, props, state) {
 
 export function updateComponent (component) {
   const { props, __propTypes } = component
+  // 由 forceUpdate 或者组件自身 setState 发起的 update 可能是没有新的nextProps的
+  const nextProps = component.nextProps || props
+  const prevProps = props
+
   if (isDEV && __propTypes) {
     let componentName = component.constructor.name
     if (isUndefined(componentName)) {
@@ -52,18 +56,17 @@ export function updateComponent (component) {
     }
     PropTypes.checkPropTypes(__propTypes, props, 'prop', componentName)
   }
-  const prevProps = component.prevProps || props
-  component.props = prevProps
+
   if (component.__mounted && component._unsafeCallUpdate === true && !hasNewLifecycle(component) && component.componentWillReceiveProps) {
     component._disable = true
-    component.componentWillReceiveProps(props)
+    component.componentWillReceiveProps(nextProps)
     component._disable = false
   }
   let state = component.getState()
 
   const prevState = component.prevState || state
 
-  const stateFromProps = callGetDerivedStateFromProps(component, props, state)
+  const stateFromProps = callGetDerivedStateFromProps(component, nextProps, state)
 
   if (!isUndefined(stateFromProps)) {
     state = stateFromProps
@@ -73,21 +76,21 @@ export function updateComponent (component) {
   if (component.__mounted) {
     if (typeof component.shouldComponentUpdate === 'function' &&
       !component._isForceUpdate &&
-      component.shouldComponentUpdate(props, state) === false) {
+      component.shouldComponentUpdate(nextProps, state) === false) {
       skip = true
     } else if (!hasNewLifecycle(component) && isFunction(component.componentWillUpdate)) {
-      component.componentWillUpdate(props, state)
+      component.componentWillUpdate(nextProps, state)
     }
   }
 
-  component.props = props
+  component.props = nextProps
   component.state = state
   component._dirty = false
   component._isForceUpdate = false
   if (!skip) {
     doUpdate(component, prevProps, prevState)
   }
-  component.prevProps = component.props
+  delete component.nextProps
   component.prevState = component.state
 }
 
@@ -114,7 +117,6 @@ export function mountComponent (component) {
     }
   }
   doUpdate(component, props, component.state)
-  component.prevProps = component.props
   component.prevState = component.state
 }
 

--- a/packages/taro-weapp/src/propsManager.js
+++ b/packages/taro-weapp/src/propsManager.js
@@ -30,7 +30,9 @@ class Manager {
 
           const extraProps = (component.$scope && component.$scope.data && component.$scope.data.extraProps) || null
           const nextProps = filterProps(ComponentClass.defaultProps, props, component.props, extraProps)
-          component.props = nextProps
+          // 这里原来是提前修改了 props, 实际更新又是nextTick异步的，这样可以会导致很多问题
+          // 很难保证如果开发者无意中多次并发更新，props可能提前于生命周期被获取到
+          component.nextProps = nextProps
           nextTick(() => {
             component._unsafeCallUpdate = true
             updateComponent(component)


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
修改了 propsManage 中提前更新了props的逻辑，改为updateComponent中做实际更新
updateComponent 中原本使用了
```
prevProps = props;
componennt.props = prevProps
// didUpdate 前的各种生命周期
....
componennt.props  = props
```
的逻辑来适应生命周期函数
现在使用额外的nextProps后，不需要重复的修改`props`来适应生命周期函数中的需求


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):
应该只能算一个优化？

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
暂时就修改了weapp， 如果可以的话，应该还是要同步修改其他平台的

**其它需要 Reviewer 或社区知晓的内容：**
