### PR TITLE
修复页面config配置类型定义缺失

### DIFF
--- a/packages/taro-components/types/common.d.ts
+++ b/packages/taro-components/types/common.d.ts
@@ -1,4 +1,4 @@
-import { CSSProperties } from 'react';
+import {CSSProperties} from 'react';
 
 export type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never })[keyof T]>;
 
@@ -27,7 +27,7 @@ export interface StandardProps extends EventProps {
   /**
    * 动画属性
    */
-  animation?: object[],
+  animation?: { actions: object[] },
   /**
    * 引用
    */
@@ -147,13 +147,13 @@ export interface BaseEventOrig<T> {
   detail: T,
 
   /**
-  * 阻止元素发生默认的行为
-  */
+   * 阻止元素发生默认的行为
+   */
   preventDefault: () => void,
 
   /**
-  * 阻止事件冒泡到父元素,阻止任何父事件处理程序被执行
-  */
+   * 阻止事件冒泡到父元素,阻止任何父事件处理程序被执行
+   */
   stopPropagation: () => void
 }
 
@@ -215,4 +215,5 @@ export interface Target {
   }
 }
 
-export interface currentTarget extends Target {}
+export interface currentTarget extends Target {
+}

--- a/packages/taro/types/taro.config.d.ts
+++ b/packages/taro/types/taro.config.d.ts
@@ -304,6 +304,7 @@ declare namespace Taro {
       [key: string]: string
     }
     window?: WindowConfig
-    cloud?: boolean
+    cloud?: boolean,
+    pageOrientation?: 'auto' | 'portrait' | 'landscape'
   }
 }


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)



**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [x] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [ ] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
