### PR TITLE
fix(mini-runner) 修复快应用自定义组件调用不支持绝对路径调用的问题

### DIFF
--- a/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
+++ b/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
@@ -19,7 +19,7 @@ import { REG_TYPESCRIPT, BUILD_TYPES, PARSE_AST_TYPE, MINI_APP_FILES, NODE_MODUL
 import { IComponentObj } from '../utils/types'
 import { resolveScriptPath, buildUsingComponents, isNpmPkg, resolveNpmSync, isEmptyObject, promoteRelativePath, printLog, isAliasPath, replaceAliasPath } from '../utils'
 import TaroSingleEntryDependency from '../dependencies/TaroSingleEntryDependency'
-import { getTaroJsQuickAppComponentsPath, generateQuickAppUx, getImportTaroSelfComponents, generateQuickAppManifest } from '../utils/helper'
+import { getTaroJsQuickAppComponentsPath, generateQuickAppUx, getImportTaroSelfComponents, getImportCustomComponents, generateQuickAppManifest } from '../utils/helper'
 import parseAst from '../utils/parseAst'
 import rewriterTemplate from '../quickapp/template-rewriter'
 
@@ -661,6 +661,7 @@ export default class MiniPlugin {
           const scriptPath = file.path
           const outputScriptPath = scriptPath.replace(this.sourceDir, this.outputDir).replace(path.extname(scriptPath), MINI_APP_FILES[buildAdapter].SCRIPT)
           const importTaroSelfComponents = getImportTaroSelfComponents(outputScriptPath, this.options.nodeModulesPath, this.outputDir, taroSelfComponents)
+          const importCustomComponents = getImportCustomComponents(this.outputDir, depComponents)
           const usingComponents = configObj.usingComponents
           let importUsingComponent: any = new Set([])
           if (usingComponents) {
@@ -671,12 +672,6 @@ export default class MiniPlugin {
               }
             }))
           }
-          const importCustomComponents = new Set(depComponents.map(item => {
-            return {
-              path: item.path,
-              name: item.name as string
-            }
-          }))
           template = generateQuickAppUx({
             template,
             imports: new Set([...importTaroSelfComponents, ...importUsingComponent, ...importCustomComponents])

--- a/packages/taro-mini-runner/src/utils/helper.ts
+++ b/packages/taro-mini-runner/src/utils/helper.ts
@@ -28,6 +28,19 @@ export function getImportTaroSelfComponents (filePath, nodeModulesPath, outputDi
   return importTaroSelfComponents
 }
 
+export function getImportCustomComponents(outputDir, depComponents) {
+  const importCustomComponents = new Set();
+  depComponents.forEach(item => {
+      const extnamePath = item.path.replace(path.extname(item.path), '')
+      const cRelativePath = path.relative(path.join(outputDir, 'index'), extnamePath).replace(/\\/g, '/')
+      importCustomComponents.add({
+          path: cRelativePath,
+          name: item.name
+      })
+  })
+  return importCustomComponents;
+}
+
 export function generateQuickAppUx ({
   script,
   template,


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
对快应用自定义组件调用进行特殊处理，将持绝对路径转换为相对路径，修复issue:https://github.com/NervJS/taro/issues/5094


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [ ] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [x] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
