### PR TITLE
fix(cli): 修复 taro-init，fix #6273

### DIFF
--- a/packages/taro-cli/src/create/creator.ts
+++ b/packages/taro-cli/src/create/creator.ts
@@ -98,6 +98,10 @@ export default class Creator {
     if (filepath.endsWith('package.json.tmpl')) {
       filepath = filepath.replace('.tmpl', '')
     }
+    const basename = path.basename(filepath)
+    if (basename.startsWith('_')) {
+      filepath = path.join(path.dirname(filepath), basename.replace(/^_/, '.'))
+    }
     return filepath
   }
 

--- a/packages/taro-cli/src/create/init.ts
+++ b/packages/taro-cli/src/create/init.ts
@@ -117,7 +117,9 @@ function createFiles (
 
     // 创建
     creater.template(template, fileRePath, path.join(projectPath, destRePath), config)
-    logs.push(`${chalk.green('✔ ')}${chalk.grey(`创建文件: ${path.join(projectName, destRePath)}`)}`)
+
+    const destinationPath = creater.destinationPath(path.join(projectPath, destRePath))
+    logs.push(`${chalk.green('✔ ')}${chalk.grey(`创建文件: ${path.join(projectName, destinationPath)}`)}`)
   })
   return logs
 }
@@ -153,25 +155,11 @@ export async function createPage (creater: Creator, params: IPageConf, cb) {
 }
 
 export async function createApp (creater: Creator, params: IProjectConf, cb) {
-  const { projectName, projectDir, template, env, autoInstall = true, framework } = params
+  const { projectName, projectDir, template, autoInstall = true, framework } = params
   const logs: string[] = []
   // path
   const templatePath = creater.templatePath(template)
   const projectPath = path.join(projectDir, projectName)
-
-  // default 模板发布 npm 会滤掉 '.' 开头的文件，因此改为 '_' 开头，这里先改回来。
-  if (env !== 'test' && template === 'default') {
-    const files = await fs.readdir(templatePath)
-    const renames = files.map(file => {
-      const filePath = path.join(templatePath, file)
-      if (fs.statSync(filePath).isFile() && file.startsWith('_')) {
-        return fs.rename(filePath, path.join(templatePath, file.replace(/^_/, '.')))
-      }
-      return Promise.resolve()
-    })
-
-    await Promise.all(renames)
-  }
 
   // npm & yarn
   const version = helper.getPkgVersion()

--- a/packages/taro-cli/templates/default/_editorconfig
+++ b/packages/taro-cli/templates/default/_editorconfig
@@ -1,0 +1,12 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/taro-cli/templates/default/_eslintrc
+++ b/packages/taro-cli/templates/default/_eslintrc
@@ -1,0 +1,26 @@
+{
+<%if (!locals.typescript) {-%>
+  "extends": ["taro"],
+  "rules": {
+    "no-unused-vars": ["error", { "varsIgnorePattern": "Taro" }],
+    "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx", ".tsx"] }]
+  },
+  "parser": "babel-eslint"
+  <%} else {-%>
+  "extends": ["taro", "plugin:@typescript-eslint/recommended"],
+  "parser": "@typescript-eslint/parser",
+  "rules": {
+    "no-unused-vars": ["error", { "varsIgnorePattern": "Taro" }],
+    "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx", ".tsx"] }],
+    "@typescript-eslint/explicit-function-return-type": 0,
+    "@typescript-eslint/no-empty-function": ["warn"]
+  },
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "useJSXTextNode": true,
+    "project": "./tsconfig.json"
+  }
+<%}-%>
+}

--- a/packages/taro-cli/templates/default/_gitignore
+++ b/packages/taro-cli/templates/default/_gitignore
@@ -1,0 +1,6 @@
+dist/
+deploy_versions/
+.temp/
+.rn_temp/
+node_modules/
+.DS_Store

--- a/packages/taro-cli/templates/default/_npmrc
+++ b/packages/taro-cli/templates/default/_npmrc
@@ -1,0 +1,10 @@
+registry=https://registry.npm.taobao.org
+disturl=https://npm.taobao.org/dist
+sass_binary_site=https://npm.taobao.org/mirrors/node-sass/
+phantomjs_cdnurl=https://npm.taobao.org/mirrors/phantomjs/
+electron_mirror=https://npm.taobao.org/mirrors/electron/
+chromedriver_cdnurl=https://npm.taobao.org/mirrors/chromedriver
+operadriver_cdnurl=https://npm.taobao.org/mirrors/operadriver
+selenium_cdnurl=https://npm.taobao.org/mirrors/selenium
+node_inspector_cdnurl=https://npm.taobao.org/mirrors/node-inspector
+fsevents_binary_host_mirror=http://npm.taobao.org/mirrors/fsevents/


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

* taro-init 会创建 .editorconfig、.eslintrc、.gitignore、.npmrc
* 优化 taro-init 的 logs

**这个 PR 是什么类型?**

- [x] 错误修复(Bugfix) issue id #6273

**这个 PR 满足以下需求:**

- [x] 提交到 next 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [x] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [x] 移动端（React-Native）
