### PR TITLE
feat: api 增加 cjs 分发，规范部分包的文件包含

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tarojs/shared",
+  "version": "3.0.0-beta.3",
   "description": "> TODO: description",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/shared#readme",
@@ -7,6 +8,9 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/NervJS/taro.git"
@@ -17,7 +21,6 @@
   "bugs": {
     "url": "https://github.com/NervJS/taro/issues"
   },
-  "version": "3.0.0-beta.3",
   "publishConfig": {
     "access": "public"
   }

--- a/packages/taro-api/package.json
+++ b/packages/taro-api/package.json
@@ -5,14 +5,14 @@
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/api#readme",
   "license": "MIT",
-  "main": "dist/index.esm.js",
-  "module": "src/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.esm.js",
   "directories": {
     "lib": "lib",
     "test": "__tests__"
   },
   "files": [
-    "lib"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/taro-api/rollup.config.js
+++ b/packages/taro-api/rollup.config.js
@@ -60,7 +60,7 @@ function rollup () {
   } else if (target === 'esm') {
     return esmConfig
   } else {
-    return esmConfig
+    return [baseConfig, esmConfig]
   }
 }
 module.exports = rollup()

--- a/packages/taro-react/package.json
+++ b/packages/taro-react/package.json
@@ -7,6 +7,9 @@
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/react.esm.js",
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/NervJS/taro.git"

--- a/packages/taro-runtime/package.json
+++ b/packages/taro-runtime/package.json
@@ -3,12 +3,15 @@
   "version": "3.0.0-beta.3",
   "description": "taro runtime for mini apps.",
   "main": "dist/index.js",
+  "module": "dist/runtime.esm.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "test": "jest",
     "build": "rollup -c",
     "dev": "rollup -c -w"
   },
-  "module": "dist/runtime.esm.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/NervJS/taro/tree/master/packages/taro-runtime"


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

在给 Taro UI 写单元测试，发现 @tarojs/api 只分发了 ESM 格式的文件（如下图），导致 Jest Runtime 报错（部分无关内容已经删除）：

```text
    Details:

    /Users/hagongyi/Projects/GitHub/taro-ui/node_modules/@tarojs/api/dist/index.esm.js:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){import { Events, eventCenter, Current, useDidShow, useDidHide, usePullDownRefresh, useReachBottom, usePageScroll, useResize, useShareAppMessage, useTabItemTap, useTitleClick, useOptionMenuClick, usePullIntercept, useRouter, options, nextTick } from '@tarojs/runtime';
                                                                                             ^^^^^^

    SyntaxError: Cannot use import statement outside a module

      at Runtime.createScriptFromCode (../../node_modules/jest-runtime/build/index.js:1086:14)
      at Object.<anonymous> (../../node_modules/@tarojs/taro/index.js:1:103)
```

![image](https://user-images.githubusercontent.com/3471836/79243652-7f166100-7ea8-11ea-9bc0-664c864c677c.png)

其他几个 @tarojs/shared @tarojs/react @tarojs/runtime 包都是没有写好 `"files"` 字段导致发型的包里源码和单元测试都打包进去了，所以做了修改。

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [x] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 next 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
