### PR TITLE
feat: enable export Entries

### DIFF
--- a/packages/taro-mini-runner/src/plugins/TaroLoadChunksPlugin.ts
+++ b/packages/taro-mini-runner/src/plugins/TaroLoadChunksPlugin.ts
@@ -102,7 +102,7 @@ export default class TaroLoadChunksPlugin {
             return addRequireToSource(getIdOrName(chunk), modules, commonChunks)
           }
           let entryModule = chunk.entryModule.rootModule ? chunk.entryModule.rootModule : chunk.entryModule
-          if (entryModule.miniType === PARSE_AST_TYPE.ENTRY) {
+          if (entryModule.miniType === PARSE_AST_TYPE.ENTRY || entryModule.miniType === PARSE_AST_TYPE.EXPORTS) {
             return addRequireToSource(getIdOrName(chunk), modules, commonChunks)
           }
           if ((this.buildAdapter === BUILD_TYPES.QUICKAPP) &&


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

### 功能
支持配置webpack entry

### 原因
业务上有主框架使用小程序原生开发，分包使用taro开发。原生需要依赖分包里的文件进行初始化。
故使用webpack 的 Entry Points配置，打包多个入口文件。原生代码可以通过commonjs规范去引入。

### 使用
配置
```js
const config = {
  mini: {
    webpackChain(chain) {
      chain.merge({
        entry: {
          'foo': ['./foo/index.js'] //支持暴露文件给外部require
        }
      })
    }
  }
}
```

打包结果
foo.js
```js
require("./runtime");
require("./common");
require("./vendors");
require("./taro");

module.exports=(swan["webpackJsonp"] = swan["webpackJsonp"] || []).push([["foo"],[],[["./src/foo/index.js","runtime","taro","vendors","common"]]]);;
```

原生代码使用
```js
const foo =  require('./dist/foo')
```

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
