### PR TITLE
fix(cli for qq): 修正qq轻应用配置文件读取

### DIFF
--- a/packages/taro-cli/src/mini/index.ts
+++ b/packages/taro-cli/src/mini/index.ts
@@ -44,7 +44,7 @@ function buildProjectConfig () {
   }
 
   let projectConfigFileName = `project.${buildAdapter}.json`
-  if (buildAdapter === BUILD_TYPES.WEAPP || buildAdapter === BUILD_TYPES.QQ) {
+  if (buildAdapter === BUILD_TYPES.WEAPP) {
     projectConfigFileName = 'project.config.json'
   }
   let projectConfigPath = path.join(appPath, projectConfigFileName)
@@ -55,7 +55,7 @@ function buildProjectConfig () {
   }
 
   const origProjectConfig = fs.readJSONSync(projectConfigPath)
-  if (buildAdapter === BUILD_TYPES.TT) {
+  if (buildAdapter === BUILD_TYPES.TT || buildAdapter === BUILD_TYPES.QQ) {
     projectConfigFileName = 'project.config.json'
   }
   fs.ensureDirSync(outputDir)


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修正编译时，taro cli 忽略project.qq.json 而使用project.config.json，导致同时使用微信小程序及qq 轻应用时出现appid 不正确，即配置文件错误的问题。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x ] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
