### PR TITLE
feat(runtime): 普通组件可以通过 eventCenter 触发页面组件的 onReady 事件

### DIFF
--- a/packages/taro-runtime/src/current.ts
+++ b/packages/taro-runtime/src/current.ts
@@ -2,7 +2,8 @@ import { AppInstance, PageInstance } from './dsl/instance'
 
 interface Router {
   params: Record<string, unknown>
-  path: string
+  path: string,
+  onReady: string
 }
 
 interface Current {

--- a/packages/taro/types/taro.extend.d.ts
+++ b/packages/taro/types/taro.extend.d.ts
@@ -109,6 +109,7 @@ declare namespace Taro {
   const Current: {
     app: AppInstance | null,
     router: RouterInfo | null,
-    page: PageInstance | null
+    page: PageInstance | null,
+    onReady: string
   }
 }


### PR DESCRIPTION
形如以下代码：
```jsx
class Test extends React.Component {
  componentDidMount () {
    Taro.eventCenter.once(Taro.Current.router.onReady, () => {
      const query = Taro.createSelectorQuery()
      query.select('#only').boundingClientRect()
      query.exec(res => {
        console.log(res, 'res')
      })
      console.log('onReady')
    })
  }

  render () {
    return (
      <View id="only">
      </View>
    )
  }
}
```