### PR TITLE
快应用图片组件mode不生效与font-family能编译，支持iconfont

### DIFF
--- a/packages/taro-components-qa/src/components/taro-image/index.ux
+++ b/packages/taro-components-qa/src/components/taro-image/index.ux
@@ -51,7 +51,7 @@
     }),
 
     onInit () {
-      let imageStyle = {}
+      this.imageStyle = Object.assign({}, this.customstyle)
       switch (this.mode) {
         case 'scaleToFill':
           this.imageStyle['object-fit'] = 'fill';
@@ -65,7 +65,6 @@
         default:
           this.imageStyle['object-fit'] = 'fill';
       }
-      this.imageStyle = Object.assign({}, this.customstyle)
     },
 
     handleClick () {

--- a/packages/taro-mini-runner/src/quickapp/style/declaration/font/index.ts
+++ b/packages/taro-mini-runner/src/quickapp/style/declaration/font/index.ts
@@ -18,6 +18,6 @@ export default {
     }
   },
   'font-style': '',
-  'font-family': 'I:',
+  'font-family': '',
   'font-variant': 'I:'
 }


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
1. 快应用的图片组件设置mode不生效
2. font-family参与编译，快应用中可使用字体


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [x] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
