### PR TITLE
增强快应用button组件，增加属性判断及点击变色等

### DIFF
--- a/packages/taro-components-qa/src/components/taro-button/index.ux
+++ b/packages/taro-components-qa/src/components/taro-button/index.ux
@@ -4,104 +4,141 @@
     disabled="{{disabled}}"
     style="{{customstyle}}"
   >
+  <image if="{{loading}}" src="{{loadingImg}}"></image>
     <slot></slot>
   </div>
 </template>
 
 <script>
-  // import LOADING_IMG from './img.js'
+import LOADING_IMG from './img.js'
+
+export default {
+  props: {
+    class: {
+      type: String,
+      required: false,
+      default: 'default'
+    },
+    id: {
+      type: String,
+      required: false,
+      default: 'default'
+    },
+    customstyle: {
+      type: Object,
+      required: false,
+      default: {}
+    },
+    size: {
+      type: String,
+      required: false,
+      default: 'default'
+    },
+    plain: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    disabled: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    loading: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    type: {
+      type: String,
+      required: false,
+      default: 'default'
+    }
+  },
+
+  data: () => ({
+    btnStyle: {},
+    btnClass: '',
+    loading: false,
+    loadingImg: LOADING_IMG,
+  }),
+
+  onInit() {
+    this.btnClass = `taro-button taro-button-${this.type} taro-button-${this.size} ${this.plain ? `taro-button-plain` : `taro-button-noplain`} ${this.disabled ? `taro-button-disabled` : `taro-button-nodisabled`} ${this.circle ? `taro-button-circle` : `taro-button-nocircle`} ${this.className}`
+  },
   
-  export default {
-    props: {
-      class: {
-        type: String,
-        required: false,
-        default: ''
-      },
-      id: {
-        type: String,
-        required: false,
-        default: ''
-      },
-      customstyle: {
-        type: Object,
-        required: false,
-        default: {}
-      },
-      size: {
-        type: String,
-        required: false,
-        default: 'default'
-      },
-      plain: {
-        type: Boolean,
-        required: false,
-        default: false
-      },
-      disabled: {
-        type: Boolean,
-        required: false,
-        default: false
-      },
-      loading: {
-        type: Boolean,
-        required: false,
-        default: false
-      },
-      type: {
-        type: String,
-        required: false,
-        default: 'default'
-      }
-    },
-
-    data: () => ({
-      btnStyle: {},
-      btnClass: '',
-      // loadingImg: LOADING_IMG,
-    }),
-
-    onInit () {
-      this.btnClass = this.plain ? 
-        `taro-button taro-button_default btn_plain btn_plain_${this.type} ${this.class}` 
-        : 
-        `taro-button taro-button_default btn_size_${this.size} ${this.disabled ? `disabled_${this.type}` : `btn_color_${this.type}`} ${this.class}`
-    },
+  onclick(){	
+    	
   }
-</script>
+};</script>
 
 <style>
   .taro-button {
-    width: 100%;
+    height: 85px;
+    width: 710px;
     padding-left: 14px;
     padding-right: 14px;
     font-size: 18px;
     text-align: center;
     text-decoration: none;
     line-height: 46px;
-    border-radius: 5px;
-    border: 1px solid #000;
+    border-radius: 7px;
+    border-color: lightslategray;  
+    background-color: #F7F7F7;
   }
-  /* .taro-button::after {
-      content: " ";
-      width: 200%;
-      height: 200%;
-      position: absolute;
-      top: 0;
-      left: 0;
-      border: 1px solid rgba(0, 0, 0, 0.2);
-      transform: scale(0.5);
-      transform-origin: 0 0;
-      box-sizing: border-box;
-      border-radius: 10px;
-  } */
-  .taro-button text {
-    color: #000;
+  .taro-button:active {
+    border-width: 1px;
+    border-color: lightslategray;  
+    background-color: #F6F6E5;
   }
-  .taro-button_default {
-      background-color: #F8F8F8;
+  .taro-button-circle {
+    border-radius: 30px;
   }
-  .taro-button_default text{
-    color: #000000;
+  .taro-button-small {
+    height: 56px;
+    width: 116px;
+    border: 1px solid #6190E8;
+    background-color: #6190E8;
+  }
+  .taro-button-full {
+    margin-left: 0px;
+    border-radius: 0px;
+    width: 100%;
+  }
+  .taro-button-primary{
+    color: #FFF;
+    border: 1px solid #6190E8;
+    background-color: #6190E8;
+  }
+  .taro-button-primary:active {
+    color: #FFF;
+    border: 1px solid #78A4F4;
+    background-color: #78A4F4;
+  }
+  .taro-button-secondary{
+    color: #6190E8;
+    border: 1.5px solid #6190E8;
+    background-color: #FFF;
+  }
+  .taro-button-secondary:active {
+    color: #6190E8;
+    border: 1.5px solid #78A4F4;
+    background-color: #FFF;
+  }     
+  .taro-button-danger {
+    background-color: #EF4F4F;
+    border-color: #EF4F4F;  
+    color: white;
+  }
+  .taro-button-danger:active {
+    background-color: #ab2048;
+    border-color: #ab2048; 
+    color: white;
+  } 
+  .taro-button-plain {
+    opacity: 0.6;
+  }
+  .taro-button-disabled {
+    opacity: 0.3;
   }
 </style>


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
1.重构样式响应的内容，增加plain透明度、type类型、size大小、disabled禁用、 circle圆角、 loading动画载入 等多种属性的样式
2.通过active伪类，实现点击时变色
3.可通过scss父类样式载入，实现flex纵向换行等布局操作
4.因div组件的特性，text被div包裹时，字体设定无法生效，可通过父类样式引入继承，使得字体大小、种类、颜色等进行设定


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [x] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [x] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
