### PR TITLE
perf(h5): 加快 h5 webpack 构建速度

### DIFF
--- a/packages/taro-components/stencil.config.ts
+++ b/packages/taro-components/stencil.config.ts
@@ -14,6 +14,13 @@ export const config: Config = {
       esmLoaderPath: '../loader'
     }
   ],
+  bundles: [
+    { components: ['taro-picker-core', 'taro-picker-group'] },
+    { components: ['taro-checkbox-core', 'taro-checkbox-group-core'] },
+    { components: ['taro-radio-core', 'taro-radio-group-core'] },
+    { components: ['taro-swiper-core', 'taro-swiper-item-core'] },
+    { components: ['taro-video-core', 'taro-video-control', 'taro-video-danmu'] }
+  ],
   excludeSrc: ['/test/', '**/.spec.', '/types/', '*.d.ts'],
   testing: {
     testRegex: '(/__tests__/.*|(\\.|/)(tt|spec))\\.[jt]sx?$',

--- a/packages/taro-h5/package.json
+++ b/packages/taro-h5/package.json
@@ -2,7 +2,7 @@
   "name": "@tarojs/taro-h5",
   "version": "3.0.0-beta.5",
   "description": "Taro h5 framework",
-  "main:h5": "src/index.js",
+  "main:h5": "dist/index.mjs.js",
   "main": "dist/index.cjs.js",
   "typings": "types/index.d.ts",
   "files": [

--- a/packages/taro-h5/rollup.config.js
+++ b/packages/taro-h5/rollup.config.js
@@ -54,6 +54,12 @@ const variesConfig = [{
   output: {
     file: 'dist/index.cjs.js'
   }
+}, {
+  input: 'src/index.js',
+  output: {
+    format: 'es',
+    file: 'dist/index.mjs.js'
+  }
 }]
 
 export default variesConfig.map(v => {

--- a/packages/taro-webpack-runner/src/util/chain.ts
+++ b/packages/taro-webpack-runner/src/util/chain.ts
@@ -487,8 +487,11 @@ export const getModule = (appPath: string, {
   }
   rule.script = {
     test: REG_SCRIPTS,
+    exclude: [filename => /node_modules/.test(filename)],
     use: {
-      babelLoader: getBabelLoader([{}])
+      babelLoader: getBabelLoader([{
+        compact: false
+      }])
     }
   }
   rule.media = {


### PR DESCRIPTION
* taro-components 合并父子组件到同一文件，减少资源请求
* babel loader 不处理 node_modules 里的文件，加快构建速度