### PR TITLE
fix(mini-runner): prerender 能够正确处理对象属性

### DIFF
--- a/packages/taro-mini-runner/src/prerender/prerender.ts
+++ b/packages/taro-mini-runner/src/prerender/prerender.ts
@@ -25,19 +25,19 @@ function unquote (str: string) {
   return str
 }
 
-function getAttrValue (value: string) {
+function getAttrValue (value) {
   if (typeof value === 'object') {
     try {
       const res = JSON.stringify(value)
-      return res.replace(/"/g, '\'')
+      return `'${res}'`
     } catch (error) {}
   }
 
   if (value === 'true' || value === 'false' || !isString(value)) {
-    return `{{${value}}}`
+    return `"{{${value}}}"`
   }
 
-  return unquote(value)
+  return `"${unquote(value)}"`
 }
 
 interface MiniData {
@@ -191,7 +191,7 @@ export class Prerender {
     return Object.keys(attrs)
       .filter(Boolean)
       .filter(k => !k.startsWith('bind') || !k.startsWith('on'))
-      .map(k => `${k}="${getAttrValue(attrs[k])}" `)
+      .map(k => `${k}=${getAttrValue(attrs[k])} `)
       .join('')
   }
 

--- a/packages/taro-mini-runner/src/prerender/prerender.ts
+++ b/packages/taro-mini-runner/src/prerender/prerender.ts
@@ -26,6 +26,13 @@ function unquote (str: string) {
 }
 
 function getAttrValue (value: string) {
+  if (typeof value === 'object') {
+    try {
+      const res = JSON.stringify(value)
+      return res.replace(/"/g, '\'')
+    } catch (error) {}
+  }
+
   if (value === 'true' || value === 'false' || !isString(value)) {
     return `{{${value}}}`
   }


### PR DESCRIPTION
目前 prerender 对属性变量是使用字符串模板转换为字符串，当变量为对象时转换会出错。因此如果属性值为对象时，首先尝试使用 JSON.stringify 进行转换。