### PR TITLE
chore(mini-runner): 升级 url-loader 到 3.0，fix #6148

### DIFF
--- a/packages/taro-mini-runner/package.json
+++ b/packages/taro-mini-runner/package.json
@@ -70,7 +70,7 @@
     "stylus-loader": "^3.0.2",
     "tapable": "1.1.3",
     "terser-webpack-plugin": "2.3.5",
-    "url-loader": "^2.0.0",
+    "url-loader": "3.0.0",
     "vm2": "^3.8.4",
     "vue-loader": "^15.7.2",
     "vue-template-compiler": "^2.6.10",


### PR DESCRIPTION
因为 h5-runner 用了 3.0，且 url-loader 3.0 有一些 breaking Changes，因此同步一下版本