### PR TITLE
feat(taro-redux): add shallowEqual func for useSelector

### DIFF
--- a/packages/taro-redux/src/index.js
+++ b/packages/taro-redux/src/index.js
@@ -5,6 +5,7 @@ import { useDispatch } from './hooks/use-dispatch'
 import { useSelector } from './hooks/use-selector'
 import { useStore } from './hooks/use-store'
 import { ReduxContext } from './hooks/context'
+import shallowEqual from './utils/shallowEqual'
 
 export default {
   connect,
@@ -14,7 +15,8 @@ export default {
   useDispatch,
   useSelector,
   useStore,
-  ReduxContext
+  ReduxContext,
+  shallowEqual
 }
 
 export {
@@ -25,5 +27,6 @@ export {
   useDispatch,
   useSelector,
   useStore,
-  ReduxContext
+  ReduxContext,
+  shallowEqual
 }

--- a/packages/taro-redux/src/utils/shallowEqual.js
+++ b/packages/taro-redux/src/utils/shallowEqual.js
@@ -1,0 +1,31 @@
+const hasOwn = Object.prototype.hasOwnProperty
+
+function is (x, y) {
+  if (x === y) {
+    return x !== 0 || y !== 0 || 1 / x === 1 / y
+  } else {
+    // eslint-disable-next-line no-self-compare
+    return x !== x && y !== y
+  }
+}
+
+export default function shallowEqual (objA, objB) {
+  if (is(objA, objB)) return true
+
+  if (typeof objA !== 'object' || objA === null || typeof objB !== 'object' || objB === null) {
+    return false
+  }
+
+  const keysA = Object.keys(objA)
+  const keysB = Object.keys(objB)
+
+  if (keysA.length !== keysB.length) return false
+
+  for (let i = 0; i < keysA.length; i++) {
+    if (!hasOwn.call(objB, keysA[i]) || !is(objA[keysA[i]], objB[keysA[i]])) {
+      return false
+    }
+  }
+
+  return true
+}

--- a/packages/taro-redux/types/index.d.ts
+++ b/packages/taro-redux/types/index.d.ts
@@ -144,3 +144,10 @@ export function useStore<S = any, A extends Action = AnyAction>(): Store<S, A>;
 // the Dispatch function (see also this PR: https://github.com/reduxjs/redux-thunk/pull/247)
 export function useDispatch<TDispatch = Dispatch<any>>(): TDispatch;
 export function useDispatch<A extends Action = AnyAction>(): Dispatch<A>;
+
+/**
+ * Compares two arbitrary values for shallow equality. Object values are compared based on their keys, i.e. they must
+ * have the same keys and for each key the value must be equal according to the `Object.is()` algorithm. Non-object
+ * values are also compared with the same algorithm as `Object.is()`.
+ */
+export function shallowEqual(left: any, right: any): boolean;


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

发现 @taro-redux 包少了一个 `shallowEqual` 的实现（react-redux 里面实现了），故添加进来。应用场景是 `useSelector` 返回一个对象时, 如果对象完全一样只是 reference 变了，不用重新渲染。

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
