### PR TITLE
fix: 头条,qq,阿里小程序报错 p.setIsUsingDiff is not a function

### DIFF
--- a/packages/taro-alipay/src/index.js
+++ b/packages/taro-alipay/src/index.js
@@ -33,7 +33,8 @@ import {
   useImperativeHandle,
   useContext,
   createContext,
-  memo
+  memo,
+  setIsUsingDiff
 } from '@tarojs/taro'
 import { shallowEqual } from '@tarojs/utils'
 
@@ -88,7 +89,8 @@ export const Taro = {
   useContext,
   createContext,
   memo,
-  shallowEqual
+  shallowEqual,
+  setIsUsingDiff
 }
 
 export default Taro

--- a/packages/taro-qq/src/index.js
+++ b/packages/taro-qq/src/index.js
@@ -33,7 +33,8 @@ import {
   useImperativeHandle,
   useContext,
   createContext,
-  memo
+  memo,
+  setIsUsingDiff
 } from '@tarojs/taro'
 import { shallowEqual } from '@tarojs/utils'
 
@@ -82,7 +83,8 @@ export const Taro = {
   useContext,
   createContext,
   memo,
-  shallowEqual
+  shallowEqual,
+  setIsUsingDiff
 }
 
 export default Taro

--- a/packages/taro-tt/src/index.js
+++ b/packages/taro-tt/src/index.js
@@ -32,7 +32,8 @@ import {
   useImperativeHandle,
   useContext,
   createContext,
-  memo
+  memo,
+  setIsUsingDiff
 } from '@tarojs/taro'
 import { shallowEqual } from '@tarojs/utils'
 
@@ -86,7 +87,8 @@ export const Taro = {
   useContext,
   createContext,
   memo,
-  shallowEqual
+  shallowEqual,
+  setIsUsingDiff
 }
 
 export default Taro


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

使用taroconvert 转换的代码，再编译到支付宝，qq，头条小程序会报错，p.setIsUsingDiff is not a function 
setIsUsingDiff 目前只开放给百度和微信，也需要开发给其他小程序。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [x] 支付宝小程序
- [ ] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
