### PR TITLE
fix(taro-mini-runner): 修复引入lodash.xxx时候报错的问题

### DIFF
--- a/packages/taro-mini-runner/src/utils/constants.ts
+++ b/packages/taro-mini-runner/src/utils/constants.ts
@@ -305,3 +305,5 @@ export const processTypeMap: IProcessTypeMap = {
 }
 
 export const excludeReplaceTaroFrameworkPkgs = new Set([taroJsRedux, taroJsMobx, taroJsMobxCommon])
+
+export const GLOBAL_PROPS = '{Function,Boolean,Object,Number,Array,Date,String,Symbol,Error,TypeError,Map,Set,WeakMap,WeakSet,ArrayBuffer,Math,Promise,RegExp,DataView,isFinite,parseInt,parseFloat,Float32Array,Float64Array,Int8Array,Int16Array,Int32Array,Uint8Array,Uint16Array,Uint32Array,Uint8ClampedArray,setTimeout,clearTimeout,setInterval,clearInterval}'

--- a/packages/taro-mini-runner/src/utils/index.ts
+++ b/packages/taro-mini-runner/src/utils/index.ts
@@ -246,8 +246,8 @@ export function removeHeadSlash (str: string) {
 
 export function npmCodeHack (filePath: string, content: string, buildAdapter: BUILD_TYPES): string {
   // 修正core-js目录 _global.js
-  // 修正所有用到过lodash的第三方包,包括@tarojs/taro-alipay/dist/index.js,@tarojs/taro/dist/index.esm.js等
-  // 注：
+  // 修正所有用到过lodash的第三方包
+  // 注：@tarojs/taro-alipay/dist/index.js,@tarojs/taro/dist/index.esm.js里面也有lodash相关的代码
   content = content && content.replace(/(\|\||:)\s*Function\(['"]return this['"]\)\(\)/g, function (match, first, second) {
     return `${first} ${GLOBAL_PROPS}`
   })

--- a/packages/taro-mini-runner/src/utils/index.ts
+++ b/packages/taro-mini-runner/src/utils/index.ts
@@ -13,7 +13,8 @@ import {
   NODE_MODULES_REG,
   processTypeMap,
   processTypeEnum,
-  BUILD_TYPES
+  BUILD_TYPES,
+  GLOBAL_PROPS
 } from './constants'
 import { IOption, IComponentObj } from './types'
 
@@ -244,17 +245,15 @@ export function removeHeadSlash (str: string) {
 }
 
 export function npmCodeHack (filePath: string, content: string, buildAdapter: BUILD_TYPES): string {
+  // 修正core-js目录 _global.js
+  // 修正所有用到过lodash的第三方包,包括@tarojs/taro-alipay/dist/index.js,@tarojs/taro/dist/index.esm.js等
+  // 注：
+  content = content && content.replace(/(\|\||:)\s*Function\(['"]return this['"]\)\(\)/g, function (match, first, second) {
+    return `${first} ${GLOBAL_PROPS}`
+  })
+
   const basename = path.basename(filePath)
   switch (basename) {
-    case 'lodash.js':
-    case '_global.js':
-    case 'lodash.min.js':
-      if (buildAdapter === BUILD_TYPES.ALIPAY || buildAdapter === BUILD_TYPES.SWAN || buildAdapter === BUILD_TYPES.JD) {
-        content = content.replace(/Function\(['"]return this['"]\)\(\)/, '{}')
-      } else {
-        content = content.replace(/Function\(['"]return this['"]\)\(\)/, 'this')
-      }
-      break
     case 'mobx.js':
       // 解决支付宝小程序全局window或global不存在的问题
       content = content.replace(


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

fix(taro-mini-runner): 修复引入lodash.xxx时候报错的问题
报错原因：Function('return this')() 返回的结果是空的，导致root.Date.now()等报错，如果用到其他对象比如String,Array,Map等也会出错

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #5421 
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
这个PR只更新了编译器相关的代码
这个PR是针对2.x版本的taro-mini-runner包的更新，master不存在该包