### PR TITLE
feat(runtime): 支持 CSS Variables

### DIFF
--- a/packages/taro-react/src/props.ts
+++ b/packages/taro-react/src/props.ts
@@ -63,9 +63,7 @@ function setEvent (dom: TaroElement, name: string, value: unknown, oldValue?: un
 }
 
 function setStyle (style: Style, key: string, value: string | number) {
-  if (key.indexOf('--') === 0) {
-    style.setCssVariables(key)
-  }
+  style.setProperty(key, value.toString())
   style[key] =
     isNumber(value) && IS_NON_DIMENSIONAL.test(key) === false
       ? value + 'px'

--- a/packages/taro-react/src/props.ts
+++ b/packages/taro-react/src/props.ts
@@ -63,7 +63,10 @@ function setEvent (dom: TaroElement, name: string, value: unknown, oldValue?: un
 }
 
 function setStyle (style: Style, key: string, value: string | number) {
-  style.setProperty(key, value.toString())
+  if (key[0] === '-') {
+    style.setProperty(key, value.toString())
+  }
+
   style[key] =
     isNumber(value) && IS_NON_DIMENSIONAL.test(key) === false
       ? value + 'px'

--- a/packages/taro-react/src/props.ts
+++ b/packages/taro-react/src/props.ts
@@ -63,6 +63,9 @@ function setEvent (dom: TaroElement, name: string, value: unknown, oldValue?: un
 }
 
 function setStyle (style: Style, key: string, value: string | number) {
+  if (key.indexOf('--') === 0) {
+    style.setCssVariables(key)
+  }
   style[key] =
     isNumber(value) && IS_NON_DIMENSIONAL.test(key) === false
       ? value + 'px'

--- a/packages/taro-runtime/src/dom/style.ts
+++ b/packages/taro-runtime/src/dom/style.ts
@@ -107,8 +107,11 @@ export class Style {
   }
 
   public setProperty (propertyName: string, value?: string | null) {
-    this.setCssVariables(propertyName)
-    propertyName = toCamelCase(propertyName)
+    if (propertyName[0] === '-') {
+      this.setCssVariables(propertyName)
+    } else {
+      propertyName = toCamelCase(propertyName)
+    }
     if (isUndefined(value)) {
       return
     }

--- a/packages/taro-runtime/src/dom/style.ts
+++ b/packages/taro-runtime/src/dom/style.ts
@@ -3,7 +3,7 @@ import { styleProperties } from './style_properties'
 import { TaroElement } from './element'
 import { PROPERTY_THRESHOLD } from '../constants'
 
-function setStyle (newVal: string, styleKey: string) {
+function setStyle (this: Style, newVal: string, styleKey: string) {
   const old = this[styleKey]
   if (newVal) {
     this._usedStyleProp.add(styleKey)
@@ -33,7 +33,7 @@ function initStyle (ctor: typeof Style) {
         return this._value[styleKey] || ''
       },
       set (this: Style, newVal: string) {
-        setStyle.apply(this, [newVal, styleKey])
+        setStyle.call(this, newVal, styleKey)
       }
     }
   }
@@ -54,15 +54,15 @@ export class Style {
     this._value = {}
   }
 
-  public setCssVariables (styleKey: string) {
-    Reflect.has(this, styleKey) || Object.defineProperty(this, styleKey, {
+  private setCssVariables (styleKey: string) {
+    this.hasOwnProperty(styleKey) || Object.defineProperty(this, styleKey, {
       enumerable: true,
       configurable: true,
       get: () => {
         return this._value[styleKey] || ''
       },
       set: (newVal: string) => {
-        setStyle.apply(this, [newVal, styleKey])
+        setStyle.call(this, newVal, styleKey)
       }
     })
   }
@@ -107,15 +107,19 @@ export class Style {
   }
 
   public setProperty (propertyName: string, value?: string | null) {
-    propertyName = toCamelCase(propertyName)
-    if (isUndefined(value)) {
-      return
-    }
-
-    if (value === null || value === '') {
-      this.removeProperty(propertyName)
+    if (propertyName[0] === '-') {
+      this.setCssVariables(propertyName)
     } else {
-      this[propertyName] = value
+      propertyName = toCamelCase(propertyName)
+      if (isUndefined(value)) {
+        return
+      }
+
+      if (value === null || value === '') {
+        this.removeProperty(propertyName)
+      } else {
+        this[propertyName] = value
+      }
     }
   }
 

--- a/packages/taro-runtime/src/dom/style.ts
+++ b/packages/taro-runtime/src/dom/style.ts
@@ -107,19 +107,16 @@ export class Style {
   }
 
   public setProperty (propertyName: string, value?: string | null) {
-    if (propertyName[0] === '-') {
-      this.setCssVariables(propertyName)
-    } else {
-      propertyName = toCamelCase(propertyName)
-      if (isUndefined(value)) {
-        return
-      }
+    this.setCssVariables(propertyName)
+    propertyName = toCamelCase(propertyName)
+    if (isUndefined(value)) {
+      return
+    }
 
-      if (value === null || value === '') {
-        this.removeProperty(propertyName)
-      } else {
-        this[propertyName] = value
-      }
+    if (value === null || value === '') {
+      this.removeProperty(propertyName)
+    } else {
+      this[propertyName] = value
     }
   }
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
让 taro-runtime & taro-react 支持 CSS Variables，[react-dom](https://github.com/facebook/react/blob/6498f62edc/packages/react-dom/src/shared/CSSPropertyOperations.js#L36) 也是支持该特性的，同时也能让 [callstack/linaria](https://github.com/callstack/linaria) 之类的 Zero-runtime CSS in JS library 可以方便的动态改变 CSS 属性。

（使用 linaria 一段时间了，遇到的问题是对 animation 之类的 [非标准 html 属性进行了过滤](https://github.com/callstack/linaria/blob/ce926c84cc/src/react/styled.ts#L74-L75)，现在只能打一个 patch 在项目中）


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
