### PR TITLE
fix(tt): ref在头条小程序中不能使用的BUG(#4912)

### DIFF
--- a/packages/taro-tt/src/create-component.js
+++ b/packages/taro-tt/src/create-component.js
@@ -192,22 +192,25 @@ export function componentTrigger (component, key, args) {
 
     if (component['$$refs'] && component['$$refs'].length > 0) {
       let refs = {}
-      const refComponents = component['$$refs'].map(ref => new Promise((resolve, reject) => {
-        const query = tt.createSelectorQuery().in(component.$scope)
-        if (ref.type === 'component') {
-          component.$scope.selectComponent(`#${ref.id}`, target => {
+      const refComponents = []
+      component['$$refs'].forEach(ref =>{
+        refComponents.push(new Promise((resolve, reject) => {
+          const query = tt.createSelectorQuery().in(component.$scope)
+          if (ref.type === 'component') {
+            component.$scope.selectComponent(`#${ref.id}`, target => {
+              resolve({
+                target: target ? target.$component || target : null,
+                ref
+              })
+            })
+          } else {
             resolve({
-              target: target ? target.$component || target : null,
+              target: query.select(`#${ref.id}`),
               ref
             })
-          })
-        } else {
-          resolve({
-            target: query.select(`#${ref.id}`),
-            ref
-          })
-        }
-      }))
+          }
+        }))
+      })
       Promise.all(refComponents)
         .then(targets => {
           targets.forEach(({ ref, target }) => {

--- a/packages/taro-tt/src/create-component.js
+++ b/packages/taro-tt/src/create-component.js
@@ -193,7 +193,7 @@ export function componentTrigger (component, key, args) {
     if (component['$$refs'] && component['$$refs'].length > 0) {
       let refs = {}
       const refComponents = []
-      component['$$refs'].forEach(ref =>{
+      component['$$refs'].forEach(ref => {
         refComponents.push(new Promise((resolve, reject) => {
           const query = tt.createSelectorQuery().in(component.$scope)
           if (ref.type === 'component') {


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
最近更新的RefsArray对象如果被map函数遍历会执行构造函数,造成错误。所以将map改为forEach


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #4912
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [x] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
