### PR TITLE
fix(RN): 修复 previewImage 加载中的 loading 提示

### DIFF
--- a/packages/taro-rn/src/api/image/previewImage.tsx
+++ b/packages/taro-rn/src/api/image/previewImage.tsx
@@ -1,7 +1,15 @@
 import React from 'react'
-import { Modal ,Text} from 'react-native'
+import { Modal, View, ActivityIndicator, StyleSheet } from 'react-native'
 import RootSiblings from 'react-native-root-siblings'
 import ImageViewer from 'react-native-image-zoom-viewer'
+
+const styles = StyleSheet.create({
+  loadingWrapper: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center'
+  }
+})
 
 function previewImage (obj) {
   let {
@@ -28,7 +36,13 @@ function previewImage (obj) {
           onClick={onSuccess}
           onSwipeDown={onSuccess}
           enableSwipeDown
-          loadingRender={() => <Text>loading...</Text>}
+          loadingRender={() => {
+            return (
+              <View style={[styles.loadingWrapper]}>
+                <ActivityIndicator size="large" color={'#999'} />
+              </View>
+            )
+          }}
         />
       </Modal>
     )


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
场景：`RN`环境下使用`previewImage`进行大图预览时，图片加载过程中无loading效果。

原因：`loadingRender` 函数返回的仅是 `<Text>loading</Text>`, 无任何颜色样式等，此时字体颜色为默认颜色，即黑色，与背景颜色重叠。

修复：使用 `RN` 组件 `ActivityIndicator`，图片资源 `loading` 状态时返回一个转动的小菊花，与其他端保持一致。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
