### PR TITLE
feat(taro-webpack-runner): add miniCssExtractLoaderOption support

### DIFF
--- a/docs/config-detail.md
+++ b/docs/config-detail.md
@@ -610,6 +610,23 @@ stylus-loader 的附加配置。配置项参考[官方文档](https://github.com
 }
 ```
 
+### h5.miniCssExtractLoaderOption
+
+`mini-css-extract-plugin` 的loader配置，在 `enableExtract` 为 `true` 的情况下生效。与 `miniCssExtractPluginOption` 选项配合使用。
+可以配置对应的loader config，配置项参考[官方文档](https://github.com/webpack-contrib/mini-css-extract-plugin)，例如：
+
+```jsx
+{
+  miniCssExtractPluginOption: {
+    filename: 'css/[name].css',
+    chunkFilename: 'css/[id].css'
+  },
+  miniCssExtractLoaderOption: {
+    publicPath: '../'
+  }
+}
+```
+
 ### h5.module
 
 配置一些 H5 端用到的插件模块配置，暂时只有 `postcss`。

--- a/packages/taro-webpack-runner/src/__tests__/index-test.ts
+++ b/packages/taro-webpack-runner/src/__tests__/index-test.ts
@@ -44,6 +44,7 @@ describe('Regs', () => {
       fontUrlLoaderOption: {},
       imageUrlLoaderOption: {},
       mediaUrlLoaderOption: {},
+      miniCssExtractLoaderOption: {},
       esnextModules: [],
 
       module: {

--- a/packages/taro-webpack-runner/src/config/dev.conf.ts
+++ b/packages/taro-webpack-runner/src/config/dev.conf.ts
@@ -50,6 +50,7 @@ export default function (appPath: string, config: Partial<BuildConfig>): any {
     imageUrlLoaderOption = emptyObj,
 
     miniCssExtractPluginOption = emptyObj,
+    miniCssExtractLoaderOption = emptyObj,
     esnextModules = [],
 
     module = {
@@ -116,6 +117,7 @@ export default function (appPath: string, config: Partial<BuildConfig>): any {
       fontUrlLoaderOption,
       imageUrlLoaderOption,
       mediaUrlLoaderOption,
+      miniCssExtractLoaderOption,
       esnextModules,
 
       module,

--- a/packages/taro-webpack-runner/src/config/prod.conf.ts
+++ b/packages/taro-webpack-runner/src/config/prod.conf.ts
@@ -47,6 +47,7 @@ export default function (appPath: string, config: Partial<BuildConfig>): any {
     mediaUrlLoaderOption = emptyObj,
     fontUrlLoaderOption = emptyObj,
     imageUrlLoaderOption = emptyObj,
+    miniCssExtractLoaderOption = emptyObj,
 
     miniCssExtractPluginOption = emptyObj,
     esnextModules = [],
@@ -137,6 +138,7 @@ export default function (appPath: string, config: Partial<BuildConfig>): any {
       fontUrlLoaderOption,
       imageUrlLoaderOption,
       mediaUrlLoaderOption,
+      miniCssExtractLoaderOption,
       esnextModules,
 
       module,

--- a/packages/taro-webpack-runner/src/util/chain.ts
+++ b/packages/taro-webpack-runner/src/util/chain.ts
@@ -161,9 +161,10 @@ const getLessLoader = pipe(mergeOption, partial(getLoader, 'less-loader'))
 const getStylusLoader = pipe(mergeOption, partial(getLoader, 'stylus-loader'))
 const getBabelLoader = pipe(mergeOption, partial(getLoader, 'babel-loader'))
 const getUrlLoader = pipe(mergeOption, partial(getLoader, 'url-loader'))
-const getExtractCssLoader = () => {
+const getExtractCssLoader = (options) => {
   return {
-    loader: MiniCssExtractPlugin.loader
+    loader: MiniCssExtractPlugin.loader,
+    options: options || {}
   }
 }
 
@@ -245,6 +246,7 @@ const getModule = (appPath: string, {
   fontUrlLoaderOption,
   imageUrlLoaderOption,
   mediaUrlLoaderOption,
+  miniCssExtractLoaderOption,
   esnextModules = [] as (string | RegExp)[],
 
   module,
@@ -316,7 +318,7 @@ const getModule = (appPath: string, {
     styleLoaderOption
   ])
 
-  const extractCssLoader = getExtractCssLoader()
+  const extractCssLoader = getExtractCssLoader(miniCssExtractLoaderOption)
 
   const lastStyleLoader = enableExtract ? extractCssLoader : styleLoader
 

--- a/packages/taro-webpack-runner/src/util/types.ts
+++ b/packages/taro-webpack-runner/src/util/types.ts
@@ -67,6 +67,7 @@ export interface TaroH5Config {
   fontUrlLoaderOption: Option;
   imageUrlLoaderOption: Option;
   miniCssExtractPluginOption: Option;
+  miniCssExtractLoaderOption: Option;
   esnextModules: string[];
 
   module?: {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

1. taro-webpack-runner 添加 `miniCssExtractLoaderOption` 的配置支持，修复从外部传入 `miniCssExtractPluginOption` 无法修改内部的 loader option的问题;
2. 文档添加对应配置 `h5.miniCssExtractLoaderOption` 的说明；
3. 修改ts 类型 `TaroH5Config`，新增 `miniCssExtractLoaderOption` 属性支持。

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [x] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
