### PR TITLE
fix(h5): Swiper组件自动开启轮播，不受autoplay控制

### DIFF
--- a/packages/taro-components/src/components/swiper/index.js
+++ b/packages/taro-components/src/components/swiper/index.js
@@ -149,10 +149,6 @@ class Swiper extends Nerv.Component {
           autoplay.stop()
         }
       }
-      if (!autoplay.paused) {
-        autoplay.run()
-        autoplay.paused = false
-      }
 
       this.mySwiper.update() // 更新子元素
     }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

> Swiper组件的index.js里的componentWillReceiveProps有这么一段代码，对应line: 143

```javascript
      const autoplay = this.mySwiper.autoplay
      // 判断是否需要停止或开始自动轮播
      if (autoplay.running !== nextProps.autoplay) {
        if (nextProps.autoplay) {
          autoplay.start()
        } else {
          autoplay.stop()
        }
      }
      if (!autoplay.paused) {
        autoplay.run()
        autoplay.paused = false
      }
```
看到是某位大佬20天前添加的commit内容为fix: swiper autoplay stuck with taro_page
上面拿的是this.mySwiper.autoplay，所以autoplay.paused默认情况下是false
这就意味着只要进了componentWillReceiveProps，并且有this.mySwiper
这个页面上的swiper就一定会自动轮播，而且关不掉，因为被无限的赋值autoplay.paused = false
autoplay.run()自然执行

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
