### PR TITLE
fix(mini-runner): 修复快应用动态class不支持三目运算符问题 (#5556)

### DIFF
--- a/packages/taro-mini-runner/src/quickapp/template/serialize.ts
+++ b/packages/taro-mini-runner/src/quickapp/template/serialize.ts
@@ -11,9 +11,9 @@ const createAttrsCode = (attrs) => {
     if (attrsKey.length) {
         attrsCode = ' ' + attrsKey.map(name => {
             if (!attrs[name] && ~ATTRS_NAME.indexOf(name)) {
-                return `${name}='true'`
+                return `${name}="true"`
             }
-            return name === 'else' ? `${name}` : `${name}='${attrs[name]}'`
+            return name === 'else' ? `${name}` : `${name}="${attrs[name]}"`
         }).join(' ')
     }
     return attrsCode
@@ -31,11 +31,11 @@ const createNodeCode = (name, children, content, attrsCode, $delete, url) => {
 const walk = (node) => {
     const attrsCode = createAttrsCode(node.attributes)
     const nodeCode = createNodeCode(
-        node.name, 
-        node.children, 
-        node.content, 
-        attrsCode, 
-        node.$delete, 
+        node.name,
+        node.children,
+        node.content,
+        attrsCode,
+        node.$delete,
         node.url
     )
     return nodeCode


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)



**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [x] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
