### PR TITLE
fix: 修复 App 的 config 为静态属性时获取不到 config 对象的问题

### DIFF
--- a/packages/taro-mini-runner/src/utils/parseAst.ts
+++ b/packages/taro-mini-runner/src/utils/parseAst.ts
@@ -155,7 +155,10 @@ export default function parseAst (
       const node = astPath.node
       const left = node.left
       if (t.isMemberExpression(left) && t.isIdentifier(left.object)) {
-        if (left.object.name === componentClassName
+        // 当 App 的 config 为静态属性(static prop)时,
+        // componentClassName(_App) 与 left.object.name(App)
+        // 不匹配, 造成获取不到 config 对象的问题
+        if ((left.object.name === componentClassName || left.object.name === 'App')
             && t.isIdentifier(left.property)
             && left.property.name === 'config') {
           configObj = traverseObjectNode(node.right, buildAdapter)


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

当 App 的 config 为静态属性(static prop)时，componentClassName(_App) 与 left.object.name(App)不匹配，造成获取不到 config 对象的问题。

```diff
class App extends Taro.Component {
+  public static config: Taro.Config = {
-  public config: Taro.Config = {
    pages: [
      'pages/index/index'
    ],
    window: {
      backgroundTextStyle: 'light',
      navigationBarBackgroundColor: '#fff',
      navigationBarTitleText: 'WeChat',
      navigationBarTextStyle: 'black'
    }
  }

  public render(): JSX.Element {
    return (
      <Index />
    )
  }
}
```

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 2.x 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
