### PR TITLE
feat(taro-router): 新增路由拦截功能beforeRouteLeave

### DIFF
--- a/packages/taro-mobx-h5/src/inject.js
+++ b/packages/taro-mobx-h5/src/inject.js
@@ -35,6 +35,15 @@ function createStoreInjector (grabStoresFn, injectNames, sourceComponent) {
         componentDidHide.call(this.__observeInstance)
       }
     }
+
+    beforeRouteLeave (from, to, next) {
+      const { beforeRouteLeave } = sourceComponent.prototype
+      if (typeof beforeRouteLeave === 'function') {
+        beforeRouteLeave.call(this.__observeInstance, ...arguments)
+      } else {
+        next(true)
+      }
+    }
   }
 
   return Injector

--- a/packages/taro-redux-h5/react-redux/components/connectAdvanced.js
+++ b/packages/taro-redux-h5/react-redux/components/connectAdvanced.js
@@ -211,6 +211,14 @@ export default function connectAdvanced(
         tryToCall(this.wrappedInstance.componentDidHide, this.wrappedInstance)
       }
 
+      beforeRouteLeave (from, to, next) {
+        if (this.wrappedInstance && typeof this.wrappedInstance.beforeRouteLeave === 'function') {
+          tryToCall(this.wrappedInstance.beforeRouteLeave, this.wrappedInstance, ...arguments)
+        } else {
+          next(true)
+        }
+      }
+
       getWrappedInstance() {
         invariant(withRef,
           `To access the wrapped instance, you need to specify ` +

--- a/packages/taro-router/src/history/createHistory.ts
+++ b/packages/taro-router/src/history/createHistory.ts
@@ -6,6 +6,7 @@ import { Action, History, HistoryState, Location, CustomRoutes } from '../utils/
 import createTransitionManager from './createTransitionManager';
 import { createLocation } from './LocationUtils';
 import { addLeadingSlash, createPath, hasBasename, stripBasename, stripTrailingSlash } from './PathUtils';
+import { tryToCall } from '../utils'
 
 const PopStateEvent = 'popstate'
 const defaultStoreKey = 'taroRouterStore'
@@ -80,6 +81,7 @@ const createHistorySerializer = (storeObj: HistoryState) => {
 
 const createHistory = (props: { basename?: string, mode: "hash" | "browser" | "multi", firstPagePath: string, customRoutes: CustomRoutes }) => {
   const transitionManager = createTransitionManager()
+  transitionManager.setPrompt('')
   const basename = props.basename ? stripTrailingSlash(addLeadingSlash(props.basename)) : ''
   const customRoutes = props.customRoutes || {}
   let listenerCount = 0
@@ -146,6 +148,27 @@ const createHistory = (props: { basename?: string, mode: "hash" | "browser" | "m
     transitionManager.notifyListeners({...params})
   }
 
+  function getCurrentRoute() {
+    if (Taro && typeof Taro.getCurrentPages === 'function') {
+      const currentPageStack = Taro.getCurrentPages()
+      const stackTop = currentPageStack.length - 1
+      return currentPageStack[stackTop]
+    }
+    
+    return {}
+  }
+
+  function getUserConfirmation(next, fromLocation, toLocation) {
+    const currentRoute = getCurrentRoute()
+    const leaveHook = currentRoute.beforeRouteLeave
+
+    if (typeof leaveHook === 'function') {
+      tryToCall(leaveHook, currentRoute, fromLocation, toLocation, next)
+    } else {
+      next(true)
+    }
+  }
+
   const push = (path: string) => {
     const action = 'PUSH'
     const key = createKey()
@@ -155,13 +178,27 @@ const createHistory = (props: { basename?: string, mode: "hash" | "browser" | "m
       location.path = customRoutes[originalPath]
     }
 
-    const href = createHref(location)
+    transitionManager.confirmTransitionTo(
+      location,
+      action,
+      (result, callback) => {
+        getUserConfirmation(callback, lastLocation, location)
+      },
+      ok => {
+        if (!ok) {
+          stateKey--
+          return
+        }
 
-    globalHistory.pushState({ key }, '', href)
+        const href = createHref(location)
 
-    store.key = key!
-
-    setState({ action, location })
+        globalHistory.pushState({ key }, '', href)
+    
+        store.key = key!
+    
+        setState({ action, location })
+      }
+    )
   }
 
   const replace = (path: string) => {
@@ -173,11 +210,22 @@ const createHistory = (props: { basename?: string, mode: "hash" | "browser" | "m
       location.path = customRoutes[originalPath]
     }
 
-    const href = createHref(location)
+    transitionManager.confirmTransitionTo(
+      location,
+      action,
+      (result, callback) => {
+        getUserConfirmation(callback, lastLocation, location)
+      },
+      ok => {
+        if (!ok) return
 
-    globalHistory.replaceState({ key }, '', href)
+        const href = createHref(location)
 
-    setState({ action, location })
+        globalHistory.replaceState({ key }, '', href)
+    
+        setState({ action, location })
+      }
+    )
   }
 
   const go = (num: number) => {
@@ -212,7 +260,36 @@ const createHistory = (props: { basename?: string, mode: "hash" | "browser" | "m
     }
 
     store.key = String(nextKey)
-    setState({ action, location: nextLocation })
+
+    transitionManager.confirmTransitionTo(
+      nextLocation,
+      action,
+      (result, callback) => {
+        getUserConfirmation(callback, lastLocation, nextLocation)
+      },
+      ok => {
+        if (ok) {
+          setState({
+            action,
+            location: nextLocation
+          })
+        } else {
+          revertPop(nextLocation)
+        }
+      }
+    )
+  }
+
+  const revertPop = fromLocation => {
+    const toLocation = history.location
+
+    const key = toLocation.state.key
+
+    const location = createLocation(toLocation.path, key, fromLocation)
+
+    const href = createHref(location)
+
+    globalHistory.pushState({ key }, '', href)
   }
 
   const checkDOMListeners = delta => {

--- a/packages/taro-router/src/history/createHistory.ts
+++ b/packages/taro-router/src/history/createHistory.ts
@@ -8,6 +8,9 @@ import { createLocation } from './LocationUtils';
 import { addLeadingSlash, createPath, hasBasename, stripBasename, stripTrailingSlash } from './PathUtils';
 import { tryToCall } from '../utils'
 
+type Callback = (ok: boolean) => void
+type CurrentRoute = Taro.Page | { beforeRouteLeave?: Function }
+
 const PopStateEvent = 'popstate'
 const defaultStoreKey = 'taroRouterStore'
 
@@ -148,7 +151,7 @@ const createHistory = (props: { basename?: string, mode: "hash" | "browser" | "m
     transitionManager.notifyListeners({...params})
   }
 
-  function getCurrentRoute() {
+  function getCurrentRoute(): CurrentRoute {
     if (Taro && typeof Taro.getCurrentPages === 'function') {
       const currentPageStack = Taro.getCurrentPages()
       const stackTop = currentPageStack.length - 1
@@ -158,7 +161,7 @@ const createHistory = (props: { basename?: string, mode: "hash" | "browser" | "m
     return {}
   }
 
-  function getUserConfirmation(next, fromLocation, toLocation) {
+  function getUserConfirmation(next: Callback, fromLocation: Location, toLocation: Location): void {
     const currentRoute = getCurrentRoute()
     const leaveHook = currentRoute.beforeRouteLeave
 
@@ -280,7 +283,7 @@ const createHistory = (props: { basename?: string, mode: "hash" | "browser" | "m
     )
   }
 
-  const revertPop = fromLocation => {
+  const revertPop = (fromLocation: Location): void => {
     const toLocation = history.location
 
     const key = toLocation.state.key

--- a/packages/taro-router/src/router/route.tsx
+++ b/packages/taro-router/src/router/route.tsx
@@ -61,8 +61,10 @@ class Route extends Taro.Component<RouteProps, {}> {
   }
 
   getRef = ref => {
-    if (ref) this.componentRef = ref
-    this.props.collectComponent(ref, this.props.k)
+    if (ref) {
+      this.componentRef = ref
+      this.props.collectComponent(ref, this.props.k)
+    }
   }
 
   updateComponent (props = this.props) {

--- a/packages/taro-router/src/router/router.tsx
+++ b/packages/taro-router/src/router/router.tsx
@@ -147,8 +147,8 @@ class Router extends Taro.Component<Props, State> {
     }
   }
 
-  componentWillUpdate () {
-    this.currentPages.length = this.state.routeStack.length
+  componentWillUpdate (nextProps, nextState) {
+    this.currentPages.length = nextState.routeStack.length
   }
 
   componentWillUnmount () {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

新增页面级别的路由拦截功能 beforeRouteLeave，只有在页面中声明该拦截函数，页面才具有路由拦截功能，否则页面不具有拦截功能，该函数有三个参数分别为**from**，**to**，**next**
- from：表示从哪个Location离开
- to：表示要跳转到哪个Location
- next: 函数，其入参为boolean；next(true)，表示继续跳转下一个页面，next(false)表示路由跳转终止
  
使用方式如下：
```js
import Taro, { Component } from '@tarojs/taro'
import { View, Button } from '@tarojs/components'

export default class Index extends Component {

  beforeRouteLeave(from, to, next) {
    Taro.showModal({
      title: '确定离开吗'
    }).then((res) => {
      if (res.confirm) {
        next(true);
      }

      if (res.cancel) {
        next(false);
      }
    })
  }

  render () {
    return (
      <View>
        <Button onClick={() => {
          Taro.navigateBack();
        }}>返回</Button>
      </View>
    )
  }
}
```

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
