### PR TITLE
fix: h5环境previewImage左右滑动时触发浏览器前进、后退

### DIFF
--- a/packages/taro-h5/src/api/image/react-wx-images-viewer/components/ImageContainer.js
+++ b/packages/taro-h5/src/api/image/react-wx-images-viewer/components/ImageContainer.js
@@ -192,8 +192,8 @@ class ImageContainer extends PureComponent {
 
   handleTouchStart = (event) => {
     // console.info('handleTouchStart')
-    // event.preventDefault()
-    // event.stopPropagation()
+    event.preventDefault()
+    event.stopPropagation()
     if (this.animationID) {
       raf.cancel(this.animationID)
     }
@@ -240,8 +240,8 @@ class ImageContainer extends PureComponent {
   }
 
   handleTouchMove = (event) => {
-    // event.preventDefault()
-    // event.stopPropagation()
+    event.preventDefault()
+    event.stopPropagation()
 
     switch (event.touches.length) {
       case 1: {

--- a/packages/taro-h5/src/api/image/react-wx-images-viewer/components/WxImageViewer.css
+++ b/packages/taro-h5/src/api/image/react-wx-images-viewer/components/WxImageViewer.css
@@ -4,6 +4,9 @@
   top: 0;
   width: 100%;
   height: 100%;
+  touch-action: none;
+  -ms-touch-action: none;
+  /* touch-action: pan-y pinch-zoom; */
 }
 .wx-image-viewer .viewer-cover {
   position: absolute;


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
场景：H5 环境下，使用 `Taro.previewImage()` 进行图片预览时，左右滑动会触发浏览器前进、后退功能，譬如当滑动到第一页时，继续右滑会导致浏览器返回上一页。常发生于 UC浏览器 及 Android自带浏览器（如OPPO的ColorOS等）。

修复：首先通过给预览图片容器 `WrapViewr` 添加 css 样式 `touch-action: none;` 禁止浏览的触摸交互功能，此方法亦可消除 `chrom`使用`preventDefault`时报错，此时可消除左右滑动时导致的浏览器返回问题。另，实测此方法在`UC浏览器IOS版`不能达到预期效果，此时需在`ImageContainer`中的处理`touch`相关事件时开启`preventDefault` 及 `stopPropagation` 方法阻止事件的传递。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
