### PR TITLE
fix(mini-runner): 修复 webpack `resolve.modules` 设置绝对路径导致的依赖引用错误

### DIFF
--- a/packages/taro-mini-runner/src/webpack/base.conf.ts
+++ b/packages/taro-mini-runner/src/webpack/base.conf.ts
@@ -9,8 +9,8 @@ export default (appPath: string) => {
       mainFields: ['browser', 'module', 'main'],
       symlinks: true,
       modules: [
-        path.join(appPath, 'node_modules'),
-        'node_modules'
+        'node_modules',
+        path.join(appPath, 'node_modules')
       ]
     },
     resolveLoader: {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

同 PR ：https://github.com/NervJS/taro/pull/5858   提到2.x版本

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
