### PR TITLE
fix: issue #5682 ,修复ios 10.x系统中，由于不支持document.body.style = bodyInlineStyle写法导致js被中断的问题

### DIFF
--- a/packages/taro-h5/src/api/utils/index.js
+++ b/packages/taro-h5/src/api/utils/index.js
@@ -302,7 +302,7 @@ const interactiveHelper = () => {
     },
     handleBeforeDestroy: () => {
       const bodyInlineStyle = bodyStatusClosure.getInlineStyle() || {}
-      document.body.style = bodyInlineStyle
+      document.body.setAttribute('style', bodyInlineStyle)
       setScrollTop(scrollTop)
     }
   }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

fix: #5682  注：之前已经对2.x分支提了pr，修复代码已经合并进去。但本公司taro版本仍未升级到2.x，所以需要对master进行修改。

taro-h5/api/utils.js handleBeforeDestroy()函数中
document.body.style = bodyInlineStyle报错（attempted to assign to readonly property） 中断了js的执行，导致hide toast等js代码没有执行。
ios 11以下，不支持直接操作style的方式，可以通过设置属性进行style，像这样：
document.body.setAttribute('style', bodyInlineStyle)

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
