### PR TITLE
fix: #5655 2.x中无法在config中使用defineConstants定义的全局变量

### DIFF
--- a/packages/taro-cli/src/mini/helper.ts
+++ b/packages/taro-cli/src/mini/helper.ts
@@ -21,7 +21,9 @@ import {
   recursiveFindNodeModules,
   shouldUseCnpm,
   shouldUseYarn,
-  unzip
+  unzip,
+  generateEnvList,
+  generateConstantsList
 } from '../util'
 import {
   IOption,
@@ -51,7 +53,8 @@ export interface IBuildData {
   jsxAttributeNameReplace?: {
     [key: string]: any
   },
-  quickappManifest?: ITaroManifestConfig
+  quickappManifest?: ITaroManifestConfig,
+  constantsReplaceList: IOption,
 }
 
 let BuildData: IBuildData
@@ -99,7 +102,10 @@ export function setBuildData (appPath: string, adapter: BUILD_TYPES, options?: P
     buildAdapter: adapter,
     outputFilesTypes: MINI_APP_FILES[adapter],
     nodeModulesPath: recursiveFindNodeModules(path.join(appPath, NODE_MODULES)),
-    jsxAttributeNameReplace: weappConf.jsxAttributeNameReplace || {}
+    jsxAttributeNameReplace: weappConf.jsxAttributeNameReplace || {},
+    constantsReplaceList:Object.assign({}, generateEnvList(projectConfig.env || {}), generateConstantsList(projectConfig.defineConstants || {}), {
+      'process.env.TARO_ENV': adapter
+    })
   }
   // 可以自定义输出文件类型
   if (weappConf!.customFilesTypes && !isEmptyObject(weappConf!.customFilesTypes)) {

--- a/packages/taro-mini-runner/src/loaders/wxTransformerLoader.ts
+++ b/packages/taro-mini-runner/src/loaders/wxTransformerLoader.ts
@@ -28,7 +28,8 @@ export default function wxTransformerLoader (source) {
     buildAdapter,
     designWidth,
     deviceRatio,
-    sourceDir
+    sourceDir,
+    constantsReplaceList,
   } = getOptions(this)
   const filePath = this.resourcePath
   const { resourceQuery } = this
@@ -69,7 +70,8 @@ export default function wxTransformerLoader (source) {
       sourcePath: filePath,
       isTyped: REG_TYPESCRIPT.test(filePath),
       adapter: buildAdapter,
-      rootProps: isEmptyObject(rootProps) || rootProps
+      rootProps: isEmptyObject(rootProps) || rootProps,
+      env: constantsReplaceList
     }
     if (miniType === PARSE_AST_TYPE.ENTRY) {
       wxTransformerParams.isApp = true
@@ -86,7 +88,8 @@ export default function wxTransformerLoader (source) {
       const newAst = transformFromAst(ast, '', {
         plugins: [
           [require('babel-plugin-preval')],
-          [require('babel-plugin-danger-remove-unused-import'), { ignore: cannotRemoves }]
+          [require('babel-plugin-danger-remove-unused-import'), { ignore: cannotRemoves }],
+          [require('babel-plugin-transform-define').default,constantsReplaceList]
         ]
       }).ast as t.File
       const result = processAst({


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

1.x可在config中使用defineConstants定义的全局变量，但2.x 却无法使用，增加2.x也支持


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [x] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
