### PR TITLE
fix: 同步ReactNative与微信的网络请求参数

### DIFF
--- a/packages/taro-rn/src/__tests__/request.test.js
+++ b/packages/taro-rn/src/__tests__/request.test.js
@@ -57,6 +57,23 @@ describe('request', () => {
       expect(res.data).toMatch(expectData)
     })
 
+    it('RN请求入参同于微信小程序', () => {
+      const url = 'https://test.taro.com/v1'
+      const expectData = JSON.stringify({ data: 'calorie' })
+      const options = {
+        url,
+        responseType: 'json',
+        complete: (res) => {
+        },
+        success: (res) => {
+          expect(JSON.stringify(res.data)).toMatch(expectData)
+        },
+        fail: (res) => {
+        }
+      }
+      Taro.request(options)
+    })
+
     test('数据被序列化', async () => {
       const fetch = jest.fn((url, params) => {
         return new Promise((resolve, reject) => {

--- a/packages/taro-rn/src/api/request/index.js
+++ b/packages/taro-rn/src/api/request/index.js
@@ -50,27 +50,45 @@ function request (options) {
   params.credentials = options.credentials
   params.cache = options.cache
   params.method = method
-  return fetch(url, params)
-    .then(response => {
-      res.statusCode = response.status
-      res.header = response.headers
-      if (options.dataType === 'json') {
-        return response.json()
-      }
-      if (options.responseType === 'arraybuffer') {
-        return response.arrayBuffer()
-      }
-      if (options.responseType === 'text') {
-        return response.text()
-      }
-      if (typeof options.dataType === 'undefined') {
-        return response.json()
-      }
-      return Promise.resolve(null)
-    }).then(data => {
-      res.data = data
-      return res
-    })
+  const originSuccess = options.success
+  const originFail = options.fail
+  const originComplete = options.complete
+  let completeRes
+  const p = new Promise((resolve, reject) => {
+    fetch(url, params)
+      .then(response => {
+        res.statusCode = response.status
+        res.header = response.headers
+        if (options.dataType === 'json') {
+          return response.json()
+        }
+        if (options.responseType === 'arraybuffer') {
+          return response.arrayBuffer()
+        }
+        if (options.responseType === 'text') {
+          return response.text()
+        }
+        if (typeof options.dataType === 'undefined') {
+          return response.json()
+        }
+        return Promise.resolve(null)
+      })
+      .then(resData => {
+        res.data = resData
+        completeRes = Object.assign({}, res)
+        originSuccess && originSuccess(res)
+        resolve(res)
+      })
+      .catch(error => {
+        completeRes = Object.assign({}, error)
+        originFail && originFail(error)
+        reject(error)
+      })
+      .finally(() => {
+        originComplete && originComplete(completeRes)
+      })
+  })
+  return p
 }
 
 export default {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

此PR用于修复同步ReactNative与微信的网络请求参数，例如有下面一段代码：

```
  return new Promise((resolve) => {
    const complete = (result) => {
      const networkErrorCode = 600
      formatResult = {
        ...handleData(result.data || {}, result.statusCode || networkErrorCode),
        header: result.header || {},
        status: result.statusCode || networkErrorCode
      }
      handleTips(tips, formatResult)
      if (formatResult.code !== 0) {
        errorReport.api({ code: formatResult.code, msg: formatResult.msg, url: newUrl, params: data })
      }
      resolve(formatResult)
    }
    // @ts-ignore
    Taro.request({ ...opt, complete })
  })
```
此种写法在微信、支付宝小程序可以正常运行，但是无法在ReactNative上正常运行，原因是ReactNative没有接收complete等参数。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
