### PR TITLE
refactor(runtime): nextTick适配小程序setData回调

### DIFF
--- a/packages/taro-runtime/src/dom/root.ts
+++ b/packages/taro-runtime/src/dom/root.ts
@@ -93,9 +93,7 @@ export class TaroRootElement extends TaroElement {
 
   public enqueueUpdateCallbak (cb: Function, ctx?: Record<string, any>) {
     this.updateCallbacks.push(() => {
-      if (cb) {
-        ctx ? cb.call(ctx) : cb()
-      }
+      ctx ? cb.call(ctx) : cb()
     })
   }
 

--- a/packages/taro-runtime/src/dom/root.ts
+++ b/packages/taro-runtime/src/dom/root.ts
@@ -11,6 +11,10 @@ export class TaroRootElement extends TaroElement {
 
   private updatePayloads: UpdatePayload[] = []
 
+  private pendingFlush = false
+
+  private updateCallbacks: Function[]= []
+
   public ctx: null | MpInstance = null
 
   public constructor () {
@@ -76,11 +80,31 @@ export class TaroRootElement extends TaroElement {
         this.pendingUpdate = false
         ctx.setData(data, () => {
           perf.stop(SET_DATA)
+          if (!this.pendingFlush) {
+            this.flushUpdateCallback()
+          }
           if (initRender) {
             perf.stop(PAGE_INIT)
           }
         })
       }
     }, 0)
+  }
+
+  public enqueueUpdateCallbak (cb: Function, ctx?: Record<string, any>) {
+    this.updateCallbacks.push(() => {
+      if (cb) {
+        ctx ? cb.call(ctx) : cb()
+      }
+    })
+  }
+
+  public flushUpdateCallback () {
+    this.pendingFlush = false
+    const copies = this.updateCallbacks.slice(0)
+    this.updateCallbacks.length = 0
+    for (let i = 0; i < copies.length; i++) {
+      copies[i]()
+    }
   }
 }

--- a/packages/taro-runtime/src/dsl/common.ts
+++ b/packages/taro-runtime/src/dsl/common.ts
@@ -72,7 +72,7 @@ function stringify (obj?: Record<string, unknown>) {
   }).join('&')
 }
 
-function getPath (id: string, options?: Record<string, unknown>): string {
+export function getPath (id: string, options?: Record<string, unknown>): string {
   let path = id
   if (!isBrowser) {
     path = id + stringify(options)

--- a/packages/taro-runtime/src/next-tick.ts
+++ b/packages/taro-runtime/src/next-tick.ts
@@ -1,3 +1,32 @@
-export const nextTick = (cb: Function) => {
-  setTimeout(cb, 1)
+import { Current } from './current'
+import { getPath } from './dsl/common'
+import { TaroRootElement } from './dom/root'
+import { document } from './bom/document'
+import { ensure } from '@tarojs/shared'
+
+function removeLeadingSlash (path?: string) {
+  if (path == null) {
+    return ''
+  }
+  return path.charAt(0) === '/' ? path.slice(1) : path
+}
+
+export const nextTick = (cb: Function, ctx?: Record<string, any>) => {
+  const hasSetDataCallbacks = ['weapp', 'swan', 'qq', 'alipay', 'tt']
+  if (~hasSetDataCallbacks.indexOf(process.env.TARO_ENV || '')) {
+    let pageElement: TaroRootElement | null = null
+    const router = Current.router
+    if (router) {
+      const path = getPath(removeLeadingSlash(router.path), router.params)
+      pageElement = document.getElementById<TaroRootElement>(path)
+      ensure(pageElement !== null, '没有找到页面实例。')
+      if (pageElement) {
+        pageElement.enqueueUpdateCallbak(cb, ctx)
+      }
+    }
+  } else {
+    setTimeout(function () {
+      ctx ? cb.call(ctx) : cb()
+    }, 1)
+  }
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
**需求背景：**
     `Taro.nextTick`目前触发时机是js线程下一个event loop，在小程序运行环境中，这个时机不能确保视图数据渲染完成；场景：在渲染某个元素之后，需要使用`Taro.createSelectorQuery()`去获取元素的样式信息时，目前触发时元素可能还没渲染完成，无法准确获取；

**修改点：**
     在小程序环境且支持渲染回调下，调用`Taro.nextTick`，则回调在`setData`渲染完成之后执行；在其他环境，则是下一个event loop;

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
