### PR TITLE
fix(mini-runner): windows 下的路径问题 

### DIFF
--- a/packages/taro-mini-runner/src/prerender/prerender.ts
+++ b/packages/taro-mini-runner/src/prerender/prerender.ts
@@ -112,10 +112,15 @@ export class Prerender {
     await this.writeScript('app')
 
     if (!this.appLoaded) {
-      this.vm.run(`
+      try {
+        this.vm.run(`
         const app = require('${this.getRealPath('app')}')
         app.onLaunch()
       `, this.outputPath)
+      } catch (error) {
+        printPrerenderFail('app')
+        console.error(error)
+      }
       this.appLoaded = true
       await Promise.resolve()
     }

--- a/packages/taro-mini-runner/src/prerender/prerender.ts
+++ b/packages/taro-mini-runner/src/prerender/prerender.ts
@@ -139,7 +139,7 @@ export class Prerender {
   }
 
   private getRealPath (path: string, ext = '.js') {
-    return join(this.outputPath, path + ext)
+    return join(this.outputPath, path + ext).replace(/\\/g, '\\\\')
   }
 
   private buildSandbox () {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

在 windows 下 getRealPath 生成的路径为 ‘\xx\xx’ 在转换字符串的时候会再次被转义成 `xxxx`，
然后在用 vm2 执行 app.onLaunch() 的时候没有捕捉错误

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
