### PR TITLE
fix(taro-alipay): 兼容支付宝和微信 request 回调函数

### DIFF
--- a/packages/taro-alipay/src/native-api.js
+++ b/packages/taro-alipay/src/native-api.js
@@ -219,22 +219,42 @@ function request (options) {
   const originSuccess = options['success']
   const originFail = options['fail']
   const originComplete = options['complete']
-  let requestTask
+  let requestTask, completeRes
   const p = new Promise((resolve, reject) => {
     options['success'] = res => {
       res.statusCode = res.status
       delete res.status
       res.header = res.headers
       delete res.headers
+      res.errMsg = 'request:ok'
+      // 避免支付宝complete回调参数为undefined
+      completeRes = res
       originSuccess && originSuccess(res)
       resolve(res)
     }
     options['fail'] = res => {
-      originFail && originFail(res)
-      reject(res)
+      // 将支付宝fail code(11: 无权跨域, 19: HTTP错误) 转为success回调 和微信保持一致
+      if (res.error && [11, 19].indexOf(res.error) !== -1) {
+        res.statusCode = res.status
+        delete res.status
+        res.header = res.headers
+        delete res.headers
+        res.errMsg = 'request:ok'
+        delete res.error
+        delete res.errorMessage
+        // 避免支付宝complete回调参数为undefined
+        completeRes = res
+        originSuccess && originSuccess(res)
+        resolve(res)
+      } else {
+        originFail && originFail(res)
+        reject(res)
+      }
     }
 
     options['complete'] = res => {
+      // 避免res为undefined
+      res = res || completeRes
       originComplete && originComplete(res)
     }
 


### PR DESCRIPTION
解决支付宝 request 与微信 success 回调不一致， 解决request complete 回调参数为undefined

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
1. 修复了支付宝 request success与微信不一致，将支付宝 fail 回调code（11：无权跨域， 19：HTTP错误）转为 success 回调
2. 避免支付宝 request complete 回调参数为 undefined


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [x] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
