### PR TITLE
feat(weapp): add missing type for image component

### DIFF
--- a/packages/taro-components/types/Image.d.ts
+++ b/packages/taro-components/types/Image.d.ts
@@ -25,6 +25,13 @@ export interface ImageProps extends StandardProps {
   lazyLoad?: boolean,
 
   /**
+   * 开启长按图片显示识别小程序码菜单
+   * 
+   * 默认值: `false`
+   */
+  showMenuByLongpress?: boolean,
+
+  /**
    * 当错误发生时，发布到 AppService 的事件名，事件对象
    *
    * event.detail = {errMsg: 'something wrong'}


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

微信小程序 image 组件有一个 show-menu-by-longpress 属性，taro-component 中缺失对应的类型定义。
![Screen Shot 2019-12-12 at 11 31 52](https://user-images.githubusercontent.com/24768249/70680400-2608a780-1cd3-11ea-99a2-9231688b7ac4.png)

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [x] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
