### PR TITLE
fix(taro-h5): 修复h5的chooseImage API无法动态设置souceType的问题，对齐小程序端

### DIFF
--- a/packages/taro-h5/src/api/image/chooseImage.js
+++ b/packages/taro-h5/src/api/image/chooseImage.js
@@ -26,6 +26,8 @@ const chooseImage = function (options) {
     tempFilePaths: [],
     tempFiles: []
   }
+  const sourceTypeString = sourceType && sourceType.toString()
+  const acceptableSourceType = ['user', 'environment', 'camera']
 
   if (count && typeof count !== 'number') {
     res.errMsg = getParameterError({
@@ -43,8 +45,6 @@ const chooseImage = function (options) {
   let taroChooseImageId = document.getElementById(imageId)
   if (!taroChooseImageId) {
     let obj = document.createElement('input')
-    const sourceTypeString = sourceType && sourceType.toString()
-    const acceptableSourceType = ['user', 'environment', 'camera']
     obj.setAttribute('type', 'file')
     obj.setAttribute('id', imageId)
     if (count > 1) {
@@ -57,6 +57,12 @@ const chooseImage = function (options) {
     obj.setAttribute('style', 'position: fixed; top: -4000px; left: -3000px; z-index: -300;')
     document.body.appendChild(obj)
     taroChooseImageId = document.getElementById(imageId)
+  } else {
+    if (acceptableSourceType.indexOf(sourceTypeString) > -1) {
+      taroChooseImageId.setAttribute('capture', sourceTypeString)
+    } else {
+      taroChooseImageId.removeAttribute('capture')
+    }
   }
   let taroChooseImageCallback
   const taroChooseImagePromise = new Promise(resolve => {
@@ -67,7 +73,7 @@ const chooseImage = function (options) {
   taroChooseImageId.dispatchEvent(TaroMouseEvents)
   taroChooseImageId.onchange = function (e) {
     let arr = [...e.target.files]
-	  arr=arr.splice(0,count)
+    arr = arr.splice(0, count)
     arr && arr.forEach(item => {
       let blob = new Blob([item], {
         type: item.type


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复h5的chooseImage API无法动态设置souceType的问题，对齐小程序端

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [ ] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**

问题复现代码如下：

- 1、新建两个页面`Index`和`Second`：

```js
// Index页面，sourceType:为['album', 'camera']
import Taro, { Component } from '@tarojs/taro'
import { View, Text, Button } from '@tarojs/components'

export default class Index extends Component {
  render () {
    return (
      <View>
        <Button onClick={() => {
          Taro.chooseImage({
            sourceType: ['album', 'camera']
          });
        }}>选择图片</Button>
        <Button onClick={() => {
          Taro.navigateTo({
            url: '/pages/second/index'
          });
        }}>下一页</Button>
      </View>
    )
  }
}

// Second页面，sourceType为['camera']
import Taro, { Component } from '@tarojs/taro'
import { View, Text, Button } from '@tarojs/components'

export default class Second extends Component {
  render () {
    return (
      <View>
        <Button onClick={() => {
          Taro.chooseImage({
            sourceType: ['camera']
          });
        }}>选择图片</Button>
      </View>
    )
  }
}
```

- 2、在小程序端，页面`Index`可以唤起相册和相机选项；而页面`Second`可以唤起相机类型；

- 3、在h5端，表现与小程序端不一致，页面`Index`可以唤起相册和相机选项；跳转到页面`Second`不可以唤起相机类型；

- 4、后来发现，在h5端，还跟打开的页面顺序有关系；如果先打开页面`Second`，则可以唤起相机类型，但是返回到页面`Index`就不能唤起相册和相机选项了，只能继续打开相机类型；

- 5、原因分析：源码中，`capture`属性在首次设置后，就不能再根据`sourceType`改变
```js
let taroChooseImageId = document.getElementById(imageId)
if (!taroChooseImageId) {
  let obj = document.createElement('input')
  const sourceTypeString = sourceType && sourceType.toString()
  const acceptableSourceType = ['user', 'environment', 'camera']
  obj.setAttribute('type', 'file')
  obj.setAttribute('id', imageId)
  if (count > 1) {
    obj.setAttribute('multiple', 'multiple')
  }
  // 原因在这
  if (acceptableSourceType.indexOf(sourceTypeString) > -1) {
    obj.setAttribute('capture', sourceTypeString)
  }
  obj.setAttribute('accept', 'image/*')
  obj.setAttribute('style', 'position: fixed; top: -4000px; left: -3000px; z-index: -300;')
  document.body.appendChild(obj)
  taroChooseImageId = document.getElementById(imageId)
}
```


