### PR TITLE
fix(taro-mini-runner): 修复postcss中url配置不生效的bug

### DIFF
--- a/packages/taro-mini-runner/src/webpack/chain.ts
+++ b/packages/taro-mini-runner/src/webpack/chain.ts
@@ -78,6 +78,13 @@ const defaultCssModuleOption: PostcssOption.cssModules = {
   }
 }
 
+const defaultUrlOption: PostcssOption.url = {
+  enable: true,
+  config: {
+    limit: 10240 // limit 10k base on document
+  }
+}
+
 const staticDirectory = 'static'
 
 const getLoader = (loaderName: string, options: IOption) => {
@@ -287,6 +294,12 @@ export const getModule = (appPath: string, {
     })
   }
 
+  const urlOptions: PostcssOption.url = recursiveMerge({}, defaultUrlOption, postcssOption.url)
+  let postcssUrlOption;
+  if (urlOptions.enable) {
+    postcssUrlOption = urlOptions.config;
+  }
+
   function addCssLoader (cssLoaders, loader) {
     const cssLoadersCopy = cloneDeep(cssLoaders)
     cssLoadersCopy.forEach(item => {
@@ -356,6 +369,7 @@ export const getModule = (appPath: string, {
       use: {
         urlLoader: getUrlLoader([defaultMediaUrlLoaderOption, {
           name: `${staticDirectory}/media/[name].[ext]`,
+          ...(postcssUrlOption || {}),
           ...mediaUrlLoaderOption
         }])
       }
@@ -365,6 +379,7 @@ export const getModule = (appPath: string, {
       use: {
         urlLoader: getUrlLoader([defaultFontUrlLoaderOption, {
           name: `${staticDirectory}/fonts/[name].[ext]`,
+          ...(postcssUrlOption || {}),
           ...fontUrlLoaderOption
         }])
       }
@@ -374,6 +389,7 @@ export const getModule = (appPath: string, {
       use: {
         urlLoader: getUrlLoader([defaultImageUrlLoaderOption, {
           name: `${staticDirectory}/images/[name].[ext]`,
+          ...(postcssUrlOption || {}),
           ...imageUrlLoaderOption
         }])
       }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

v3.0.0-alpha.3版本，小程序的配置中postcss的url配置不生效，
且默认配置和文档中描述的 `limit: 10240` 不一致

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #5488
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
