### PR TITLE
chore(ci): 2.x 自动发布版本

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,115 @@
+name: publish
+on:
+  # When Release Pull Request is merged
+  pull_request:
+    branches:
+      - 2.x
+    types: [closed]
+
+env:
+  CI: true
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name : GITHUB CONTEXT
+        env: 
+          GITHUB_CONTEXT: ${{ toJson(github) }} 
+        run: echo "$GITHUB_CONTEXT" 
+      - name: Get commit message
+        run: |
+           echo ::set-env name=commitmsg::$(git log --format=%B -n 1 ${{ github.event.after }})
+      - name: Show commit message
+        run : echo $commitmsg
+      - name: Setup Node ${{ matrix.node_version }}
+        uses: actions/setup-node@v1
+        with:
+          node_version: 12
+          registry-url: 'https://registry.npmjs.org'
+      - name: Git Identity
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/$GITHUB_REPOSITORY
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: install
+        if: startsWith( env.commitmsg , 'chore(release):' )
+        run: npm install
+      - name: bootstrap
+        if: startsWith( env.commitmsg , 'chore(release):' )
+        run: npm run bootstrap:lerna
+      - name: build
+        if: startsWith( env.commitmsg , 'chore(release):' )
+        run: npm run build
+      # Define ${CURRENT_VERSION}
+      - name: Set Current Version
+        if: startsWith( env.commitmsg , 'chore(release):' )
+        shell: bash -ex {0}
+        run: |
+          CURRENT_VERSION=$(node -p 'require("./lerna.json").version')
+          echo "::set-env name=CURRENT_VERSION::${CURRENT_VERSION}"
+      - name: Tag Check
+        if: startsWith( env.commitmsg , 'chore(release):' )
+        id: tag_check
+        shell: bash -ex {0}
+        run: |
+          GET_API_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/git/ref/tags/v${CURRENT_VERSION}"
+          http_status_code=$(curl -LI $GET_API_URL -o /dev/null -w '%{http_code}\n' -s \
+            -H "Authorization: token ${GITHUB_TOKEN}")
+          if [ "$http_status_code" -ne "404" ] ; then
+            echo "::set-output name=exists_tag::true"
+          else
+            echo "::set-output name=exists_tag::false"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Git Tag
+        if: startsWith( env.commitmsg , 'chore(release):' ) && steps.tag_check.outputs.exists_tag == 'false'
+        uses: azu/action-package-version-to-git-tag@v1
+        with:
+          version: ${{ env.CURRENT_VERSION }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_repo: ${{ github.repository }}
+          git_commit_sha: ${{ github.sha }}
+          git_tag_prefix: "v"
+      - name: Create Release
+        id: create_release
+        if: startsWith( env.commitmsg , 'chore(release):' ) && steps.tag_check.outputs.exists_tag == 'false' && github.event.pull_request.merged == true
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ env.CURRENT_VERSION }}
+          # Copy Pull Request's tile and body to Release Note
+          release_name: ${{ github.event.pull_request.title }}
+          body: |
+            ${{ github.event.pull_request.body }}
+          draft: false
+          prerelease: false
+      - name: Drop current changes
+        if: startsWith( env.commitmsg , 'chore(release):' )
+        run: |
+          git add .
+          git stash
+      - name: Publish
+        if: steps.tag_check.outputs.exists_tag == 'false' && startsWith( env.commitmsg , 'chore(release):' )
+        run: |
+          npm run release:only
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - uses: actions/github-script@0.8.0
+        if: startsWith( env.commitmsg , 'chore(release):' )
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'https://github.com/${{ github.repository }}/releases/tag/v${{ env.CURRENT_VERSION }} is released 🎉'
+            })

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name : GITHUB CONTEXT
-        env: 
-          GITHUB_CONTEXT: ${{ toJson(github) }} 
-        run: echo "$GITHUB_CONTEXT" 
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
       - name: Get commit message
         run: |
            echo ::set-env name=commitmsg::$(git log --format=%B -n 1 ${{ github.event.after }})
@@ -37,23 +37,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: install
-        if: startsWith( env.commitmsg , 'chore(release):' )
+        if: startsWith( env.commitmsg , 'chore(release):' ) && !contains( env.commitmsg , '[skip ci]' )
         run: npm install
       - name: bootstrap
-        if: startsWith( env.commitmsg , 'chore(release):' )
+        if: startsWith( env.commitmsg , 'chore(release):' ) && !contains( env.commitmsg , '[skip ci]' )
         run: npm run bootstrap:lerna
       - name: build
