### PR TITLE
fix(runtime): 修复小程序跳转同一路由时，事件通知处理有误

### DIFF
--- a/packages/taro-runtime/src/dsl/common.ts
+++ b/packages/taro-runtime/src/dsl/common.ts
@@ -73,7 +73,7 @@ function stringify (obj?: Record<string, unknown>) {
   }).join('&')
 }
 
-function getPath(id, options) {
+function getPath(id:string, options?: Record<string, unknown>): string {
   let path = id
   if (!isBrowser) {
     path = id + stringify(options)

--- a/packages/taro-runtime/src/dsl/common.ts
+++ b/packages/taro-runtime/src/dsl/common.ts
@@ -31,8 +31,10 @@ function addLeadingSlash (path?: string) {
 
 const pageId = incrementId()
 
-function safeExecute (instance: Instance, lifecycle: keyof PageInstance, ...args: unknown[]) {
+function safeExecute (path: string, lifecycle: keyof PageInstance, ...args: unknown[]) {
   const isReact = process.env.FRAMEWORK !== 'vue' // isReact means all kind of react-like library
+
+  const instance = instances.get(path)
 
   if (instance == null) {
     return
@@ -71,11 +73,18 @@ function stringify (obj?: Record<string, unknown>) {
   }).join('&')
 }
 
+function getPath(id, options) {
+  let path = id
+  if (!isBrowser) {
+    path = id + stringify(options)
+  }
+  return path
+}
+
 export function createPageConfig (component: React.ComponentClass, pageName?: string, data?: Record<string, unknown>) {
   const id = pageName ?? `taro_page_${pageId()}`
   // 小程序 Page 构造器是一个傲娇小公主，不能把复杂的对象挂载到参数上
   let pageElement: TaroRootElement | null = null
-  let instance: Instance = instances.get(id)!
 
   const config: PageInstance = {
     onLoad (this: MpInstance, options, cb?: Function) {
@@ -86,18 +95,13 @@ export function createPageConfig (component: React.ComponentClass, pageName?: st
 
       perf.start(PAGE_INIT)
 
-      let path = id
-
-      if (!isBrowser) {
-        path = id + stringify(options)
-      }
+      const path = getPath(id, options)
 
       Current.app!.mount(component, path, () => {
         pageElement = document.getElementById<TaroRootElement>(path)
-        instance = instances.get(path) || EMPTY_OBJ
 
         ensure(pageElement !== null, '没有找到页面实例。')
-        safeExecute(instance, 'onLoad', options)
+        safeExecute(path, 'onLoad', options)
         if (!isBrowser) {
           pageElement.ctx = this
           pageElement.performUpdate(true, cb)
@@ -113,21 +117,26 @@ export function createPageConfig (component: React.ComponentClass, pageName?: st
     },
     onShow () {
       Current.page = this as any
-      safeExecute(instance, 'onShow')
+      const path = getPath(id, this.options)
+      safeExecute(path, 'onShow')
     },
     onHide () {
       Current.page = null
       Current.router = null
-      safeExecute(instance, 'onHide')
+      const path = getPath(id, this.options)
+      safeExecute(path, 'onHide')
     },
     onPullDownRefresh () {
-      return safeExecute(instance, 'onPullDownRefresh')
+      const path = getPath(id, this.options)
+      return safeExecute(path, 'onPullDownRefresh')
     },
     onReachBottom () {
-      return safeExecute(instance, 'onReachBottom')
+      const path = getPath(id, this.options)
+      return safeExecute(path, 'onReachBottom')
     },
     onPageScroll (options) {
-      return safeExecute(instance, 'onPageScroll', options)
+      const path = getPath(id, this.options)
+      return safeExecute(path, 'onPageScroll', options)
     },
     onShareAppMessage (options) {
       const target = options.target
@@ -138,25 +147,32 @@ export function createPageConfig (component: React.ComponentClass, pageName?: st
           options.target!.dataset = element.dataset
         }
       }
-      return safeExecute(instance, 'onShareAppMessage', options)
+      const path = getPath(id, this.options)
+      return safeExecute(path, 'onShareAppMessage', options)
     },
     onResize (options) {
-      return safeExecute(instance, 'onResize', options)
+      const path = getPath(id, this.options)
+      return safeExecute(path, 'onResize', options)
     },
     onTabItemTap (options) {
-      return safeExecute(instance, 'onTabItemTap', options)
+      const path = getPath(id, this.options)
+      return safeExecute(path, 'onTabItemTap', options)
     },
     onTitleClick () {
-      return safeExecute(instance, 'onTitleClick')
+      const path = getPath(id, this.options)
+      return safeExecute(path, 'onTitleClick')
     },
     onOptionMenuClick () {
-      return safeExecute(instance, 'onOptionMenuClick')
+      const path = getPath(id, this.options)
+      return safeExecute(path, 'onOptionMenuClick')
     },
     onPopMenuClick () {
-      return safeExecute(instance, 'onPopMenuClick')
+      const path = getPath(id, this.options)
+      return safeExecute(path, 'onPopMenuClick')
     },
     onPullIntercept () {
-      return safeExecute(instance, 'onPullIntercept')
+      const path = getPath(id, this.options)
+      return safeExecute(path, 'onPullIntercept')
     }
   }
 
@@ -176,16 +192,14 @@ export function createPageConfig (component: React.ComponentClass, pageName?: st
 export function createComponentConfig (component: React.ComponentClass, componentName?: string, data?: Record<string, unknown>) {
   const id = componentName ?? `taro_component_${pageId()}`
   let componentElement: TaroRootElement | null = null
-  let instance: Instance = instances.get(id)!
 
   const config: any = {
     attached () {
       perf.start(PAGE_INIT)
       Current.app!.mount(component, id, () => {
         componentElement = document.getElementById<TaroRootElement>(id)
-        instance = instances.get(id) || EMPTY_OBJ
         ensure(componentElement !== null, '没有找到组件实例。')
-        safeExecute(instance, 'onLoad')
+        safeExecute(id, 'onLoad')
         if (!isBrowser) {
           componentElement.ctx = this
           componentElement.performUpdate(true)
@@ -201,10 +215,10 @@ export function createComponentConfig (component: React.ComponentClass, componen
     },
     pageLifetimes: {
       show () {
-        safeExecute(instance, 'onShow')
+        safeExecute(id, 'onShow')
       },
       hide () {
-        safeExecute(instance, 'onHide')
+        safeExecute(id, 'onHide')
       }
     },
     methods: {

--- a/packages/taro-runtime/src/dsl/instance.ts
+++ b/packages/taro-runtime/src/dsl/instance.ts
@@ -54,6 +54,7 @@ export interface PageLifeCycle extends Show {
 export interface PageInstance extends PageLifeCycle {
   data?: Record<string, unknown>
   path?: string
+  options?: Record<string, unknown>
 }
 
 interface Show {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

[小程序允许反复跳转同一路由](https://github.com/NervJS/taro/commit/93188261f339593247c16270426fcc2a71cf5a6a)，这个fix 方式，应该还是有点bug。

由于「小程序允许反复跳转同一路由」，事实上现在会对应多个实例。因为 [instance](https://github.com/NervJS/taro/blob/next/packages/taro-runtime/src/dsl/common.ts#L78) 只有在[onLoad](https://github.com/NervJS/taro/blob/next/packages/taro-runtime/src/dsl/common.ts#L97)时候才会重新赋值，会导致同一个路由下的`safeExecute `这些事件永远只通知了最后一个（也就是最后onLoad那个）

我主要修改了下获取实例的方式。不知道满不满足你的设计思路

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
