### PR TITLE
支持导出微信插件入口文件

### DIFF
--- a/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
+++ b/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
@@ -202,11 +202,13 @@ export default class MiniPlugin {
   apply (compiler) {
     this.context = compiler.context
     this.appEntry = this.getAppEntry(compiler)
+    let taroLoadChunksPlugin
     compiler.hooks.run.tapAsync(
 			PLUGIN_NAME,
 			this.tryAsync(async (compiler: webpack.Compiler) => {
         await this.run(compiler)
-        new TaroLoadChunksPlugin({
+        if(taroLoadChunksPlugin) taroLoadChunksPlugin.destroy()
+        taroLoadChunksPlugin = new TaroLoadChunksPlugin({
           commonChunks: this.options.commonChunks,
           buildAdapter: this.options.buildAdapter,
           isBuildPlugin: this.options.isBuildPlugin,
@@ -215,7 +217,8 @@ export default class MiniPlugin {
           depsMap: this.pageComponentsDependenciesMap,
           sourceDir: this.sourceDir,
           subPackages: this.subPackages
-        }).apply(compiler)
+        })
+        taroLoadChunksPlugin.apply(compiler)
 			})
     )
 
@@ -228,7 +231,8 @@ export default class MiniPlugin {
         } else {
           await this.watchRun(compiler, changedFiles)
         }
-        new TaroLoadChunksPlugin({
+        if(taroLoadChunksPlugin) taroLoadChunksPlugin.destroy()
+        taroLoadChunksPlugin = new TaroLoadChunksPlugin({
           commonChunks: this.options.commonChunks,
           buildAdapter: this.options.buildAdapter,
           isBuildPlugin: this.options.isBuildPlugin,
@@ -237,7 +241,8 @@ export default class MiniPlugin {
           depsMap: this.pageComponentsDependenciesMap,
           sourceDir: this.sourceDir,
           subPackages: this.subPackages
-        }).apply(compiler)
+        })
+        taroLoadChunksPlugin.apply(compiler)
 			})
     )
 

--- a/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
+++ b/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
@@ -37,6 +37,7 @@ interface IMiniPluginOptions {
   designWidth: number,
   commonChunks: string[],
   pluginConfig?: object,
+  pluginMainEntry?: string,
   isBuildPlugin: boolean,
   alias: object
   addChunkPages?: AddPageChunks,
@@ -575,6 +576,9 @@ export default class MiniPlugin {
       const filePath = this.appEntry[key][0]
       const code = fs.readFileSync(filePath).toString()
       const isTaroComponentRes = this.judgeFileToBeTaroComponent(code, filePath, buildAdapter)
+      if (key === this.options.pluginMainEntry) {
+        this.addEntry(compiler, filePath, key, PARSE_AST_TYPE.EXPORTS)
+      }
       if (isTaroComponentRes == null) {
         return null
       }

--- a/packages/taro-mini-runner/src/plugins/TaroLoadChunksPlugin.ts
+++ b/packages/taro-mini-runner/src/plugins/TaroLoadChunksPlugin.ts
@@ -85,6 +85,17 @@ export default class TaroLoadChunksPlugin {
       })
       compilation.chunkTemplate.hooks.renderWithEntry.tap(PLUGIN_NAME, (modules, chunk) => {
         if (chunk.entryModule) {
+          let entryModule = chunk.entryModule.rootModule ? chunk.entryModule.rootModule : chunk.entryModule
+          if (entryModule.miniType === PARSE_AST_TYPE.EXPORTS) {
+            const source = new ConcatSource()
+            source.add('module.exports=')
+            source.add(modules)
+            return source
+          }
+        }
+      })
+      compilation.chunkTemplate.hooks.renderWithEntry.tap(PLUGIN_NAME, (modules, chunk) => {
+        if (chunk.entryModule) {
           if (this.isBuildPlugin) {
             return addRequireToSource(getIdOrName(chunk), modules, commonChunks)
           }

--- a/packages/taro-mini-runner/src/utils/constants.ts
+++ b/packages/taro-mini-runner/src/utils/constants.ts
@@ -234,7 +234,8 @@ export enum PARSE_AST_TYPE {
   PAGE = 'PAGE',
   COMPONENT = 'COMPONENT',
   NORMAL = 'NORMAL',
-  STATIC = 'STATIC'
+  STATIC = 'STATIC',
+  EXPORTS = 'EXPORTS'
 }
 
 export const enum processTypeEnum {

--- a/packages/taro-mini-runner/src/webpack/build.conf.ts
+++ b/packages/taro-mini-runner/src/webpack/build.conf.ts
@@ -104,6 +104,7 @@ export default (appPath: string, mode, config: Partial<IBuildConfig>): any => {
     quickappJSON,
     designWidth,
     pluginConfig: entryRes!.pluginConfig,
+    pluginMainEntry: entryRes!.pluginMainEntry,
     isBuildPlugin: !!config.isBuildPlugin,
     commonChunks: customCommonChunks,
     addChunkPages,

--- a/packages/taro-mini-runner/src/webpack/chain.ts
+++ b/packages/taro-mini-runner/src/webpack/chain.ts
@@ -406,11 +406,13 @@ export const getEntry = ({
   }
   const pluginConfig = fs.readJSONSync(pluginConfigPath)
   const entryObj = {}
+  let pluginMainEntry
   Object.keys(pluginConfig).forEach(key => {
     if (key === 'main') {
       const filePath = path.join(pluginDir, pluginConfig[key])
       const fileName = path.basename(filePath).replace(path.extname(filePath), '')
-      entryObj[`plugin/${fileName}`] = [resolveScriptPath(filePath.replace(path.extname(filePath), ''))]
+      pluginMainEntry = `plugin/${fileName}`
+      entryObj[pluginMainEntry] = [resolveScriptPath(filePath.replace(path.extname(filePath), ''))]
     } else if (key === 'publicComponents' || key === 'pages') {
       Object.keys(pluginConfig[key]).forEach(subKey => {
         const filePath = path.join(pluginDir, pluginConfig[key][subKey])
@@ -420,7 +422,8 @@ export const getEntry = ({
   })
   return {
     entry: entryObj,
-    pluginConfig
+    pluginConfig,
+    pluginMainEntry,
   }
 }
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

0. 增加了 PARSE_AST_TYPE.EXPORTS 类型，用于导出入口文件，目前用于微信小程序插件开发。
0. 修复了TaroLoadChunksPlugin重复初始化，导致的renderWithEntry重复触发的问题。[webpack tapable无法直接删除，使用了flag方案](https://github.com/webpack/tapable/issues/109)
0. plugin.json 还是用的copy方案，需手动把index.ts 改为 index.js。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #5571
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
