### PR TITLE
feat(taro-h5): add capture attribute support for chooseImage api when…

### DIFF
--- a/packages/taro-h5/src/api/image/chooseImage.js
+++ b/packages/taro-h5/src/api/image/chooseImage.js
@@ -3,7 +3,7 @@ import { shouleBeObject, getParameterError } from '../utils'
 /**
  * 从本地相册选择图片或使用相机拍照。
  * @param {Object} object 参数
- * @param {string[]} [object.sourceType=['album', 'camera']] 选择图片的来源（h5端未实现）
+ * @param {string[]} [object.sourceType=['album', 'camera']] 选择图片的来源，h5允许传入 `user`
  * @param {string[]} [object.sizeType=['original', 'compressed']] 所选的图片的尺寸（h5端未实现）
  * @param {number} [object.count=9] 最多可以选择的图片张数
  * @param {function} [object.success] 接口调用成功的回调函数
@@ -20,7 +20,7 @@ const chooseImage = function (options) {
     return Promise.reject(res)
   }
 
-  const { count = 1, success, fail, complete, imageId = 'taroChooseImage' } = options
+  const { count = 1, success, fail, complete, imageId = 'taroChooseImage', sourceType = ['album', 'camera'] } = options
   const res = {
     errMsg: 'chooseImage:ok',
     tempFilePaths: [],
@@ -43,10 +43,15 @@ const chooseImage = function (options) {
   let taroChooseImageId = document.getElementById(imageId)
   if (!taroChooseImageId) {
     let obj = document.createElement('input')
+    const sourceTypeString = sourceType && sourceType.toString()
+    const acceptableSourceType = ['user', 'environment', 'camera']
     obj.setAttribute('type', 'file')
     obj.setAttribute('id', imageId)
     if (count > 1) {
       obj.setAttribute('multiple', 'multiple')
+    }
+    if (acceptableSourceType.indexOf(sourceTypeString) > -1) {
+      obj.setAttribute('capture', sourceTypeString)
     }
     obj.setAttribute('accept', 'image/*')
     obj.setAttribute('style', 'position: fixed; top: -4000px; left: -3000px; z-index: -300;')

--- a/packages/taro-h5/src/api/image/chooseImage.js
+++ b/packages/taro-h5/src/api/image/chooseImage.js
@@ -3,7 +3,7 @@ import { shouleBeObject, getParameterError } from '../utils'
 /**
  * 从本地相册选择图片或使用相机拍照。
  * @param {Object} object 参数
- * @param {string[]} [object.sourceType=['album', 'camera']] 选择图片的来源，h5允许传入 `user`
+ * @param {string[]} [object.sourceType=['album', 'camera']] 选择图片的来源，h5允许传入 `user/environment/camera/`
  * @param {string[]} [object.sizeType=['original', 'compressed']] 所选的图片的尺寸（h5端未实现）
  * @param {number} [object.count=9] 最多可以选择的图片张数
  * @param {function} [object.success] 接口调用成功的回调函数

--- a/packages/taro/types/api/media/image.d.ts
+++ b/packages/taro/types/api/media/image.d.ts
@@ -152,6 +152,10 @@ declare namespace Taro {
       album
       /** 使用相机 */
       camera
+      /** 使用前置摄像头(仅H5纯浏览器使用) */
+      user
+      /** 使用后置摄像头(仅H5纯浏览器) */
+      environment
     }
     interface SuccessCallbackResult extends General.CallbackResult {
       /** 图片的本地临时文件路径列表 */
@@ -185,7 +189,7 @@ declare namespace Taro {
    * Taro.chooseImage({
    *   count: 1, // 默认9
    *   sizeType: ['original', 'compressed'], // 可以指定是原图还是压缩图，默认二者都有
-   *   sourceType: ['album', 'camera'], // 可以指定来源是相册还是相机，默认二者都有
+   *   sourceType: ['album', 'camera'], // 可以指定来源是相册还是相机，默认二者都有，在H5浏览器端支持使用 `user` 和 `environment`分别指定为前后摄像头
    *   success: function (res) {
    *     // 返回选定照片的本地文件路径列表，tempFilePath可以作为img标签的src属性显示图片
    *     var tempFilePaths = res.tempFilePaths


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

1. 添加taro-h5 的 chooseImage  api 在传入 sourceType 为 `camera` 、`user` 、`environment` 属性时，在浏览器端添加 capture属性设置的支持

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
