### PR TITLE
fix #6054

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "type": "git",
     "url": "git+https://github.com/NervJS/taro.git"
   },
-  "//lint-staged": {
+  "lint-staged": {
     "*.{js,jsx}": [
       "eslint --fix",
       "git add"
@@ -34,7 +34,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "//pre-commit": "lint-staged"
+      "pre-commit": "lint-staged"
     }
   },
   "keywords": [

--- a/packages/taro-runtime/src/dsl/common.ts
+++ b/packages/taro-runtime/src/dsl/common.ts
@@ -1,5 +1,5 @@
 /* eslint-disable dot-notation */
-import { isFunction, EMPTY_OBJ, ensure, Shortcuts, isUndefined, isArray } from '@tarojs/shared'
+import { isFunction, EMPTY_OBJ, ensure, Shortcuts, isUndefined, isArray, warn } from '@tarojs/shared'
 import { eventHandler } from '../dom/event'
 import { Current } from '../current'
 import { document } from '../bom/document'
@@ -251,6 +251,14 @@ export function createRecursiveComponentConfig () {
         value: {
           [Shortcuts.NodeName]: 'view'
         }
+      }
+    },
+    observers: {
+      i (val: Record<string, unknown>) {
+        warn(
+          val[Shortcuts.NodeName] === '#text',
+          `请在此元素外再套一层非 Text 元素：<text>${val[Shortcuts.Text]}</text>，详情：https://github.com/NervJS/taro/issues/6054`
+        )
       }
     },
     options: {


### PR DESCRIPTION
小程序的 text 组件无法容纳除了字符串之外的任何元素，而当前的渲染机制会在层数达到阈值时使用一个自定义组件重启渲染，新的自定义组件会插入到 text 组件中，导致自定义组件内容无法渲染。

当前解决方案是出现这种情况时给一个警告。