### PR TITLE
fix(taro-cli): 修复基于taro第三方ui 组件循环依赖时打包失败 Closes #5620

### DIFF
--- a/packages/taro-cli/src/ui/common.ts
+++ b/packages/taro-cli/src/ui/common.ts
@@ -216,7 +216,7 @@ export function copyFileToDist (filePath: string, sourceDir: string, outputDir: 
   }))
 }
 
-export function analyzeFiles (files: string[], sourceDir: string, outputDir: string, buildData: IBuildData) {
+function _analyzeFiles(files: string[], sourceDir: string, outputDir: string, buildData: IBuildData){
   files.forEach(file => {
     if (fs.existsSync(file)) {
       if (processedScriptFiles.has(file)) {
@@ -246,13 +246,17 @@ export function analyzeFiles (files: string[], sourceDir: string, outputDir: str
         })
       }
       if (scriptFiles.length) {
-        analyzeFiles(scriptFiles, sourceDir, outputDir, buildData)
+        _analyzeFiles(scriptFiles, sourceDir, outputDir, buildData)
       }
       if (styleFiles.length) {
         analyzeStyleFilesImport(styleFiles, sourceDir, outputDir, buildData)
       }
     }
   })
+}
+
+export function analyzeFiles (files: string[], sourceDir: string, outputDir: string, buildData: IBuildData) {
+  _analyzeFiles(files, sourceDir, outputDir, buildData)
   processedScriptFiles = new Set()
 }
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复基于taro第三方ui 组件循环依赖时打包失败
原因是analyzeFiles函数在递归调用时提前清空processedScriptFiles集合的问题


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
