### PR TITLE
fix: 函数名错误

### DIFF
--- a/packages/taro-components/src/components/swiper/index.js
+++ b/packages/taro-components/src/components/swiper/index.js
@@ -45,7 +45,7 @@ class Swiper extends Nerv.Component {
       onChange,
       circular,
       vertical,
-      onAnimationfinish,
+      onAnimationFinish,
       spaceBetween
     } = this.props
 
@@ -83,7 +83,7 @@ class Swiper extends Nerv.Component {
               }
             })
           } catch (err) {}
-          onAnimationfinish && onAnimationfinish(e)
+          onAnimationFinish && onAnimationFinish(e)
         }
       }
     }


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
    在官方文档和 types/Swiper.d.ts 中用的都是 onAnimationFinish，而在 swiper/index.js 中为 onAnimationfinish ，类型推断错误


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
