### PR TITLE
修复RN下使用sass.resource配置后报错的问题

### DIFF
--- a/packages/taro-plugin-sass/index.js
+++ b/packages/taro-plugin-sass/index.js
@@ -50,7 +50,7 @@ module.exports = function compileSass (content, file, config) {
 
     const opts = Object.assign({}, config, {
       file,
-      data: bundledContent ? bundledContent + content : content
+      data: bundledContent ? bundledContent + (content ? content : '') : content
     })
 
     let result


### PR DESCRIPTION
关联issue： https://github.com/NervJS/taro/issues/5110

**这个 PR 做了什么?** (简要描述所做更改)

taro-rn，如果配置中使用了 sass.resource，会有 Error: Invalid CSS after "null": expected "{", was "" 这种报错，经排查，发现是因为一个变量传入为null，然后当做字符串合并导致。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #5110
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
