### PR TITLE
perf(runtime): 降低使用 react 的内存占用

### DIFF
--- a/packages/taro-react/src/props.ts
+++ b/packages/taro-react/src/props.ts
@@ -26,11 +26,10 @@ export function updateProps (dom: TaroElement, oldProps: Props, newProps: Props)
   }
 }
 
-const listeners: WeakMap<TaroElement, Record<string, Function>> = new WeakMap()
-
 function eventProxy (e: CommonEvent) {
   const el = document.getElementById(e.currentTarget.id)
-  listeners.get(el!)![e.type](e)
+  const handlers = el!.__handlers[e.type]
+  handlers[0](e)
 }
 
 function setEvent (dom: TaroElement, name: string, value: unknown, oldValue?: unknown) {
@@ -48,17 +47,9 @@ function setEvent (dom: TaroElement, name: string, value: unknown, oldValue?: un
     if (!oldValue) {
       dom.addEventListener(eventName, eventProxy, isCapture)
     }
-    let events = listeners.get(dom)
-    if (!events) {
-      listeners.set(dom, events = {})
-    }
-    events[eventName] = value
+    dom.__handlers[eventName][0] = value
   } else {
     dom.removeEventListener(eventName, eventProxy)
-    const events = listeners.get(dom)
-    if (events) {
-      delete events[eventName]
-    }
   }
 }
 

--- a/packages/taro-runtime/src/dom/event_target.ts
+++ b/packages/taro-runtime/src/dom/event_target.ts
@@ -14,7 +14,7 @@ export interface EventHandler extends Function {
 }
 
 export class TaroEventTarget {
-  protected __handlers: Record<string, EventHandler[]> = {}
+  public __handlers: Record<string, EventHandler[]> = {}
 
   public addEventListener (type: string, handler: EventHandler, options?: boolean | AddEventListenerOptions) {
     warn(type === 'regionchange', 'map 组件的 regionchange 事件非常特殊，请使用 begin/end 事件替代。详情：https://github.com/NervJS/taro/issues/5766')

--- a/packages/taro-runtime/src/dom/node.ts
+++ b/packages/taro-runtime/src/dom/node.ts
@@ -129,6 +129,7 @@ export class TaroNode extends TaroEventTarget {
     }
     child.parentNode = null
     eventSource.delete(child.uid)
+    child._empty()
     return child
   }
 
@@ -160,14 +161,29 @@ export class TaroNode extends TaroEventTarget {
   }
 
   /**
+   * like jQuery's $.empty()
+   */
+  private _empty () {
+    while (this.childNodes.length > 0) {
+      const child = this.childNodes[0]
+      child.parentNode = null
+      eventSource.delete(child.uid)
+      this.childNodes.shift()
+    }
+  }
+
+  /**
    * @textContent 目前只能置空子元素
    * @TODO 等待完整 innerHTML 实现
    */
   public set textContent (text: string) {
     if (text === '') {
-      while (this.childNodes.length > 0) {
-        this.childNodes[0].remove()
-      }
+      this._empty()
+
+      this.enqueueUpdate({
+        path: `${this._path}.${Shortcuts.Childnodes}`,
+        value: () => []
+      })
     }
   }
 


### PR DESCRIPTION
https://github.com/NervJS/taro/commit/0369c987f1a463701ddb26bb48c5e6e66471d792
会在元素被从 DOM 树中清除时，同时清理它的所有子元素，以及他们的引用

https://github.com/NervJS/taro/commit/97efc4579838c64e7872f5275e3a04d416b7e823
重构 react 的事件代理机制，从前使用 weakMap 实现，但由于小程序开发者工具没有可以找到对象引用关系的工具，无法定位问题。目前的实现把事件代理机制绑定到 DOM 本身，利用 `TaroEventTarget` 的内部对象实现。