### PR TITLE
H5修复chooseVideo生成的blob对象缺少类型的问题

### DIFF
--- a/packages/taro-h5/src/api/video/index.js
+++ b/packages/taro-h5/src/api/video/index.js
@@ -62,7 +62,9 @@ export function chooseVideo (options) {
   taroChooseVideo.onchange = function (e) {
     let arr = [...e.target.files]
     arr && arr.forEach(item => {
-      let blob = new Blob([item])
+      let blob = new Blob([item], {
+        type: item.type
+      })
       let url = URL.createObjectURL(blob)
       res.tempFilePaths.push(url)
       res.tempFiles.push({path: url, size: item.size, type: item.type})


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
H5修复chooseVideo生成的blob对象缺少类型的问题


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #5366
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
