### PR TITLE
Fix/ios 10.x style operate

### DIFF
--- a/packages/taro-h5/src/api/utils/index.js
+++ b/packages/taro-h5/src/api/utils/index.js
@@ -1,4 +1,4 @@
-function shouleBeObject(target) {
+function shouleBeObject (target) {
   if (target && typeof target === 'object') return { res: true }
   return {
     res: false,
@@ -9,19 +9,19 @@ function shouleBeObject(target) {
   }
 }
 
-function getParameterError({ name = '', para, correct, wrong }) {
+function getParameterError ({ name = '', para, correct, wrong }) {
   const parameter = para ? `parameter.${para}` : 'parameter'
   const errorType = upperCaseFirstLetter(wrong === null ? 'Null' : typeof wrong)
   return `${name}:fail parameter error: ${parameter} should be ${correct} instead of ${errorType}`
 }
 
-function upperCaseFirstLetter(string) {
+function upperCaseFirstLetter (string) {
   if (typeof string !== 'string') return string
   string = string.replace(/^./, match => match.toUpperCase())
   return string
 }
 
-function inlineStyle(style) {
+function inlineStyle (style) {
   let res = ''
   for (let attr in style) res += `${attr}: ${style[attr]};`
   if (res.indexOf('display: flex;') >= 0) res += 'display: -webkit-box;display: -webkit-flex;'
@@ -30,7 +30,7 @@ function inlineStyle(style) {
   return res
 }
 
-function setTransform(el, val) {
+function setTransform (el, val) {
   el.style.transform = val
   el.style.OTransform = val
   el.style.msTransform = val
@@ -38,11 +38,11 @@ function setTransform(el, val) {
   el.style.WebkitTransform = val
 }
 
-function isFunction(obj) {
+function isFunction (obj) {
   return typeof obj === 'function'
 }
 
-function successHandler(success, complete) {
+function successHandler (success, complete) {
   return function (res) {
     isFunction(success) && success(res)
     isFunction(complete) && complete(res)
@@ -50,7 +50,7 @@ function successHandler(success, complete) {
   }
 }
 
-function errorHandler(fail, complete) {
+function errorHandler (fail, complete) {
   return function (res) {
     isFunction(fail) && fail(res)
     isFunction(complete) && complete(res)
@@ -58,7 +58,7 @@ function errorHandler(fail, complete) {
   }
 }
 
-function serializeParams(params) {
+function serializeParams (params) {
   if (!params) {
     return ''
   }
@@ -70,7 +70,7 @@ function serializeParams(params) {
     .join('&')
 }
 
-function temporarilyNotSupport(apiName) {
+function temporarilyNotSupport (apiName) {
   return () => {
     const errMsg = `暂时不支持 API ${apiName}`
     console.error(errMsg)
@@ -80,7 +80,7 @@ function temporarilyNotSupport(apiName) {
   }
 }
 
-function weixinCorpSupport(apiName) {
+function weixinCorpSupport (apiName) {
   return () => {
     const errMsg = `h5端仅在微信公众号中支持 API ${apiName}`
     console.error(errMsg)
@@ -90,7 +90,7 @@ function weixinCorpSupport(apiName) {
   }
 }
 
-function permanentlyNotSupport(apiName) {
+function permanentlyNotSupport (apiName) {
   return () => {
     const errMsg = `不支持 API ${apiName}`
     console.error(errMsg)
@@ -193,7 +193,7 @@ const createScroller = () => {
   return { listen, unlisten, getPos, isReachBottom }
 }
 
-function processOpenapi(apiName, defaultOptions, formatResult = res => res, formatParams = options => options) {
+function processOpenapi (apiName, defaultOptions, formatResult = res => res, formatParams = options => options) {
   if (!window.wx) {
     return weixinCorpSupport(apiName)
   }
@@ -259,7 +259,7 @@ const bodyStatusClosure = (() => {
  *
  * @returns scrollTop
  */
-function getScrollTop() {
+function getScrollTop () {
   if (document.scrollingElement) {
     return document.scrollingElement.scrollTop
   } else {
@@ -273,7 +273,7 @@ function getScrollTop() {
  * for more info @see: https://www.zhangxinxu.com/wordpress/2019/02/document-scrollingelement/
  * @param scrollTop scrollTop which needs to be reset
  */
-function setScrollTop(scrollTop) {
+function setScrollTop (scrollTop) {
   if (document.scrollingElement) {
     document.scrollingElement.scrollTop = scrollTop
   } else {

--- a/packages/taro-h5/src/api/utils/index.js
+++ b/packages/taro-h5/src/api/utils/index.js
@@ -1,4 +1,4 @@
-function shouleBeObject (target) {
+function shouleBeObject(target) {
   if (target && typeof target === 'object') return { res: true }
   return {
     res: false,
@@ -9,19 +9,19 @@ function shouleBeObject (target) {
   }
 }
 
-function getParameterError ({ name = '', para, correct, wrong }) {
+function getParameterError({ name = '', para, correct, wrong }) {
   const parameter = para ? `parameter.${para}` : 'parameter'
   const errorType = upperCaseFirstLetter(wrong === null ? 'Null' : typeof wrong)
   return `${name}:fail parameter error: ${parameter} should be ${correct} instead of ${errorType}`
 }
 
-function upperCaseFirstLetter (string) {
+function upperCaseFirstLetter(string) {
   if (typeof string !== 'string') return string
   string = string.replace(/^./, match => match.toUpperCase())
   return string
 }
 
-function inlineStyle (style) {
+function inlineStyle(style) {
   let res = ''
   for (let attr in style) res += `${attr}: ${style[attr]};`
   if (res.indexOf('display: flex;') >= 0) res += 'display: -webkit-box;display: -webkit-flex;'
@@ -30,7 +30,7 @@ function inlineStyle (style) {
   return res
 }
 
-function setTransform (el, val) {
+function setTransform(el, val) {
   el.style.transform = val
   el.style.OTransform = val
   el.style.msTransform = val
@@ -38,11 +38,11 @@ function setTransform (el, val) {
   el.style.WebkitTransform = val
 }
 
-function isFunction (obj) {
+function isFunction(obj) {
   return typeof obj === 'function'
 }
 
-function successHandler (success, complete) {
+function successHandler(success, complete) {
   return function (res) {
     isFunction(success) && success(res)
     isFunction(complete) && complete(res)
@@ -50,7 +50,7 @@ function successHandler (success, complete) {
   }
 }
 
-function errorHandler (fail, complete) {
+function errorHandler(fail, complete) {
   return function (res) {
     isFunction(fail) && fail(res)
     isFunction(complete) && complete(res)
@@ -58,7 +58,7 @@ function errorHandler (fail, complete) {
   }
 }
 
-function serializeParams (params) {
+function serializeParams(params) {
   if (!params) {
     return ''
   }
@@ -70,7 +70,7 @@ function serializeParams (params) {
     .join('&')
 }
 
-function temporarilyNotSupport (apiName) {
+function temporarilyNotSupport(apiName) {
   return () => {
     const errMsg = `暂时不支持 API ${apiName}`
     console.error(errMsg)
@@ -80,7 +80,7 @@ function temporarilyNotSupport (apiName) {
   }
 }
 
-function weixinCorpSupport (apiName) {
+function weixinCorpSupport(apiName) {
   return () => {
     const errMsg = `h5端仅在微信公众号中支持 API ${apiName}`
     console.error(errMsg)
@@ -90,7 +90,7 @@ function weixinCorpSupport (apiName) {
   }
 }
 
-function permanentlyNotSupport (apiName) {
+function permanentlyNotSupport(apiName) {
   return () => {
     const errMsg = `不支持 API ${apiName}`
     console.error(errMsg)
@@ -193,7 +193,7 @@ const createScroller = () => {
   return { listen, unlisten, getPos, isReachBottom }
 }
 
-function processOpenapi (apiName, defaultOptions, formatResult = res => res, formatParams = options => options) {
+function processOpenapi(apiName, defaultOptions, formatResult = res => res, formatParams = options => options) {
   if (!window.wx) {
     return weixinCorpSupport(apiName)
   }
@@ -259,7 +259,7 @@ const bodyStatusClosure = (() => {
  *
  * @returns scrollTop
  */
-function getScrollTop () {
+function getScrollTop() {
   if (document.scrollingElement) {
     return document.scrollingElement.scrollTop
   } else {
@@ -273,7 +273,7 @@ function getScrollTop () {
  * for more info @see: https://www.zhangxinxu.com/wordpress/2019/02/document-scrollingelement/
  * @param scrollTop scrollTop which needs to be reset
  */
-function setScrollTop (scrollTop) {
+function setScrollTop(scrollTop) {
   if (document.scrollingElement) {
     document.scrollingElement.scrollTop = scrollTop
   } else {
@@ -302,7 +302,7 @@ const interactiveHelper = () => {
     },
     handleBeforeDestroy: () => {
       const bodyInlineStyle = bodyStatusClosure.getInlineStyle() || {}
-      document.body.style = bodyInlineStyle
+      document.body.setAttribute('style', bodyInlineStyle)
       setScrollTop(scrollTop)
     }
   }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

fix:  #5682 

taro-h5/api/utils.js handleBeforeDestroy()函数中
document.body.style = bodyInlineStyle报错（attempted to assign to readonly property） 中断了js的执行，导致hide toast等js代码没有执行。
ios 11以下，不支持直接操作style的方式，可以通过设置属性进行style，像这样：
document.body.setAttribute('style', bodyInlineStyle)

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #5682 
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
