### PR TITLE
fix(mini-runner): webpack配置多余参数导致webpack,loader参数校验失败

### DIFF
--- a/packages/taro-mini-runner/src/webpack/build.conf.ts
+++ b/packages/taro-mini-runner/src/webpack/build.conf.ts
@@ -20,15 +20,13 @@ import {
 import getBaseConf from './base.conf'
 import { Targets } from '../plugins/MiniPlugin'
 
-const emptyObj: Record<string, string> = {}
-
 export default (appPath: string, mode, config: Partial<IBuildConfig>): any => {
   const chain = getBaseConf(appPath)
   const {
     buildAdapter = BUILD_TYPES.WEAPP,
-    alias = emptyObj,
-    entry = emptyObj,
-    output = emptyObj,
+    alias = {},
+    entry = {},
+    output = {},
     outputRoot = 'dist',
     sourceRoot = 'src',
 
@@ -39,18 +37,18 @@ export default (appPath: string, mode, config: Partial<IBuildConfig>): any => {
     framework = 'nerv',
     prerender,
 
-    defineConstants = emptyObj,
-    env = emptyObj,
-    cssLoaderOption = emptyObj,
-    sassLoaderOption = emptyObj,
-    lessLoaderOption = emptyObj,
-    stylusLoaderOption = emptyObj,
-    mediaUrlLoaderOption = emptyObj,
-    fontUrlLoaderOption = emptyObj,
-    imageUrlLoaderOption = emptyObj,
-    miniCssExtractPluginOption = emptyObj,
+    defineConstants = {},
+    env = {},
+    cssLoaderOption = {},
+    sassLoaderOption = {},
+    lessLoaderOption = {},
+    stylusLoaderOption = {},
+    mediaUrlLoaderOption = {},
+    fontUrlLoaderOption = {},
+    imageUrlLoaderOption = {},
+    miniCssExtractPluginOption = {},
 
-    postcss = emptyObj,
+    postcss = {},
     nodeModulesPath,
     quickappJSON,
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

version:`3.0.0-beta.1`
![image](https://user-images.githubusercontent.com/20211964/77838659-a1219b00-71a8-11ea-9059-2ba03fcc626e.png)
webpack配置中，`output`参数`saas-loader`中的参数
![image](https://user-images.githubusercontent.com/20211964/77838721-f8c00680-71a8-11ea-8917-c0a193921534.png)
有两个多余参数，导致启动编译，参数校验失败。

原因是因为，`taro-mini-runner/src/webpack/build.config.ts`中`emptyObj`做为多个参数的默认值，内部添加`env`配置，导致所有引用`emptyObj`的配置有额外参数

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
