### PR TITLE
fix(components): h5端image组件缩放方式使用css实现

### DIFF
--- a/packages/taro-components/src/components/image/index.js
+++ b/packages/taro-components/src/components/image/index.js
@@ -9,8 +9,7 @@ class Image extends Nerv.Component {
   constructor () {
     super(...arguments)
     this.state = {
-      isLoaded: false,
-      aspectFillMode: 'width'
+      isLoaded: false
     }
     this.imageOnLoad = this.imageOnLoad.bind(this)
     this.observer = {}
@@ -46,11 +45,6 @@ class Image extends Nerv.Component {
         height: this.imgRef.height
       }
     })
-    if (this.imgRef.naturalWidth > this.imgRef.naturalHeight) {
-      this.setState({ aspectFillMode: 'width' })
-    } else {
-      this.setState({ aspectFillMode: 'height' })
-    }
     onLoad && onLoad(e)
   }
 
@@ -65,7 +59,6 @@ class Image extends Nerv.Component {
       imgProps,
       ...reset
     } = this.props
-    const { aspectFillMode } = this.state
     const cls = classNames(
       'taro-img',
       {
@@ -75,10 +68,7 @@ class Image extends Nerv.Component {
     )
     const imgCls = classNames(
       'taro-img__mode-' +
-        (mode || 'scaleToFill').toLowerCase().replace(/\s/g, ''),
-      {
-        [`taro-img__mode-aspectfill--${aspectFillMode}`]: mode === 'aspectFill'
-      }
+        (mode || 'scaleToFill').toLowerCase().replace(/\s/g, '')
     )
 
     return (

--- a/packages/taro-components/src/components/image/style/index.scss
+++ b/packages/taro-components/src/components/image/style/index.scss
@@ -13,26 +13,19 @@ img[src=""] {
   }
   &__mode {
     &-scaletofill {
+      object-fit: contain;
       width: 100%;
       height: 100%;
     }
     &-aspectfit {
-      max-width: 100%;
-      max-height: 100%;
+      object-fit: contain;
+      width: 100%;
+      height: 100%;
     }
     &-aspectfill {
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      &--width {
-        min-width: 100%;
-        height: 100%;
-      }
-      &--height {
-        width: 100%;
-        min-height: 100%;
-      }
+      object-fit: cover;
+      width: 100%;
+      height: 100%;
     }
     &-widthfix {
       width: 100%;


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
h5端，mode实现部分的代码重构，[我之前的实现](https://github.com/NervJS/taro/pull/4897)代码不是很优雅，同时也带来了额外一次setState。 这次改用css方式，使用[object-fit](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit)实现


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [x] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