-        if: startsWith( env.commitmsg , 'chore(release):' )
+        if: startsWith( env.commitmsg , 'chore(release):' ) && !contains( env.commitmsg , '[skip ci]' )
         run: npm run build
       # Define ${CURRENT_VERSION}
       - name: Set Current Version
-        if: startsWith( env.commitmsg , 'chore(release):' )
+        if: startsWith( env.commitmsg , 'chore(release):' ) && !contains( env.commitmsg , '[skip ci]' )
         shell: bash -ex {0}
         run: |
           CURRENT_VERSION=$(node -p 'require("./lerna.json").version')
           echo "::set-env name=CURRENT_VERSION::${CURRENT_VERSION}"
       - name: Tag Check
-        if: startsWith( env.commitmsg , 'chore(release):' )
+        if: startsWith( env.commitmsg , 'chore(release):' ) && !contains( env.commitmsg , '[skip ci]' )
         id: tag_check
         shell: bash -ex {0}
         run: |
@@ -68,7 +68,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Git Tag
-        if: startsWith( env.commitmsg , 'chore(release):' ) && steps.tag_check.outputs.exists_tag == 'false'
+        if: startsWith( env.commitmsg , 'chore(release):' ) && steps.tag_check.outputs.exists_tag == 'false' && !contains( env.commitmsg , '[skip ci]' )
         uses: azu/action-package-version-to-git-tag@v1
         with:
           version: ${{ env.CURRENT_VERSION }}
@@ -78,7 +78,7 @@ jobs:
           git_tag_prefix: "v"
       - name: Create Release
         id: create_release
-        if: startsWith( env.commitmsg , 'chore(release):' ) && steps.tag_check.outputs.exists_tag == 'false' && github.event.pull_request.merged == true
+        if: startsWith( env.commitmsg , 'chore(release):' ) && steps.tag_check.outputs.exists_tag == 'false' && github.event.pull_request.merged == true && !contains( env.commitmsg , '[skip ci]' )
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -91,19 +91,19 @@ jobs:
           draft: false
           prerelease: false
       - name: Drop current changes
-        if: startsWith( env.commitmsg , 'chore(release):' )
+        if: startsWith( env.commitmsg , 'chore(release):' ) && !contains( env.commitmsg , '[skip ci]' )
         run: |
           git add .
           git stash
       - name: Publish
-        if: steps.tag_check.outputs.exists_tag == 'false' && startsWith( env.commitmsg , 'chore(release):' )
+        if: steps.tag_check.outputs.exists_tag == 'false' && startsWith( env.commitmsg , 'chore(release):' ) && !contains( env.commitmsg , '[skip ci]' )
         run: |
           npm run release:only
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - uses: actions/github-script@0.8.0
-        if: startsWith( env.commitmsg , 'chore(release):' )
+        if: startsWith( env.commitmsg , 'chore(release):' ) && !contains( env.commitmsg , '[skip ci]' )
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "build:docs": "node ./build/docs.js",
     "build:docs-api": "ts-node --project ./scripts/tsconfig.json ./scripts/docs-api.ts --verbose",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
+    "versionup": "lerna publish --force-publish=* --skip-git --skip-npm",
+    "release:only": "lerna exec -- npm publish",
     "release:lerna": "lerna publish --force-publish=* --exact --skip-temp-tag --preid=minor",
     "release:beta": "lerna publish --force-publish=* --exact --skip-temp-tag  --preid=beta --npm-tag=beta",
     "release": "npm-run-all build release:lerna && npm run changelog && node ./build/docs-version.js",


### PR DESCRIPTION
这个 PR 在 `2.x` 分支实现版本自动发布。

## 发布角色
1. [项目维护者] 在本地开发版本发布分支并发起 Pull Request
2. [Taro 团队] Review 版本发布分支 PR
3. [CI] 发布版本

## 发布流程

1. [本地] checkout 发布分支：`git checkout -b release/<semver>`
2. [本地] 运行 `npm run versionup ` 和 `npm run changelog` 修改 `CHANGELOG.md` 和 `package.json` 以及 `lerna.json`
	* 本地只修改文件，不发布 `git tag`, `GitHub Release` 和 NPM 版本
3. [本地] 提交版本发布分支 Pull Request
4. [GitHub] Review 并 merge 版本发布分支
	* 使用 `Squash and merge` 合并分支
	* 合并提交信息必须为包含 `chore(release): publish <semver>`
5. [CI] 校验版本发布分支的提交信息是否为 `chore(release): publish <semver>`
6. [CI] 添加 `git tag <semver>`
7. [CI] 将版本发布分支 PR 的标题和内容发布到 GitHub Release 页面
8. [CI] 发布版本到 NPM

## skip
提交信息若以 `chore(release):` 开头，但又包含 `[skip ci]` 可以跳过此流程。