### PR TITLE
fix(typescript types): 修复 Taro.getExtConfigSync 返回值类型。

### DIFF
--- a/packages/taro/types/api/ext/index.d.ts
+++ b/packages/taro/types/api/ext/index.d.ts
@@ -1,10 +1,4 @@
 declare namespace Taro {
-  namespace getExtConfigSync {
-    interface ExtInfo {
-      /** 第三方平台自定义的数据 */
-      extConfig: General.IAnyObject
-    }
-  }
   /** Taro.getExtConfig 的同步版本。
    *
    * **Tips**
@@ -18,7 +12,7 @@ declare namespace Taro {
    * ```
    * @see https://developers.weixin.qq.com/miniprogram/dev/api/ext/wx.getExtConfigSync.html
    */
-  function getExtConfigSync(): getExtConfigSync.ExtInfo
+  function getExtConfigSync(): General.IAnyObject
 
   namespace getExtConfig {
     interface Option {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复 Taro.getExtConfigSync 返回值类型。
Taro.getExtConfigSync() 返回的是自定义数据，外层没有 `extConfig`。


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [x] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [ ] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
