### PR TITLE
fix(webpack-runner): 修复h5 跳转到分包页报错的问题

### DIFF
--- a/packages/taro-webpack-runner/src/plugins/MainPlugin.ts
+++ b/packages/taro-webpack-runner/src/plugins/MainPlugin.ts
@@ -152,6 +152,8 @@ export default class MainPlugin {
                 name: pageItem,
                 path: pagePath
               })
+              // eslint-disable-next-line no-unused-expressions
+              this.appConfig.pages?.push(pageItem)
             }
           })
         }


### PR DESCRIPTION
将 subpackages 的页面路径加入到 app.json 的 pages 字段中，让路由能够识别分包页