### PR TITLE
fix(mini-runner): 修复支付宝使用 async await 报错，fix #6278

### DIFF
--- a/packages/taro-mini-runner/__tests__/__snapshots__/alipay.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/alipay.spec.ts.snap
@@ -16,21 +16,21 @@ require(\\"./taro\\");
     11: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         if (true) {
-            module.exports = __webpack_require__(27);
+            module.exports = __webpack_require__(28);
         } else {}
     },
-    17: function(module, exports, __webpack_require__) {
+    18: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         if (true) {
-            module.exports = __webpack_require__(25);
+            module.exports = __webpack_require__(26);
         } else {}
     },
-    24: function(module, exports, __webpack_require__) {},
-    25: function(module, exports, __webpack_require__) {
-        var _typeof = __webpack_require__(14);
+    25: function(module, exports, __webpack_require__) {},
+    26: function(module, exports, __webpack_require__) {
+        var _typeof = __webpack_require__(13);
         module.exports = function $$$reconciler($$$hostConfig) {
             \\"use strict\\";
-            var aa = __webpack_require__(26), ba = __webpack_require__(6), m = __webpack_require__(11);
+            var aa = __webpack_require__(27), ba = __webpack_require__(6), m = __webpack_require__(11);
             function n(a) {
                 for (var b = \\"https://reactjs.org/docs/error-decoder.html?invariant=\\" + a, c = 1; c < arguments.length; c++) {
                     b += \\"&args[]=\\" + encodeURIComponent(arguments[c]);
@@ -4017,7 +4017,7 @@ require(\\"./taro\\");
             return $$$renderer;
         };
     },
-    26: function(module, exports, __webpack_require__) {
+    27: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         var getOwnPropertySymbols = Object.getOwnPropertySymbols;
         var hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -4083,10 +4083,10 @@ require(\\"./taro\\");
             return to;
         };
     },
-    27: function(module, exports, __webpack_require__) {
+    28: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         (function(window) {
-            var _typeof = __webpack_require__(14);
+            var _typeof = __webpack_require__(13);
             Object.defineProperty(exports, \\"__esModule\\", {
                 value: !0
             });
@@ -4359,7 +4359,7 @@ require(\\"./taro\\");
             exports.unstable_Profiling = null;
         }).call(this, __webpack_require__(3)[\\"window\\"]);
     },
-    30: function(module, __webpack_exports__, __webpack_require__) {
+    35: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         __webpack_require__.r(__webpack_exports__);
         var runtime_esm = __webpack_require__(3);
@@ -4369,7 +4369,7 @@ require(\\"./taro\\");
         var getPrototypeOf = __webpack_require__(2);
         var inherits = __webpack_require__(5);
         var react = __webpack_require__(6);
-        var app = __webpack_require__(24);
+        var app = __webpack_require__(25);
         var app_App = function(_Component) {
             Object(inherits[\\"a\\"])(App, _Component);
             function App() {
@@ -4397,10 +4397,10 @@ require(\\"./taro\\");
             return App;
         }(react[\\"Component\\"]);
         var lib_src_app = app_App;
-        var react_esm = __webpack_require__(16);
+        var react_esm = __webpack_require__(17);
         var inst = App(Object(runtime_esm[\\"createReactApp\\"])(lib_src_app, react, react_esm[\\"a\\"]));
     }
-}, [ [ 30, 0, 1, 2 ] ] ]);
+}, [ [ 35, 0, 1, 2 ] ] ]);
 
 
 
@@ -5471,13 +5471,13 @@ object-assign
 
 /** filePath: dist/comp.js **/
 (wx[\\"webpackJsonp\\"] = wx[\\"webpackJsonp\\"] || []).push([ [ 5 ], {
-    28: function(module, __webpack_exports__, __webpack_require__) {
+    29: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         __webpack_require__.r(__webpack_exports__);
         var _tarojs_runtime__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(3);
         Component(Object(_tarojs_runtime__WEBPACK_IMPORTED_MODULE_0__[\\"createRecursiveComponentConfig\\"])());
     }
-}, [ [ 28, 0, 1, 2 ] ] ]);
+}, [ [ 29, 0, 1, 2 ] ] ]);
 
 /** filePath: dist/comp.json **/
 {\\"component\\":true,\\"usingComponents\\":{\\"comp\\":\\"./comp\\"}}
@@ -5488,11 +5488,556 @@ object-assign
 
 /** filePath: dist/pages/index/index.js **/
 (wx[\\"webpackJsonp\\"] = wx[\\"webpackJsonp\\"] || []).push([ [ 6 ], {
-    29: function(module, exports, __webpack_require__) {},
-    31: function(module, __webpack_exports__, __webpack_require__) {
+    15: function(module, exports, __webpack_require__) {
+        module.exports = __webpack_require__(30);
+    },
+    30: function(module, exports, __webpack_require__) {
+        var g = function() {
+            return this;
+        }() || Function(\\"return this\\")();
+        var hadRuntime = g.regeneratorRuntime && Object.getOwnPropertyNames(g).indexOf(\\"regeneratorRuntime\\") >= 0;
+        var oldRuntime = hadRuntime && g.regeneratorRuntime;
+        g.regeneratorRuntime = undefined;
+        module.exports = __webpack_require__(31);
+        if (hadRuntime) {
+            g.regeneratorRuntime = oldRuntime;
+        } else {
+            try {
+                delete g.regeneratorRuntime;
+            } catch (e) {
+                g.regeneratorRuntime = undefined;
+            }
+        }
+    },
+    31: function(module, exports, __webpack_require__) {
+        (function(module) {
+            var _typeof = __webpack_require__(13);
+            !function(global) {
+                \\"use strict\\";
+                var Op = Object.prototype;
+                var hasOwn = Op.hasOwnProperty;
+                var undefined;
+                var $Symbol = typeof Symbol === \\"function\\" ? Symbol : {};
+                var iteratorSymbol = $Symbol.iterator || \\"@@iterator\\";
+                var asyncIteratorSymbol = $Symbol.asyncIterator || \\"@@asyncIterator\\";
+                var toStringTagSymbol = $Symbol.toStringTag || \\"@@toStringTag\\";
+                var inModule = (false ? undefined : _typeof(module)) === \\"object\\";
+                var runtime = global.regeneratorRuntime;
+                if (runtime) {
+                    if (inModule) {
+                        module.exports = runtime;
+                    }
+                    return;
+                }
+                runtime = global.regeneratorRuntime = inModule ? module.exports : {};
+                function wrap(innerFn, outerFn, self, tryLocsList) {
+                    var protoGenerator = outerFn && outerFn.prototype instanceof Generator ? outerFn : Generator;
+                    var generator = Object.create(protoGenerator.prototype);
+                    var context = new Context(tryLocsList || []);
+                    generator._invoke = makeInvokeMethod(innerFn, self, context);
+                    return generator;
+                }
+                runtime.wrap = wrap;
+                function tryCatch(fn, obj, arg) {
+                    try {
+                        return {
+                            type: \\"normal\\",
+                            arg: fn.call(obj, arg)
+                        };
+                    } catch (err) {
+                        return {
+                            type: \\"throw\\",
+                            arg: err
+                        };
+                    }
+                }
+                var GenStateSuspendedStart = \\"suspendedStart\\";
+                var GenStateSuspendedYield = \\"suspendedYield\\";
+                var GenStateExecuting = \\"executing\\";
+                var GenStateCompleted = \\"completed\\";
+                var ContinueSentinel = {};
+                function Generator() {}
+                function GeneratorFunction() {}
+                function GeneratorFunctionPrototype() {}
+                var IteratorPrototype = {};
+                IteratorPrototype[iteratorSymbol] = function() {
+                    return this;
+                };
+                var getProto = Object.getPrototypeOf;
+                var NativeIteratorPrototype = getProto && getProto(getProto(values([])));
+                if (NativeIteratorPrototype && NativeIteratorPrototype !== Op && hasOwn.call(NativeIteratorPrototype, iteratorSymbol)) {
+                    IteratorPrototype = NativeIteratorPrototype;
+                }
+                var Gp = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(IteratorPrototype);
+                GeneratorFunction.prototype = Gp.constructor = GeneratorFunctionPrototype;
+                GeneratorFunctionPrototype.constructor = GeneratorFunction;
+                GeneratorFunctionPrototype[toStringTagSymbol] = GeneratorFunction.displayName = \\"GeneratorFunction\\";
+                function defineIteratorMethods(prototype) {
+                    [ \\"next\\", \\"throw\\", \\"return\\" ].forEach((function(method) {
+                        prototype[method] = function(arg) {
+                            return this._invoke(method, arg);
+                        };
+                    }));
+                }
+                runtime.isGeneratorFunction = function(genFun) {
+                    var ctor = typeof genFun === \\"function\\" && genFun.constructor;
+                    return ctor ? ctor === GeneratorFunction || (ctor.displayName || ctor.name) === \\"GeneratorFunction\\" : false;
+                };
+                runtime.mark = function(genFun) {
+                    if (Object.setPrototypeOf) {
+                        Object.setPrototypeOf(genFun, GeneratorFunctionPrototype);
+                    } else {
+                        genFun.__proto__ = GeneratorFunctionPrototype;
+                        if (!(toStringTagSymbol in genFun)) {
+                            genFun[toStringTagSymbol] = \\"GeneratorFunction\\";
+                        }
+                    }
+                    genFun.prototype = Object.create(Gp);
+                    return genFun;
+                };
+                runtime.awrap = function(arg) {
+                    return {
+                        __await: arg
+                    };
+                };
+                function AsyncIterator(generator) {
+                    function invoke(method, arg, resolve, reject) {
+                        var record = tryCatch(generator[method], generator, arg);
+                        if (record.type === \\"throw\\") {
+                            reject(record.arg);
+                        } else {
+                            var result = record.arg;
+                            var value = result.value;
+                            if (value && _typeof(value) === \\"object\\" && hasOwn.call(value, \\"__await\\")) {
+                                return Promise.resolve(value.__await).then((function(value) {
+                                    invoke(\\"next\\", value, resolve, reject);
+                                }), (function(err) {
+                                    invoke(\\"throw\\", err, resolve, reject);
+                                }));
+                            }
+                            return Promise.resolve(value).then((function(unwrapped) {
+                                result.value = unwrapped;
+                                resolve(result);
+                            }), reject);
+                        }
+                    }
+                    var previousPromise;
+                    function enqueue(method, arg) {
+                        function callInvokeWithMethodAndArg() {
+                            return new Promise((function(resolve, reject) {
+                                invoke(method, arg, resolve, reject);
+                            }));
+                        }
+                        return previousPromise = previousPromise ? previousPromise.then(callInvokeWithMethodAndArg, callInvokeWithMethodAndArg) : callInvokeWithMethodAndArg();
+                    }
+                    this._invoke = enqueue;
+                }
+                defineIteratorMethods(AsyncIterator.prototype);
+                AsyncIterator.prototype[asyncIteratorSymbol] = function() {
+                    return this;
+                };
+                runtime.AsyncIterator = AsyncIterator;
+                runtime.async = function(innerFn, outerFn, self, tryLocsList) {
+                    var iter = new AsyncIterator(wrap(innerFn, outerFn, self, tryLocsList));
+                    return runtime.isGeneratorFunction(outerFn) ? iter : iter.next().then((function(result) {
+                        return result.done ? result.value : iter.next();
+                    }));
+                };
+                function makeInvokeMethod(innerFn, self, context) {
+                    var state = GenStateSuspendedStart;
+                    return function invoke(method, arg) {
+                        if (state === GenStateExecuting) {
+                            throw new Error(\\"Generator is already running\\");
+                        }
+                        if (state === GenStateCompleted) {
+                            if (method === \\"throw\\") {
+                                throw arg;
+                            }
+                            return doneResult();
+                        }
+                        context.method = method;
+                        context.arg = arg;
+                        while (true) {
+                            var delegate = context.delegate;
+                            if (delegate) {
+                                var delegateResult = maybeInvokeDelegate(delegate, context);
+                                if (delegateResult) {
+                                    if (delegateResult === ContinueSentinel) continue;
+                                    return delegateResult;
+                                }
+                            }
+                            if (context.method === \\"next\\") {
+                                context.sent = context._sent = context.arg;
+                            } else if (context.method === \\"throw\\") {
+                                if (state === GenStateSuspendedStart) {
+                                    state = GenStateCompleted;
+                                    throw context.arg;
+                                }
+                                context.dispatchException(context.arg);
+                            } else if (context.method === \\"return\\") {
+                                context.abrupt(\\"return\\", context.arg);
+                            }
+                            state = GenStateExecuting;
+                            var record = tryCatch(innerFn, self, context);
+                            if (record.type === \\"normal\\") {
+                                state = context.done ? GenStateCompleted : GenStateSuspendedYield;
+                                if (record.arg === ContinueSentinel) {
+                                    continue;
+                                }
+                                return {
+                                    value: record.arg,
+                                    done: context.done
+                                };
+                            } else if (record.type === \\"throw\\") {
+                                state = GenStateCompleted;
+                                context.method = \\"throw\\";
+                                context.arg = record.arg;
+                            }
+                        }
+                    };
+                }
+                function maybeInvokeDelegate(delegate, context) {
+                    var method = delegate.iterator[context.method];
+                    if (method === undefined) {
+                        context.delegate = null;
+                        if (context.method === \\"throw\\") {
+                            if (delegate.iterator.return) {
+                                context.method = \\"return\\";
+                                context.arg = undefined;
+                                maybeInvokeDelegate(delegate, context);
+                                if (context.method === \\"throw\\") {
+                                    return ContinueSentinel;
+                                }
+                            }
+                            context.method = \\"throw\\";
+                            context.arg = new TypeError(\\"The iterator does not provide a 'throw' method\\");
+                        }
+                        return ContinueSentinel;
+                    }
+                    var record = tryCatch(method, delegate.iterator, context.arg);
+                    if (record.type === \\"throw\\") {
+                        context.method = \\"throw\\";
+                        context.arg = record.arg;
+                        context.delegate = null;
+                        return ContinueSentinel;
+                    }
+                    var info = record.arg;
+                    if (!info) {
+                        context.method = \\"throw\\";
+                        context.arg = new TypeError(\\"iterator result is not an object\\");
+                        context.delegate = null;
+                        return ContinueSentinel;
+                    }
+                    if (info.done) {
+                        context[delegate.resultName] = info.value;
+                        context.next = delegate.nextLoc;
+                        if (context.method !== \\"return\\") {
+                            context.method = \\"next\\";
+                            context.arg = undefined;
+                        }
+                    } else {
+                        return info;
+                    }
+                    context.delegate = null;
+                    return ContinueSentinel;
+                }
+                defineIteratorMethods(Gp);
+                Gp[toStringTagSymbol] = \\"Generator\\";
+                Gp[iteratorSymbol] = function() {
+                    return this;
+                };
+                Gp.toString = function() {
+                    return \\"[object Generator]\\";
+                };
+                function pushTryEntry(locs) {
+                    var entry = {
+                        tryLoc: locs[0]
+                    };
+                    if (1 in locs) {
+                        entry.catchLoc = locs[1];
+                    }
+                    if (2 in locs) {
+                        entry.finallyLoc = locs[2];
+                        entry.afterLoc = locs[3];
+                    }
+                    this.tryEntries.push(entry);
+                }
+                function resetTryEntry(entry) {
+                    var record = entry.completion || {};
+                    record.type = \\"normal\\";
+                    delete record.arg;
+                    entry.completion = record;
+                }
+                function Context(tryLocsList) {
+                    this.tryEntries = [ {
+                        tryLoc: \\"root\\"
+                    } ];
+                    tryLocsList.forEach(pushTryEntry, this);
+                    this.reset(true);
+                }
+                runtime.keys = function(object) {
+                    var keys = [];
+                    for (var key in object) {
+                        keys.push(key);
+                    }
+                    keys.reverse();
+                    return function next() {
+                        while (keys.length) {
+                            var key = keys.pop();
+                            if (key in object) {
+                                next.value = key;
+                                next.done = false;
+                                return next;
+                            }
+                        }
+                        next.done = true;
+                        return next;
+                    };
+                };
+                function values(iterable) {
+                    if (iterable) {
+                        var iteratorMethod = iterable[iteratorSymbol];
+                        if (iteratorMethod) {
+                            return iteratorMethod.call(iterable);
+                        }
+                        if (typeof iterable.next === \\"function\\") {
+                            return iterable;
+                        }
+                        if (!isNaN(iterable.length)) {
+                            var i = -1, next = function next() {
+                                while (++i < iterable.length) {
+                                    if (hasOwn.call(iterable, i)) {
+                                        next.value = iterable[i];
+                                        next.done = false;
+                                        return next;
+                                    }
+                                }
+                                next.value = undefined;
+                                next.done = true;
+                                return next;
+                            };
+                            return next.next = next;
+                        }
+                    }
+                    return {
+                        next: doneResult
+                    };
+                }
+                runtime.values = values;
+                function doneResult() {
+                    return {
+                        value: undefined,
+                        done: true
+                    };
+                }
+                Context.prototype = {
+                    constructor: Context,
+                    reset: function reset(skipTempReset) {
+                        this.prev = 0;
+                        this.next = 0;
+                        this.sent = this._sent = undefined;
+                        this.done = false;
+                        this.delegate = null;
+                        this.method = \\"next\\";
+                        this.arg = undefined;
+                        this.tryEntries.forEach(resetTryEntry);
+                        if (!skipTempReset) {
+                            for (var name in this) {
+                                if (name.charAt(0) === \\"t\\" && hasOwn.call(this, name) && !isNaN(+name.slice(1))) {
+                                    this[name] = undefined;
+                                }
+                            }
+                        }
+                    },
+                    stop: function stop() {
+                        this.done = true;
+                        var rootEntry = this.tryEntries[0];
+                        var rootRecord = rootEntry.completion;
+                        if (rootRecord.type === \\"throw\\") {
+                            throw rootRecord.arg;
+                        }
+                        return this.rval;
+                    },
+                    dispatchException: function dispatchException(exception) {
+                        if (this.done) {
+                            throw exception;
+                        }
+                        var context = this;
+                        function handle(loc, caught) {
+                            record.type = \\"throw\\";
+                            record.arg = exception;
+                            context.next = loc;
+                            if (caught) {
+                                context.method = \\"next\\";
+                                context.arg = undefined;
+                            }
+                            return !!caught;
+                        }
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            var record = entry.completion;
+                            if (entry.tryLoc === \\"root\\") {
+                                return handle(\\"end\\");
+                            }
+                            if (entry.tryLoc <= this.prev) {
+                                var hasCatch = hasOwn.call(entry, \\"catchLoc\\");
+                                var hasFinally = hasOwn.call(entry, \\"finallyLoc\\");
+                                if (hasCatch && hasFinally) {
+                                    if (this.prev < entry.catchLoc) {
+                                        return handle(entry.catchLoc, true);
+                                    } else if (this.prev < entry.finallyLoc) {
+                                        return handle(entry.finallyLoc);
+                                    }
+                                } else if (hasCatch) {
+                                    if (this.prev < entry.catchLoc) {
+                                        return handle(entry.catchLoc, true);
+                                    }
+                                } else if (hasFinally) {
+                                    if (this.prev < entry.finallyLoc) {
+                                        return handle(entry.finallyLoc);
+                                    }
+                                } else {
+                                    throw new Error(\\"try statement without catch or finally\\");
+                                }
+                            }
+                        }
+                    },
+                    abrupt: function abrupt(type, arg) {
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            if (entry.tryLoc <= this.prev && hasOwn.call(entry, \\"finallyLoc\\") && this.prev < entry.finallyLoc) {
+                                var finallyEntry = entry;
+                                break;
+                            }
+                        }
+                        if (finallyEntry && (type === \\"break\\" || type === \\"continue\\") && finallyEntry.tryLoc <= arg && arg <= finallyEntry.finallyLoc) {
+                            finallyEntry = null;
+                        }
+                        var record = finallyEntry ? finallyEntry.completion : {};
+                        record.type = type;
+                        record.arg = arg;
+                        if (finallyEntry) {
+                            this.method = \\"next\\";
+                            this.next = finallyEntry.finallyLoc;
+                            return ContinueSentinel;
+                        }
+                        return this.complete(record);
+                    },
+                    complete: function complete(record, afterLoc) {
+                        if (record.type === \\"throw\\") {
+                            throw record.arg;
+                        }
+                        if (record.type === \\"break\\" || record.type === \\"continue\\") {
+                            this.next = record.arg;
+                        } else if (record.type === \\"return\\") {
+                            this.rval = this.arg = record.arg;
+                            this.method = \\"return\\";
+                            this.next = \\"end\\";
+                        } else if (record.type === \\"normal\\" && afterLoc) {
+                            this.next = afterLoc;
+                        }
+                        return ContinueSentinel;
+                    },
+                    finish: function finish(finallyLoc) {
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            if (entry.finallyLoc === finallyLoc) {
+                                this.complete(entry.completion, entry.afterLoc);
+                                resetTryEntry(entry);
+                                return ContinueSentinel;
+                            }
+                        }
+                    },
+                    catch: function _catch(tryLoc) {
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            if (entry.tryLoc === tryLoc) {
+                                var record = entry.completion;
+                                if (record.type === \\"throw\\") {
+                                    var thrown = record.arg;
+                                    resetTryEntry(entry);
+                                }
+                                return thrown;
+                            }
+                        }
+                        throw new Error(\\"illegal catch attempt\\");
+                    },
+                    delegateYield: function delegateYield(iterable, resultName, nextLoc) {
+                        this.delegate = {
+                            iterator: values(iterable),
+                            resultName: resultName,
+                            nextLoc: nextLoc
+                        };
+                        if (this.method === \\"next\\") {
+                            this.arg = undefined;
+                        }
+                        return ContinueSentinel;
+                    }
+                };
+            }(function() {
+                return this;
+            }() || Function(\\"return this\\")());
+        }).call(this, __webpack_require__(32)(module));
+    },
+    32: function(module, exports) {
+        module.exports = function(module) {
+            if (!module.webpackPolyfill) {
+                module.deprecate = function() {};
+                module.paths = [];
+                if (!module.children) module.children = [];
+                Object.defineProperty(module, \\"loaded\\", {
+                    enumerable: true,
+                    get: function get() {
+                        return module.l;
+                    }
+                });
+                Object.defineProperty(module, \\"id\\", {
+                    enumerable: true,
+                    get: function get() {
+                        return module.i;
+                    }
+                });
+                module.webpackPolyfill = 1;
+            }
+            return module;
+        };
+    },
+    33: function(module, exports, __webpack_require__) {},
+    34: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         __webpack_require__.r(__webpack_exports__);
         var runtime_esm = __webpack_require__(3);
+        var regenerator = __webpack_require__(15);
+        var regenerator_default = __webpack_require__.n(regenerator);
+        function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
+            try {
+                var info = gen[key](arg);
+                var value = info.value;
+            } catch (error) {
+                reject(error);
+                return;
+            }
+            if (info.done) {
+                resolve(value);
+            } else {
+                Promise.resolve(value).then(_next, _throw);
+            }
+        }
+        function _asyncToGenerator(fn) {
+            return function() {
+                var self = this, args = arguments;
+                return new Promise((function(resolve, reject) {
+                    var gen = fn.apply(self, args);
+                    function _next(value) {
+                        asyncGeneratorStep(gen, resolve, reject, _next, _throw, \\"next\\", value);
+                    }
+                    function _throw(err) {
+                        asyncGeneratorStep(gen, resolve, reject, _next, _throw, \\"throw\\", err);
+                    }
+                    _next(undefined);
+                }));
+            };
+        }
         var classCallCheck = __webpack_require__(0);
         var createClass = __webpack_require__(1);
         var possibleConstructorReturn = __webpack_require__(4);
@@ -5501,7 +6046,7 @@ object-assign
         var react = __webpack_require__(6);
         var react_default = __webpack_require__.n(react);
         var mini = __webpack_require__(12);
-        var index = __webpack_require__(29);
+        var index = __webpack_require__(33);
         var index_Index = function(_Component) {
             Object(inherits[\\"a\\"])(Index, _Component);
             function Index() {
@@ -5510,7 +6055,27 @@ object-assign
             }
             Object(createClass[\\"a\\"])(Index, [ {
                 key: \\"componentWillMount\\",
-                value: function componentWillMount() {}
+                value: function() {
+                    var _componentWillMount = _asyncToGenerator(regenerator_default.a.mark((function _callee() {
+                        return regenerator_default.a.wrap((function _callee$(_context) {
+                            while (1) {
+                                switch (_context.prev = _context.next) {
+                                  case 0:
+                                    _context.next = 2;
+                                    return Promise.resolve(1);
+
+                                  case 2:
+                                  case \\"end\\":
+                                    return _context.stop();
+                                }
+                            }
+                        }), _callee);
+                    })));
+                    function componentWillMount() {
+                        return _componentWillMount.apply(this, arguments);
+                    }
+                    return componentWillMount;
+                }()
             }, {
                 key: \\"componentDidMount\\",
                 value: function componentDidMount() {}
@@ -5540,7 +6105,7 @@ object-assign
         }(react[\\"Component\\"]);
         var inst = Page(Object(runtime_esm[\\"createPageConfig\\"])(index_Index, \\"pages/index/index\\"));
     }
-}, [ [ 31, 0, 1, 2 ] ] ]);
+}, [ [ 34, 0, 1, 2 ] ] ]);
 
 /** filePath: dist/pages/index/index.json **/
 {\\"navigationBarTitleText\\":\\"首页\\",\\"usingComponents\\":{\\"comp\\":\\"../../comp\\"}}
@@ -5731,12 +6296,12 @@ object-assign
         var MovableArea = \\"movable-area\\";
         var MovableView = \\"movable-view\\";
     },
-    16: function(module, __webpack_exports__, __webpack_require__) {
+    17: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         var _babel_runtime_helpers_esm_classCallCheck__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
         var _babel_runtime_helpers_esm_createClass__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(1);
         var _babel_runtime_helpers_esm_typeof__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(8);
-        var react_reconciler__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(17);
+        var react_reconciler__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(18);
         var react_reconciler__WEBPACK_IMPORTED_MODULE_3___default = __webpack_require__.n(react_reconciler__WEBPACK_IMPORTED_MODULE_3__);
         var scheduler__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(11);
         var scheduler__WEBPACK_IMPORTED_MODULE_4___default = __webpack_require__.n(scheduler__WEBPACK_IMPORTED_MODULE_4__);
@@ -6219,13 +6784,13 @@ object-assign
             __webpack_require__.d(__webpack_exports__, \\"window\\", (function() {
                 return window$1;
             }));
-            var _babel_runtime_helpers_esm_toConsumableArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(18);
-            var _babel_runtime_helpers_esm_set__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(19);
+            var _babel_runtime_helpers_esm_toConsumableArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(19);
+            var _babel_runtime_helpers_esm_set__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(20);
             var _babel_runtime_helpers_esm_possibleConstructorReturn__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(4);
             var _babel_runtime_helpers_esm_getPrototypeOf__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(2);
             var _babel_runtime_helpers_esm_assertThisInitialized__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(10);
             var _babel_runtime_helpers_esm_inherits__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(5);
-            var _babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(15);
+            var _babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(16);
             var _babel_runtime_helpers_esm_defineProperty__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(7);
             var _babel_runtime_helpers_esm_classCallCheck__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(0);
             var _babel_runtime_helpers_esm_createClass__WEBPACK_IMPORTED_MODULE_9__ = __webpack_require__(1);
@@ -9220,7 +9785,7 @@ object-assign
 }, function(module, exports, __webpack_require__) {
     \\"use strict\\";
     if (true) {
-        module.exports = __webpack_require__(22);
+        module.exports = __webpack_require__(23);
     } else {}
 }, function(module, __webpack_exports__, __webpack_require__) {
     \\"use strict\\";
@@ -9281,21 +9846,7 @@ object-assign
         }
         return self;
     }
-}, , , function(module, __webpack_exports__, __webpack_require__) {
-    \\"use strict\\";
-    __webpack_require__.d(__webpack_exports__, \\"a\\", (function() {
-        return _unsupportedIterableToArray;
-    }));
-    var _arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(9);
-    function _unsupportedIterableToArray(o, minLen) {
-        if (!o) return;
-        if (typeof o === \\"string\\") return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
-        var n = Object.prototype.toString.call(o).slice(8, -1);
-        if (n === \\"Object\\" && o.constructor) n = o.constructor.name;
-        if (n === \\"Map\\" || n === \\"Set\\") return Array.from(o);
-        if (n === \\"Arguments\\" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
-    }
-}, function(module, exports) {
+}, , , function(module, exports) {
     function _typeof(obj) {
         \\"@babel/helpers - typeof\\";
         if (typeof Symbol === \\"function\\" && typeof Symbol.iterator === \\"symbol\\") {
@@ -9311,6 +9862,20 @@ object-assign
     }
     module.exports = _typeof;
 }, function(module, __webpack_exports__, __webpack_require__) {
+    \\"use strict\\";
+    __webpack_require__.d(__webpack_exports__, \\"a\\", (function() {
+        return _unsupportedIterableToArray;
+    }));
+    var _arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(9);
+    function _unsupportedIterableToArray(o, minLen) {
+        if (!o) return;
+        if (typeof o === \\"string\\") return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
+        var n = Object.prototype.toString.call(o).slice(8, -1);
+        if (n === \\"Object\\" && o.constructor) n = o.constructor.name;
+        if (n === \\"Map\\" || n === \\"Set\\") return Array.from(o);
+        if (n === \\"Arguments\\" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
+    }
+}, , function(module, __webpack_exports__, __webpack_require__) {
     \\"use strict\\";
     __webpack_require__.d(__webpack_exports__, \\"a\\", (function() {
         return _slicedToArray;
@@ -9341,7 +9906,7 @@ object-assign
         }
         return _arr;
     }
-    var unsupportedIterableToArray = __webpack_require__(13);
+    var unsupportedIterableToArray = __webpack_require__(14);
     function _nonIterableRest() {
         throw new TypeError(\\"Invalid attempt to destructure non-iterable instance.\\\\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.\\");
     }
@@ -9360,7 +9925,7 @@ object-assign
     function _iterableToArray(iter) {
         if (typeof Symbol !== \\"undefined\\" && Symbol.iterator in Object(iter)) return Array.from(iter);
     }
-    var unsupportedIterableToArray = __webpack_require__(13);
+    var unsupportedIterableToArray = __webpack_require__(14);
     function _nonIterableSpread() {
         throw new TypeError(\\"Invalid attempt to spread non-iterable instance.\\\\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.\\");
     }
@@ -9421,8 +9986,8 @@ object-assign
     }
 }, , , function(module, exports, __webpack_require__) {
     \\"use strict\\";
-    var _typeof = __webpack_require__(14);
-    var l = __webpack_require__(23), n = \\"function\\" === typeof Symbol && Symbol.for, p = n ? Symbol.for(\\"react.element\\") : 60103, q = n ? Symbol.for(\\"react.portal\\") : 60106, r = n ? Symbol.for(\\"react.fragment\\") : 60107, t = n ? Symbol.for(\\"react.strict_mode\\") : 60108, u = n ? Symbol.for(\\"react.profiler\\") : 60114, v = n ? Symbol.for(\\"react.provider\\") : 60109, w = n ? Symbol.for(\\"react.context\\") : 60110, x = n ? Symbol.for(\\"react.forward_ref\\") : 60112, y = n ? Symbol.for(\\"react.suspense\\") : 60113, z = n ? Symbol.for(\\"react.memo\\") : 60115, A = n ? Symbol.for(\\"react.lazy\\") : 60116, B = \\"function\\" === typeof Symbol && Symbol.iterator;
+    var _typeof = __webpack_require__(13);
+    var l = __webpack_require__(24), n = \\"function\\" === typeof Symbol && Symbol.for, p = n ? Symbol.for(\\"react.element\\") : 60103, q = n ? Symbol.for(\\"react.portal\\") : 60106, r = n ? Symbol.for(\\"react.fragment\\") : 60107, t = n ? Symbol.for(\\"react.strict_mode\\") : 60108, u = n ? Symbol.for(\\"react.profiler\\") : 60114, v = n ? Symbol.for(\\"react.provider\\") : 60109, w = n ? Symbol.for(\\"react.context\\") : 60110, x = n ? Symbol.for(\\"react.forward_ref\\") : 60112, y = n ? Symbol.for(\\"react.suspense\\") : 60113, z = n ? Symbol.for(\\"react.memo\\") : 60115, A = n ? Symbol.for(\\"react.lazy\\") : 60116, B = \\"function\\" === typeof Symbol && Symbol.iterator;
     function C(a) {
         for (var b = \\"https://reactjs.org/docs/error-decoder.html?invariant=\\" + a, c = 1; c < arguments.length; c++) {
             b += \\"&args[]=\\" + encodeURIComponent(arguments[c]);

--- a/packages/taro-mini-runner/__tests__/__snapshots__/bytedance.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/bytedance.spec.ts.snap
@@ -16,21 +16,21 @@ require(\\"./taro\\");
     11: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         if (true) {
-            module.exports = __webpack_require__(27);
+            module.exports = __webpack_require__(28);
         } else {}
     },
-    17: function(module, exports, __webpack_require__) {
+    18: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         if (true) {
-            module.exports = __webpack_require__(25);
+            module.exports = __webpack_require__(26);
         } else {}
     },
-    24: function(module, exports, __webpack_require__) {},
-    25: function(module, exports, __webpack_require__) {
-        var _typeof = __webpack_require__(14);
+    25: function(module, exports, __webpack_require__) {},
+    26: function(module, exports, __webpack_require__) {
+        var _typeof = __webpack_require__(13);
         module.exports = function $$$reconciler($$$hostConfig) {
             \\"use strict\\";
-            var aa = __webpack_require__(26), ba = __webpack_require__(6), m = __webpack_require__(11);
+            var aa = __webpack_require__(27), ba = __webpack_require__(6), m = __webpack_require__(11);
             function n(a) {
                 for (var b = \\"https://reactjs.org/docs/error-decoder.html?invariant=\\" + a, c = 1; c < arguments.length; c++) {
                     b += \\"&args[]=\\" + encodeURIComponent(arguments[c]);
@@ -4017,7 +4017,7 @@ require(\\"./taro\\");
             return $$$renderer;
         };
     },
-    26: function(module, exports, __webpack_require__) {
+    27: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         var getOwnPropertySymbols = Object.getOwnPropertySymbols;
         var hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -4083,10 +4083,10 @@ require(\\"./taro\\");
             return to;
         };
     },
-    27: function(module, exports, __webpack_require__) {
+    28: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         (function(window) {
-            var _typeof = __webpack_require__(14);
+            var _typeof = __webpack_require__(13);
             Object.defineProperty(exports, \\"__esModule\\", {
                 value: !0
             });
@@ -4359,7 +4359,7 @@ require(\\"./taro\\");
             exports.unstable_Profiling = null;
         }).call(this, __webpack_require__(3)[\\"window\\"]);
     },
-    30: function(module, __webpack_exports__, __webpack_require__) {
+    35: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         __webpack_require__.r(__webpack_exports__);
         var runtime_esm = __webpack_require__(3);
@@ -4369,7 +4369,7 @@ require(\\"./taro\\");
         var getPrototypeOf = __webpack_require__(2);
         var inherits = __webpack_require__(5);
         var react = __webpack_require__(6);
-        var app = __webpack_require__(24);
+        var app = __webpack_require__(25);
         var app_App = function(_Component) {
             Object(inherits[\\"a\\"])(App, _Component);
             function App() {
@@ -4397,10 +4397,10 @@ require(\\"./taro\\");
             return App;
         }(react[\\"Component\\"]);
         var lib_src_app = app_App;
-        var react_esm = __webpack_require__(16);
+        var react_esm = __webpack_require__(17);
         var inst = App(Object(runtime_esm[\\"createReactApp\\"])(lib_src_app, react, react_esm[\\"a\\"]));
     }
-}, [ [ 30, 0, 1, 2 ] ] ]);
+}, [ [ 35, 0, 1, 2 ] ] ]);
 
 
 
@@ -5471,13 +5471,13 @@ object-assign
 
 /** filePath: dist/comp.js **/
 (wx[\\"webpackJsonp\\"] = wx[\\"webpackJsonp\\"] || []).push([ [ 5 ], {
-    28: function(module, __webpack_exports__, __webpack_require__) {
+    29: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         __webpack_require__.r(__webpack_exports__);
         var _tarojs_runtime__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(3);
         Component(Object(_tarojs_runtime__WEBPACK_IMPORTED_MODULE_0__[\\"createRecursiveComponentConfig\\"])());
     }
-}, [ [ 28, 0, 1, 2 ] ] ]);
+}, [ [ 29, 0, 1, 2 ] ] ]);
 
 /** filePath: dist/comp.json **/
 {\\"component\\":true,\\"usingComponents\\":{\\"comp\\":\\"./comp\\"}}
@@ -5488,11 +5488,556 @@ object-assign
 
 /** filePath: dist/pages/index/index.js **/
 (wx[\\"webpackJsonp\\"] = wx[\\"webpackJsonp\\"] || []).push([ [ 6 ], {
-    29: function(module, exports, __webpack_require__) {},
-    31: function(module, __webpack_exports__, __webpack_require__) {
+    15: function(module, exports, __webpack_require__) {
+        module.exports = __webpack_require__(30);
+    },
+    30: function(module, exports, __webpack_require__) {
+        var g = function() {
+            return this;
+        }() || Function(\\"return this\\")();
+        var hadRuntime = g.regeneratorRuntime && Object.getOwnPropertyNames(g).indexOf(\\"regeneratorRuntime\\") >= 0;
+        var oldRuntime = hadRuntime && g.regeneratorRuntime;
+        g.regeneratorRuntime = undefined;
+        module.exports = __webpack_require__(31);
+        if (hadRuntime) {
+            g.regeneratorRuntime = oldRuntime;
+        } else {
+            try {
+                delete g.regeneratorRuntime;
+            } catch (e) {
+                g.regeneratorRuntime = undefined;
+            }
+        }
+    },
+    31: function(module, exports, __webpack_require__) {
+        (function(module) {
+            var _typeof = __webpack_require__(13);
+            !function(global) {
+                \\"use strict\\";
+                var Op = Object.prototype;
+                var hasOwn = Op.hasOwnProperty;
+                var undefined;
+                var $Symbol = typeof Symbol === \\"function\\" ? Symbol : {};
+                var iteratorSymbol = $Symbol.iterator || \\"@@iterator\\";
+                var asyncIteratorSymbol = $Symbol.asyncIterator || \\"@@asyncIterator\\";
+                var toStringTagSymbol = $Symbol.toStringTag || \\"@@toStringTag\\";
+                var inModule = (false ? undefined : _typeof(module)) === \\"object\\";
+                var runtime = global.regeneratorRuntime;
+                if (runtime) {
+                    if (inModule) {
+                        module.exports = runtime;
+                    }
+                    return;
+                }
+                runtime = global.regeneratorRuntime = inModule ? module.exports : {};
+                function wrap(innerFn, outerFn, self, tryLocsList) {
+                    var protoGenerator = outerFn && outerFn.prototype instanceof Generator ? outerFn : Generator;
+                    var generator = Object.create(protoGenerator.prototype);
+                    var context = new Context(tryLocsList || []);
+                    generator._invoke = makeInvokeMethod(innerFn, self, context);
+                    return generator;
+                }
+                runtime.wrap = wrap;
+                function tryCatch(fn, obj, arg) {
+                    try {
+                        return {
+                            type: \\"normal\\",
+                            arg: fn.call(obj, arg)
+                        };
+                    } catch (err) {
+                        return {
+                            type: \\"throw\\",
+                            arg: err
+                        };
+                    }
+                }
+                var GenStateSuspendedStart = \\"suspendedStart\\";
+                var GenStateSuspendedYield = \\"suspendedYield\\";
+                var GenStateExecuting = \\"executing\\";
+                var GenStateCompleted = \\"completed\\";
+                var ContinueSentinel = {};
+                function Generator() {}
+                function GeneratorFunction() {}
+                function GeneratorFunctionPrototype() {}
+                var IteratorPrototype = {};
+                IteratorPrototype[iteratorSymbol] = function() {
+                    return this;
+                };
+                var getProto = Object.getPrototypeOf;
+                var NativeIteratorPrototype = getProto && getProto(getProto(values([])));
+                if (NativeIteratorPrototype && NativeIteratorPrototype !== Op && hasOwn.call(NativeIteratorPrototype, iteratorSymbol)) {
+                    IteratorPrototype = NativeIteratorPrototype;
+                }
+                var Gp = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(IteratorPrototype);
+                GeneratorFunction.prototype = Gp.constructor = GeneratorFunctionPrototype;
+                GeneratorFunctionPrototype.constructor = GeneratorFunction;
+                GeneratorFunctionPrototype[toStringTagSymbol] = GeneratorFunction.displayName = \\"GeneratorFunction\\";
+                function defineIteratorMethods(prototype) {
+                    [ \\"next\\", \\"throw\\", \\"return\\" ].forEach((function(method) {
+                        prototype[method] = function(arg) {
+                            return this._invoke(method, arg);
+                        };
+                    }));
+                }
+                runtime.isGeneratorFunction = function(genFun) {
+                    var ctor = typeof genFun === \\"function\\" && genFun.constructor;
+                    return ctor ? ctor === GeneratorFunction || (ctor.displayName || ctor.name) === \\"GeneratorFunction\\" : false;
+                };
+                runtime.mark = function(genFun) {
+                    if (Object.setPrototypeOf) {
+                        Object.setPrototypeOf(genFun, GeneratorFunctionPrototype);
+                    } else {
+                        genFun.__proto__ = GeneratorFunctionPrototype;
+                        if (!(toStringTagSymbol in genFun)) {
+                            genFun[toStringTagSymbol] = \\"GeneratorFunction\\";
+                        }
+                    }
+                    genFun.prototype = Object.create(Gp);
+                    return genFun;
+                };
+                runtime.awrap = function(arg) {
+                    return {
+                        __await: arg
+                    };
+                };
+                function AsyncIterator(generator) {
+                    function invoke(method, arg, resolve, reject) {
+                        var record = tryCatch(generator[method], generator, arg);
+                        if (record.type === \\"throw\\") {
+                            reject(record.arg);
+                        } else {
+                            var result = record.arg;
+                            var value = result.value;
+                            if (value && _typeof(value) === \\"object\\" && hasOwn.call(value, \\"__await\\")) {
+                                return Promise.resolve(value.__await).then((function(value) {
+                                    invoke(\\"next\\", value, resolve, reject);
+                                }), (function(err) {
+                                    invoke(\\"throw\\", err, resolve, reject);
+                                }));
+                            }
+                            return Promise.resolve(value).then((function(unwrapped) {
+                                result.value = unwrapped;
+                                resolve(result);
+                            }), reject);
+                        }
+                    }
+                    var previousPromise;
+                    function enqueue(method, arg) {
+                        function callInvokeWithMethodAndArg() {
+                            return new Promise((function(resolve, reject) {
+                                invoke(method, arg, resolve, reject);
+                            }));
+                        }
+                        return previousPromise = previousPromise ? previousPromise.then(callInvokeWithMethodAndArg, callInvokeWithMethodAndArg) : callInvokeWithMethodAndArg();
+                    }
+                    this._invoke = enqueue;
+                }
+                defineIteratorMethods(AsyncIterator.prototype);
+                AsyncIterator.prototype[asyncIteratorSymbol] = function() {
+                    return this;
+                };
+                runtime.AsyncIterator = AsyncIterator;
+                runtime.async = function(innerFn, outerFn, self, tryLocsList) {
+                    var iter = new AsyncIterator(wrap(innerFn, outerFn, self, tryLocsList));
+                    return runtime.isGeneratorFunction(outerFn) ? iter : iter.next().then((function(result) {
+                        return result.done ? result.value : iter.next();
+                    }));
+                };
+                function makeInvokeMethod(innerFn, self, context) {
+                    var state = GenStateSuspendedStart;
+                    return function invoke(method, arg) {
+                        if (state === GenStateExecuting) {
+                            throw new Error(\\"Generator is already running\\");
+                        }
+                        if (state === GenStateCompleted) {
+                            if (method === \\"throw\\") {
+                                throw arg;
+                            }
+                            return doneResult();
+                        }
+                        context.method = method;
+                        context.arg = arg;
+                        while (true) {
+                            var delegate = context.delegate;
+                            if (delegate) {
+                                var delegateResult = maybeInvokeDelegate(delegate, context);
+                                if (delegateResult) {
+                                    if (delegateResult === ContinueSentinel) continue;
+                                    return delegateResult;
+                                }
+                            }
+                            if (context.method === \\"next\\") {
+                                context.sent = context._sent = context.arg;
+                            } else if (context.method === \\"throw\\") {
+                                if (state === GenStateSuspendedStart) {
+                                    state = GenStateCompleted;
+                                    throw context.arg;
+                                }
+                                context.dispatchException(context.arg);
+                            } else if (context.method === \\"return\\") {
+                                context.abrupt(\\"return\\", context.arg);
+                            }
+                            state = GenStateExecuting;
+                            var record = tryCatch(innerFn, self, context);
+                            if (record.type === \\"normal\\") {
+                                state = context.done ? GenStateCompleted : GenStateSuspendedYield;
+                                if (record.arg === ContinueSentinel) {
+                                    continue;
+                                }
+                                return {
+                                    value: record.arg,
+                                    done: context.done
+                                };
+                            } else if (record.type === \\"throw\\") {
+                                state = GenStateCompleted;
+                                context.method = \\"throw\\";
+                                context.arg = record.arg;
+                            }
+                        }
+                    };
+                }
+                function maybeInvokeDelegate(delegate, context) {
+                    var method = delegate.iterator[context.method];
+                    if (method === undefined) {
+                        context.delegate = null;
+                        if (context.method === \\"throw\\") {
+                            if (delegate.iterator.return) {
+                                context.method = \\"return\\";
+                                context.arg = undefined;
+                                maybeInvokeDelegate(delegate, context);
+                                if (context.method === \\"throw\\") {
+                                    return ContinueSentinel;
+                                }
+                            }
+                            context.method = \\"throw\\";
+                            context.arg = new TypeError(\\"The iterator does not provide a 'throw' method\\");
+                        }
+                        return ContinueSentinel;
+                    }
+                    var record = tryCatch(method, delegate.iterator, context.arg);
+                    if (record.type === \\"throw\\") {
+                        context.method = \\"throw\\";
+                        context.arg = record.arg;
+                        context.delegate = null;
+                        return ContinueSentinel;
+                    }
+                    var info = record.arg;
+                    if (!info) {
+                        context.method = \\"throw\\";
+                        context.arg = new TypeError(\\"iterator result is not an object\\");
+                        context.delegate = null;
+                        return ContinueSentinel;
+                    }
+                    if (info.done) {
+                        context[delegate.resultName] = info.value;
+                        context.next = delegate.nextLoc;
+                        if (context.method !== \\"return\\") {
+                            context.method = \\"next\\";
+                            context.arg = undefined;
+                        }
+                    } else {
+                        return info;
+                    }
+                    context.delegate = null;
+                    return ContinueSentinel;
+                }
+                defineIteratorMethods(Gp);
+                Gp[toStringTagSymbol] = \\"Generator\\";
+                Gp[iteratorSymbol] = function() {
+                    return this;
+                };
+                Gp.toString = function() {
+                    return \\"[object Generator]\\";
+                };
+                function pushTryEntry(locs) {
+                    var entry = {
+                        tryLoc: locs[0]
+                    };
+                    if (1 in locs) {
+                        entry.catchLoc = locs[1];
+                    }
+                    if (2 in locs) {
+                        entry.finallyLoc = locs[2];
+                        entry.afterLoc = locs[3];
+                    }
+                    this.tryEntries.push(entry);
+                }
+                function resetTryEntry(entry) {
+                    var record = entry.completion || {};
+                    record.type = \\"normal\\";
+                    delete record.arg;
+                    entry.completion = record;
+                }
+                function Context(tryLocsList) {
+                    this.tryEntries = [ {
+                        tryLoc: \\"root\\"
+                    } ];
+                    tryLocsList.forEach(pushTryEntry, this);
+                    this.reset(true);
+                }
+                runtime.keys = function(object) {
+                    var keys = [];
+                    for (var key in object) {
+                        keys.push(key);
+                    }
+                    keys.reverse();
+                    return function next() {
+                        while (keys.length) {
+                            var key = keys.pop();
+                            if (key in object) {
+                                next.value = key;
+                                next.done = false;
+                                return next;
+                            }
+                        }
+                        next.done = true;
+                        return next;
+                    };
+                };
+                function values(iterable) {
+                    if (iterable) {
+                        var iteratorMethod = iterable[iteratorSymbol];
+                        if (iteratorMethod) {
+                            return iteratorMethod.call(iterable);
+                        }
+                        if (typeof iterable.next === \\"function\\") {
+                            return iterable;
+                        }
+                        if (!isNaN(iterable.length)) {
+                            var i = -1, next = function next() {
+                                while (++i < iterable.length) {
+                                    if (hasOwn.call(iterable, i)) {
+                                        next.value = iterable[i];
+                                        next.done = false;
+                                        return next;
+                                    }
+                                }
+                                next.value = undefined;
+                                next.done = true;
+                                return next;
+                            };
+                            return next.next = next;
+                        }
+                    }
+                    return {
+                        next: doneResult
+                    };
+                }
+                runtime.values = values;
+                function doneResult() {
+                    return {
+                        value: undefined,
+                        done: true
+                    };
+                }
+                Context.prototype = {
+                    constructor: Context,
+                    reset: function reset(skipTempReset) {
+                        this.prev = 0;
+                        this.next = 0;
+                        this.sent = this._sent = undefined;
+                        this.done = false;
+                        this.delegate = null;
+                        this.method = \\"next\\";
+                        this.arg = undefined;
+                        this.tryEntries.forEach(resetTryEntry);
+                        if (!skipTempReset) {
+                            for (var name in this) {
+                                if (name.charAt(0) === \\"t\\" && hasOwn.call(this, name) && !isNaN(+name.slice(1))) {
+                                    this[name] = undefined;
+                                }
+                            }
+                        }
+                    },
+                    stop: function stop() {
+                        this.done = true;
+                        var rootEntry = this.tryEntries[0];
+                        var rootRecord = rootEntry.completion;
+                        if (rootRecord.type === \\"throw\\") {
+                            throw rootRecord.arg;
+                        }
+                        return this.rval;
+                    },
+                    dispatchException: function dispatchException(exception) {
+                        if (this.done) {
+                            throw exception;
+                        }
+                        var context = this;
+                        function handle(loc, caught) {
+                            record.type = \\"throw\\";
+                            record.arg = exception;
+                            context.next = loc;
+                            if (caught) {
+                                context.method = \\"next\\";
+                                context.arg = undefined;
+                            }
+                            return !!caught;
+                        }
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            var record = entry.completion;
+                            if (entry.tryLoc === \\"root\\") {
+                                return handle(\\"end\\");
+                            }
+                            if (entry.tryLoc <= this.prev) {
+                                var hasCatch = hasOwn.call(entry, \\"catchLoc\\");
+                                var hasFinally = hasOwn.call(entry, \\"finallyLoc\\");
+                                if (hasCatch && hasFinally) {
+                                    if (this.prev < entry.catchLoc) {
+                                        return handle(entry.catchLoc, true);
+                                    } else if (this.prev < entry.finallyLoc) {
+                                        return handle(entry.finallyLoc);
+                                    }
+                                } else if (hasCatch) {
+                                    if (this.prev < entry.catchLoc) {
+                                        return handle(entry.catchLoc, true);
+                                    }
+                                } else if (hasFinally) {
+                                    if (this.prev < entry.finallyLoc) {
+                                        return handle(entry.finallyLoc);
+                                    }
+                                } else {
+                                    throw new Error(\\"try statement without catch or finally\\");
+                                }
+                            }
+                        }
+                    },
+                    abrupt: function abrupt(type, arg) {
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            if (entry.tryLoc <= this.prev && hasOwn.call(entry, \\"finallyLoc\\") && this.prev < entry.finallyLoc) {
+                                var finallyEntry = entry;
+                                break;
+                            }
+                        }
+                        if (finallyEntry && (type === \\"break\\" || type === \\"continue\\") && finallyEntry.tryLoc <= arg && arg <= finallyEntry.finallyLoc) {
+                            finallyEntry = null;
+                        }
+                        var record = finallyEntry ? finallyEntry.completion : {};
+                        record.type = type;
+                        record.arg = arg;
+                        if (finallyEntry) {
+                            this.method = \\"next\\";
+                            this.next = finallyEntry.finallyLoc;
+                            return ContinueSentinel;
+                        }
+                        return this.complete(record);
+                    },
+                    complete: function complete(record, afterLoc) {
+                        if (record.type === \\"throw\\") {
+                            throw record.arg;
+                        }
+                        if (record.type === \\"break\\" || record.type === \\"continue\\") {
+                            this.next = record.arg;
+                        } else if (record.type === \\"return\\") {
+                            this.rval = this.arg = record.arg;
+                            this.method = \\"return\\";
+                            this.next = \\"end\\";
+                        } else if (record.type === \\"normal\\" && afterLoc) {
+                            this.next = afterLoc;
+                        }
+                        return ContinueSentinel;
+                    },
+                    finish: function finish(finallyLoc) {
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            if (entry.finallyLoc === finallyLoc) {
+                                this.complete(entry.completion, entry.afterLoc);
+                                resetTryEntry(entry);
+                                return ContinueSentinel;
+                            }
+                        }
+                    },
+                    catch: function _catch(tryLoc) {
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            if (entry.tryLoc === tryLoc) {
+                                var record = entry.completion;
+                                if (record.type === \\"throw\\") {
+                                    var thrown = record.arg;
+                                    resetTryEntry(entry);
+                                }
+                                return thrown;
+                            }
+                        }
+                        throw new Error(\\"illegal catch attempt\\");
+                    },
+                    delegateYield: function delegateYield(iterable, resultName, nextLoc) {
+                        this.delegate = {
+                            iterator: values(iterable),
+                            resultName: resultName,
+                            nextLoc: nextLoc
+                        };
+                        if (this.method === \\"next\\") {
+                            this.arg = undefined;
+                        }
+                        return ContinueSentinel;
+                    }
+                };
+            }(function() {
+                return this;
+            }() || Function(\\"return this\\")());
+        }).call(this, __webpack_require__(32)(module));
+    },
+    32: function(module, exports) {
+        module.exports = function(module) {
+            if (!module.webpackPolyfill) {
+                module.deprecate = function() {};
+                module.paths = [];
+                if (!module.children) module.children = [];
+                Object.defineProperty(module, \\"loaded\\", {
+                    enumerable: true,
+                    get: function get() {
+                        return module.l;
+                    }
+                });
+                Object.defineProperty(module, \\"id\\", {
+                    enumerable: true,
+                    get: function get() {
+                        return module.i;
+                    }
+                });
+                module.webpackPolyfill = 1;
+            }
+            return module;
+        };
+    },
+    33: function(module, exports, __webpack_require__) {},
+    34: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         __webpack_require__.r(__webpack_exports__);
         var runtime_esm = __webpack_require__(3);
+        var regenerator = __webpack_require__(15);
+        var regenerator_default = __webpack_require__.n(regenerator);
+        function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
+            try {
+                var info = gen[key](arg);
+                var value = info.value;
+            } catch (error) {
+                reject(error);
+                return;
+            }
+            if (info.done) {
+                resolve(value);
+            } else {
+                Promise.resolve(value).then(_next, _throw);
+            }
+        }
+        function _asyncToGenerator(fn) {
+            return function() {
+                var self = this, args = arguments;
+                return new Promise((function(resolve, reject) {
+                    var gen = fn.apply(self, args);
+                    function _next(value) {
+                        asyncGeneratorStep(gen, resolve, reject, _next, _throw, \\"next\\", value);
+                    }
+                    function _throw(err) {
+                        asyncGeneratorStep(gen, resolve, reject, _next, _throw, \\"throw\\", err);
+                    }
+                    _next(undefined);
+                }));
+            };
+        }
         var classCallCheck = __webpack_require__(0);
         var createClass = __webpack_require__(1);
         var possibleConstructorReturn = __webpack_require__(4);
@@ -5501,7 +6046,7 @@ object-assign
         var react = __webpack_require__(6);
         var react_default = __webpack_require__.n(react);
         var mini = __webpack_require__(12);
-        var index = __webpack_require__(29);
+        var index = __webpack_require__(33);
         var index_Index = function(_Component) {
             Object(inherits[\\"a\\"])(Index, _Component);
             function Index() {
@@ -5510,7 +6055,27 @@ object-assign
             }
             Object(createClass[\\"a\\"])(Index, [ {
                 key: \\"componentWillMount\\",
-                value: function componentWillMount() {}
+                value: function() {
+                    var _componentWillMount = _asyncToGenerator(regenerator_default.a.mark((function _callee() {
+                        return regenerator_default.a.wrap((function _callee$(_context) {
+                            while (1) {
+                                switch (_context.prev = _context.next) {
+                                  case 0:
+                                    _context.next = 2;
+                                    return Promise.resolve(1);
+
+                                  case 2:
+                                  case \\"end\\":
+                                    return _context.stop();
+                                }
+                            }
+                        }), _callee);
+                    })));
+                    function componentWillMount() {
+                        return _componentWillMount.apply(this, arguments);
+                    }
+                    return componentWillMount;
+                }()
             }, {
                 key: \\"componentDidMount\\",
                 value: function componentDidMount() {}
@@ -5540,7 +6105,7 @@ object-assign
         }(react[\\"Component\\"]);
         var inst = Page(Object(runtime_esm[\\"createPageConfig\\"])(index_Index, \\"pages/index/index\\"));
     }
-}, [ [ 31, 0, 1, 2 ] ] ]);
+}, [ [ 34, 0, 1, 2 ] ] ]);
 
 /** filePath: dist/pages/index/index.json **/
 {\\"navigationBarTitleText\\":\\"首页\\",\\"usingComponents\\":{\\"comp\\":\\"../../comp\\"}}
@@ -5731,12 +6296,12 @@ object-assign
         var MovableArea = \\"movable-area\\";
         var MovableView = \\"movable-view\\";
     },
-    16: function(module, __webpack_exports__, __webpack_require__) {
+    17: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         var _babel_runtime_helpers_esm_classCallCheck__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
         var _babel_runtime_helpers_esm_createClass__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(1);
         var _babel_runtime_helpers_esm_typeof__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(8);
-        var react_reconciler__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(17);
+        var react_reconciler__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(18);
         var react_reconciler__WEBPACK_IMPORTED_MODULE_3___default = __webpack_require__.n(react_reconciler__WEBPACK_IMPORTED_MODULE_3__);
         var scheduler__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(11);
         var scheduler__WEBPACK_IMPORTED_MODULE_4___default = __webpack_require__.n(scheduler__WEBPACK_IMPORTED_MODULE_4__);
@@ -6219,13 +6784,13 @@ object-assign
             __webpack_require__.d(__webpack_exports__, \\"window\\", (function() {
                 return window$1;
             }));
-            var _babel_runtime_helpers_esm_toConsumableArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(18);
-            var _babel_runtime_helpers_esm_set__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(19);
+            var _babel_runtime_helpers_esm_toConsumableArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(19);
+            var _babel_runtime_helpers_esm_set__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(20);
             var _babel_runtime_helpers_esm_possibleConstructorReturn__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(4);
             var _babel_runtime_helpers_esm_getPrototypeOf__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(2);
             var _babel_runtime_helpers_esm_assertThisInitialized__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(10);
             var _babel_runtime_helpers_esm_inherits__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(5);
-            var _babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(15);
+            var _babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(16);
             var _babel_runtime_helpers_esm_defineProperty__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(7);
             var _babel_runtime_helpers_esm_classCallCheck__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(0);
             var _babel_runtime_helpers_esm_createClass__WEBPACK_IMPORTED_MODULE_9__ = __webpack_require__(1);
@@ -9222,7 +9787,7 @@ object-assign
 }, function(module, exports, __webpack_require__) {
     \\"use strict\\";
     if (true) {
-        module.exports = __webpack_require__(22);
+        module.exports = __webpack_require__(23);
     } else {}
 }, function(module, __webpack_exports__, __webpack_require__) {
     \\"use strict\\";
@@ -9283,21 +9848,7 @@ object-assign
         }
         return self;
     }
-}, , , function(module, __webpack_exports__, __webpack_require__) {
-    \\"use strict\\";
-    __webpack_require__.d(__webpack_exports__, \\"a\\", (function() {
-        return _unsupportedIterableToArray;
-    }));
-    var _arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(9);
-    function _unsupportedIterableToArray(o, minLen) {
-        if (!o) return;
-        if (typeof o === \\"string\\") return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
-        var n = Object.prototype.toString.call(o).slice(8, -1);
-        if (n === \\"Object\\" && o.constructor) n = o.constructor.name;
-        if (n === \\"Map\\" || n === \\"Set\\") return Array.from(o);
-        if (n === \\"Arguments\\" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
-    }
-}, function(module, exports) {
+}, , , function(module, exports) {
     function _typeof(obj) {
         \\"@babel/helpers - typeof\\";
         if (typeof Symbol === \\"function\\" && typeof Symbol.iterator === \\"symbol\\") {
@@ -9313,6 +9864,20 @@ object-assign
     }
     module.exports = _typeof;
 }, function(module, __webpack_exports__, __webpack_require__) {
+    \\"use strict\\";
+    __webpack_require__.d(__webpack_exports__, \\"a\\", (function() {
+        return _unsupportedIterableToArray;
+    }));
+    var _arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(9);
+    function _unsupportedIterableToArray(o, minLen) {
+        if (!o) return;
+        if (typeof o === \\"string\\") return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
+        var n = Object.prototype.toString.call(o).slice(8, -1);
+        if (n === \\"Object\\" && o.constructor) n = o.constructor.name;
+        if (n === \\"Map\\" || n === \\"Set\\") return Array.from(o);
+        if (n === \\"Arguments\\" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
+    }
+}, , function(module, __webpack_exports__, __webpack_require__) {
     \\"use strict\\";
     __webpack_require__.d(__webpack_exports__, \\"a\\", (function() {
         return _slicedToArray;
@@ -9343,7 +9908,7 @@ object-assign
         }
         return _arr;
     }
-    var unsupportedIterableToArray = __webpack_require__(13);
+    var unsupportedIterableToArray = __webpack_require__(14);
     function _nonIterableRest() {
         throw new TypeError(\\"Invalid attempt to destructure non-iterable instance.\\\\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.\\");
     }
@@ -9362,7 +9927,7 @@ object-assign
     function _iterableToArray(iter) {
         if (typeof Symbol !== \\"undefined\\" && Symbol.iterator in Object(iter)) return Array.from(iter);
     }
-    var unsupportedIterableToArray = __webpack_require__(13);
+    var unsupportedIterableToArray = __webpack_require__(14);
     function _nonIterableSpread() {
         throw new TypeError(\\"Invalid attempt to spread non-iterable instance.\\\\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.\\");
     }
@@ -9423,8 +9988,8 @@ object-assign
     }
 }, , , function(module, exports, __webpack_require__) {
     \\"use strict\\";
-    var _typeof = __webpack_require__(14);
-    var l = __webpack_require__(23), n = \\"function\\" === typeof Symbol && Symbol.for, p = n ? Symbol.for(\\"react.element\\") : 60103, q = n ? Symbol.for(\\"react.portal\\") : 60106, r = n ? Symbol.for(\\"react.fragment\\") : 60107, t = n ? Symbol.for(\\"react.strict_mode\\") : 60108, u = n ? Symbol.for(\\"react.profiler\\") : 60114, v = n ? Symbol.for(\\"react.provider\\") : 60109, w = n ? Symbol.for(\\"react.context\\") : 60110, x = n ? Symbol.for(\\"react.forward_ref\\") : 60112, y = n ? Symbol.for(\\"react.suspense\\") : 60113, z = n ? Symbol.for(\\"react.memo\\") : 60115, A = n ? Symbol.for(\\"react.lazy\\") : 60116, B = \\"function\\" === typeof Symbol && Symbol.iterator;
+    var _typeof = __webpack_require__(13);
+    var l = __webpack_require__(24), n = \\"function\\" === typeof Symbol && Symbol.for, p = n ? Symbol.for(\\"react.element\\") : 60103, q = n ? Symbol.for(\\"react.portal\\") : 60106, r = n ? Symbol.for(\\"react.fragment\\") : 60107, t = n ? Symbol.for(\\"react.strict_mode\\") : 60108, u = n ? Symbol.for(\\"react.profiler\\") : 60114, v = n ? Symbol.for(\\"react.provider\\") : 60109, w = n ? Symbol.for(\\"react.context\\") : 60110, x = n ? Symbol.for(\\"react.forward_ref\\") : 60112, y = n ? Symbol.for(\\"react.suspense\\") : 60113, z = n ? Symbol.for(\\"react.memo\\") : 60115, A = n ? Symbol.for(\\"react.lazy\\") : 60116, B = \\"function\\" === typeof Symbol && Symbol.iterator;
     function C(a) {
         for (var b = \\"https://reactjs.org/docs/error-decoder.html?invariant=\\" + a, c = 1; c < arguments.length; c++) {
             b += \\"&args[]=\\" + encodeURIComponent(arguments[c]);

--- a/packages/taro-mini-runner/__tests__/__snapshots__/jd.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/jd.spec.ts.snap
@@ -16,21 +16,21 @@ require(\\"./taro\\");
     11: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         if (true) {
-            module.exports = __webpack_require__(27);
+            module.exports = __webpack_require__(28);
         } else {}
     },
-    17: function(module, exports, __webpack_require__) {
+    18: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         if (true) {
-            module.exports = __webpack_require__(25);
+            module.exports = __webpack_require__(26);
         } else {}
     },
-    24: function(module, exports, __webpack_require__) {},
-    25: function(module, exports, __webpack_require__) {
-        var _typeof = __webpack_require__(14);
+    25: function(module, exports, __webpack_require__) {},
+    26: function(module, exports, __webpack_require__) {
+        var _typeof = __webpack_require__(13);
         module.exports = function $$$reconciler($$$hostConfig) {
             \\"use strict\\";
-            var aa = __webpack_require__(26), ba = __webpack_require__(6), m = __webpack_require__(11);
+            var aa = __webpack_require__(27), ba = __webpack_require__(6), m = __webpack_require__(11);
             function n(a) {
                 for (var b = \\"https://reactjs.org/docs/error-decoder.html?invariant=\\" + a, c = 1; c < arguments.length; c++) {
                     b += \\"&args[]=\\" + encodeURIComponent(arguments[c]);
@@ -4017,7 +4017,7 @@ require(\\"./taro\\");
             return $$$renderer;
         };
     },
-    26: function(module, exports, __webpack_require__) {
+    27: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         var getOwnPropertySymbols = Object.getOwnPropertySymbols;
         var hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -4083,10 +4083,10 @@ require(\\"./taro\\");
             return to;
         };
     },
-    27: function(module, exports, __webpack_require__) {
+    28: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         (function(window) {
-            var _typeof = __webpack_require__(14);
+            var _typeof = __webpack_require__(13);
             Object.defineProperty(exports, \\"__esModule\\", {
                 value: !0
             });
@@ -4359,7 +4359,7 @@ require(\\"./taro\\");
             exports.unstable_Profiling = null;
         }).call(this, __webpack_require__(3)[\\"window\\"]);
     },
-    30: function(module, __webpack_exports__, __webpack_require__) {
+    35: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         __webpack_require__.r(__webpack_exports__);
         var runtime_esm = __webpack_require__(3);
@@ -4369,7 +4369,7 @@ require(\\"./taro\\");
         var getPrototypeOf = __webpack_require__(2);
         var inherits = __webpack_require__(5);
         var react = __webpack_require__(6);
-        var app = __webpack_require__(24);
+        var app = __webpack_require__(25);
         var app_App = function(_Component) {
             Object(inherits[\\"a\\"])(App, _Component);
             function App() {
@@ -4397,10 +4397,10 @@ require(\\"./taro\\");
             return App;
         }(react[\\"Component\\"]);
         var lib_src_app = app_App;
-        var react_esm = __webpack_require__(16);
+        var react_esm = __webpack_require__(17);
         var inst = App(Object(runtime_esm[\\"createReactApp\\"])(lib_src_app, react, react_esm[\\"a\\"]));
     }
-}, [ [ 30, 0, 1, 2 ] ] ]);
+}, [ [ 35, 0, 1, 2 ] ] ]);
 
 
 
@@ -5471,13 +5471,13 @@ object-assign
 
 /** filePath: dist/comp.js **/
 (wx[\\"webpackJsonp\\"] = wx[\\"webpackJsonp\\"] || []).push([ [ 5 ], {
-    28: function(module, __webpack_exports__, __webpack_require__) {
+    29: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         __webpack_require__.r(__webpack_exports__);
         var _tarojs_runtime__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(3);
         Component(Object(_tarojs_runtime__WEBPACK_IMPORTED_MODULE_0__[\\"createRecursiveComponentConfig\\"])());
     }
-}, [ [ 28, 0, 1, 2 ] ] ]);
+}, [ [ 29, 0, 1, 2 ] ] ]);
 
 /** filePath: dist/comp.json **/
 {\\"component\\":true,\\"usingComponents\\":{\\"comp\\":\\"./comp\\"}}
@@ -5488,11 +5488,556 @@ object-assign
 
 /** filePath: dist/pages/index/index.js **/
 (wx[\\"webpackJsonp\\"] = wx[\\"webpackJsonp\\"] || []).push([ [ 6 ], {
-    29: function(module, exports, __webpack_require__) {},
-    31: function(module, __webpack_exports__, __webpack_require__) {
+    15: function(module, exports, __webpack_require__) {
+        module.exports = __webpack_require__(30);
+    },
+    30: function(module, exports, __webpack_require__) {
+        var g = function() {
+            return this;
+        }() || Function(\\"return this\\")();
+        var hadRuntime = g.regeneratorRuntime && Object.getOwnPropertyNames(g).indexOf(\\"regeneratorRuntime\\") >= 0;
+        var oldRuntime = hadRuntime && g.regeneratorRuntime;
+        g.regeneratorRuntime = undefined;
+        module.exports = __webpack_require__(31);
+        if (hadRuntime) {
+            g.regeneratorRuntime = oldRuntime;
+        } else {
+            try {
+                delete g.regeneratorRuntime;
+            } catch (e) {
+                g.regeneratorRuntime = undefined;
+            }
+        }
+    },
+    31: function(module, exports, __webpack_require__) {
+        (function(module) {
+            var _typeof = __webpack_require__(13);
+            !function(global) {
+                \\"use strict\\";
+                var Op = Object.prototype;
+                var hasOwn = Op.hasOwnProperty;
+                var undefined;
+                var $Symbol = typeof Symbol === \\"function\\" ? Symbol : {};
+                var iteratorSymbol = $Symbol.iterator || \\"@@iterator\\";
+                var asyncIteratorSymbol = $Symbol.asyncIterator || \\"@@asyncIterator\\";
+                var toStringTagSymbol = $Symbol.toStringTag || \\"@@toStringTag\\";
+                var inModule = (false ? undefined : _typeof(module)) === \\"object\\";
+                var runtime = global.regeneratorRuntime;
+                if (runtime) {
+                    if (inModule) {
+                        module.exports = runtime;
+                    }
+                    return;
+                }
+                runtime = global.regeneratorRuntime = inModule ? module.exports : {};
+                function wrap(innerFn, outerFn, self, tryLocsList) {
+                    var protoGenerator = outerFn && outerFn.prototype instanceof Generator ? outerFn : Generator;
+                    var generator = Object.create(protoGenerator.prototype);
+                    var context = new Context(tryLocsList || []);
+                    generator._invoke = makeInvokeMethod(innerFn, self, context);
+                    return generator;
+                }
+                runtime.wrap = wrap;
+                function tryCatch(fn, obj, arg) {
+                    try {
+                        return {
+                            type: \\"normal\\",
+                            arg: fn.call(obj, arg)
+                        };
+                    } catch (err) {
+                        return {
+                            type: \\"throw\\",
+                            arg: err
+                        };
+                    }
+                }
+                var GenStateSuspendedStart = \\"suspendedStart\\";
+                var GenStateSuspendedYield = \\"suspendedYield\\";
+                var GenStateExecuting = \\"executing\\";
+                var GenStateCompleted = \\"completed\\";
+                var ContinueSentinel = {};
+                function Generator() {}
+                function GeneratorFunction() {}
+                function GeneratorFunctionPrototype() {}
+                var IteratorPrototype = {};
+                IteratorPrototype[iteratorSymbol] = function() {
+                    return this;
+                };
+                var getProto = Object.getPrototypeOf;
+                var NativeIteratorPrototype = getProto && getProto(getProto(values([])));
+                if (NativeIteratorPrototype && NativeIteratorPrototype !== Op && hasOwn.call(NativeIteratorPrototype, iteratorSymbol)) {
+                    IteratorPrototype = NativeIteratorPrototype;
+                }
+                var Gp = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(IteratorPrototype);
+                GeneratorFunction.prototype = Gp.constructor = GeneratorFunctionPrototype;
+                GeneratorFunctionPrototype.constructor = GeneratorFunction;
+                GeneratorFunctionPrototype[toStringTagSymbol] = GeneratorFunction.displayName = \\"GeneratorFunction\\";
+                function defineIteratorMethods(prototype) {
+                    [ \\"next\\", \\"throw\\", \\"return\\" ].forEach((function(method) {
+                        prototype[method] = function(arg) {
+                            return this._invoke(method, arg);
+                        };
+                    }));
+                }
+                runtime.isGeneratorFunction = function(genFun) {
+                    var ctor = typeof genFun === \\"function\\" && genFun.constructor;
+                    return ctor ? ctor === GeneratorFunction || (ctor.displayName || ctor.name) === \\"GeneratorFunction\\" : false;
+                };
+                runtime.mark = function(genFun) {
+                    if (Object.setPrototypeOf) {
+                        Object.setPrototypeOf(genFun, GeneratorFunctionPrototype);
+                    } else {
+                        genFun.__proto__ = GeneratorFunctionPrototype;
+                        if (!(toStringTagSymbol in genFun)) {
+                            genFun[toStringTagSymbol] = \\"GeneratorFunction\\";
+                        }
+                    }
+                    genFun.prototype = Object.create(Gp);
+                    return genFun;
+                };
+                runtime.awrap = function(arg) {
+                    return {
+                        __await: arg
+                    };
+                };
+                function AsyncIterator(generator) {
+                    function invoke(method, arg, resolve, reject) {
+                        var record = tryCatch(generator[method], generator, arg);
+                        if (record.type === \\"throw\\") {
+                            reject(record.arg);
+                        } else {
+                            var result = record.arg;
+                            var value = result.value;
+                            if (value && _typeof(value) === \\"object\\" && hasOwn.call(value, \\"__await\\")) {
+                                return Promise.resolve(value.__await).then((function(value) {
+                                    invoke(\\"next\\", value, resolve, reject);
+                                }), (function(err) {
+                                    invoke(\\"throw\\", err, resolve, reject);
+                                }));
+                            }
+                            return Promise.resolve(value).then((function(unwrapped) {
+                                result.value = unwrapped;
+                                resolve(result);
+                            }), reject);
+                        }
+                    }
+                    var previousPromise;
+                    function enqueue(method, arg) {
+                        function callInvokeWithMethodAndArg() {
+                            return new Promise((function(resolve, reject) {
+                                invoke(method, arg, resolve, reject);
+                            }));
+                        }
+                        return previousPromise = previousPromise ? previousPromise.then(callInvokeWithMethodAndArg, callInvokeWithMethodAndArg) : callInvokeWithMethodAndArg();
+                    }
+                    this._invoke = enqueue;
+                }
+                defineIteratorMethods(AsyncIterator.prototype);
+                AsyncIterator.prototype[asyncIteratorSymbol] = function() {
+                    return this;
+                };
+                runtime.AsyncIterator = AsyncIterator;
+                runtime.async = function(innerFn, outerFn, self, tryLocsList) {
+                    var iter = new AsyncIterator(wrap(innerFn, outerFn, self, tryLocsList));
+                    return runtime.isGeneratorFunction(outerFn) ? iter : iter.next().then((function(result) {
+                        return result.done ? result.value : iter.next();
+                    }));
+                };
+                function makeInvokeMethod(innerFn, self, context) {
+                    var state = GenStateSuspendedStart;
+                    return function invoke(method, arg) {
+                        if (state === GenStateExecuting) {
+                            throw new Error(\\"Generator is already running\\");
+                        }
+                        if (state === GenStateCompleted) {
+                            if (method === \\"throw\\") {
+                                throw arg;
+                            }
+                            return doneResult();
+                        }
+                        context.method = method;
+                        context.arg = arg;
+                        while (true) {
+                            var delegate = context.delegate;
+                            if (delegate) {
+                                var delegateResult = maybeInvokeDelegate(delegate, context);
+                                if (delegateResult) {
+                                    if (delegateResult === ContinueSentinel) continue;
+                                    return delegateResult;
+                                }
+                            }
+                            if (context.method === \\"next\\") {
+                                context.sent = context._sent = context.arg;
+                            } else if (context.method === \\"throw\\") {
+                                if (state === GenStateSuspendedStart) {
+                                    state = GenStateCompleted;
+                                    throw context.arg;
+                                }
+                                context.dispatchException(context.arg);
+                            } else if (context.method === \\"return\\") {
+                                context.abrupt(\\"return\\", context.arg);
+                            }
+                            state = GenStateExecuting;
+                            var record = tryCatch(innerFn, self, context);
+                            if (record.type === \\"normal\\") {
+                                state = context.done ? GenStateCompleted : GenStateSuspendedYield;
+                                if (record.arg === ContinueSentinel) {
+                                    continue;
+                                }
+                                return {
+                                    value: record.arg,
+                                    done: context.done
+                                };
+                            } else if (record.type === \\"throw\\") {
+                                state = GenStateCompleted;
+                                context.method = \\"throw\\";
+                                context.arg = record.arg;
+                            }
+                        }
+                    };
+                }
+                function maybeInvokeDelegate(delegate, context) {
+                    var method = delegate.iterator[context.method];
+                    if (method === undefined) {
+                        context.delegate = null;
+                        if (context.method === \\"throw\\") {
+                            if (delegate.iterator.return) {
+                                context.method = \\"return\\";
+                                context.arg = undefined;
+                                maybeInvokeDelegate(delegate, context);
+                                if (context.method === \\"throw\\") {
+                                    return ContinueSentinel;
+                                }
+                            }
+                            context.method = \\"throw\\";
+                            context.arg = new TypeError(\\"The iterator does not provide a 'throw' method\\");
+                        }
+                        return ContinueSentinel;
+                    }
+                    var record = tryCatch(method, delegate.iterator, context.arg);
+                    if (record.type === \\"throw\\") {
+                        context.method = \\"throw\\";
+                        context.arg = record.arg;
+                        context.delegate = null;
+                        return ContinueSentinel;
+                    }
+                    var info = record.arg;
+                    if (!info) {
+                        context.method = \\"throw\\";
+                        context.arg = new TypeError(\\"iterator result is not an object\\");
+                        context.delegate = null;
+                        return ContinueSentinel;
+                    }
+                    if (info.done) {
+                        context[delegate.resultName] = info.value;
+                        context.next = delegate.nextLoc;
+                        if (context.method !== \\"return\\") {
+                            context.method = \\"next\\";
+                            context.arg = undefined;
+                        }
+                    } else {
+                        return info;
+                    }
+                    context.delegate = null;
+                    return ContinueSentinel;
+                }
+                defineIteratorMethods(Gp);
+                Gp[toStringTagSymbol] = \\"Generator\\";
+                Gp[iteratorSymbol] = function() {
+                    return this;
+                };
+                Gp.toString = function() {
+                    return \\"[object Generator]\\";
+                };
+                function pushTryEntry(locs) {
+                    var entry = {
+                        tryLoc: locs[0]
+                    };
+                    if (1 in locs) {
+                        entry.catchLoc = locs[1];
+                    }
+                    if (2 in locs) {
+                        entry.finallyLoc = locs[2];
+                        entry.afterLoc = locs[3];
+                    }
+                    this.tryEntries.push(entry);
+                }
+                function resetTryEntry(entry) {
+                    var record = entry.completion || {};
+                    record.type = \\"normal\\";
+                    delete record.arg;
+                    entry.completion = record;
+                }
+                function Context(tryLocsList) {
+                    this.tryEntries = [ {
+                        tryLoc: \\"root\\"
+                    } ];
+                    tryLocsList.forEach(pushTryEntry, this);
+                    this.reset(true);
+                }
+                runtime.keys = function(object) {
+                    var keys = [];
+                    for (var key in object) {
+                        keys.push(key);
+                    }
+                    keys.reverse();
+                    return function next() {
+                        while (keys.length) {
+                            var key = keys.pop();
+                            if (key in object) {
+                                next.value = key;
+                                next.done = false;
+                                return next;
+                            }
+                        }
+                        next.done = true;
+                        return next;
+                    };
+                };
+                function values(iterable) {
+                    if (iterable) {
+                        var iteratorMethod = iterable[iteratorSymbol];
+                        if (iteratorMethod) {
+                            return iteratorMethod.call(iterable);
+                        }
+                        if (typeof iterable.next === \\"function\\") {
+                            return iterable;
+                        }
+                        if (!isNaN(iterable.length)) {
+                            var i = -1, next = function next() {
+                                while (++i < iterable.length) {
+                                    if (hasOwn.call(iterable, i)) {
+                                        next.value = iterable[i];
+                                        next.done = false;
+                                        return next;
+                                    }
+                                }
+                                next.value = undefined;
+                                next.done = true;
+                                return next;
+                            };
+                            return next.next = next;
+                        }
+                    }
+                    return {
+                        next: doneResult
+                    };
+                }
+                runtime.values = values;
+                function doneResult() {
+                    return {
+                        value: undefined,
+                        done: true
+                    };
+                }
+                Context.prototype = {
+                    constructor: Context,
+                    reset: function reset(skipTempReset) {
+                        this.prev = 0;
+                        this.next = 0;
+                        this.sent = this._sent = undefined;
+                        this.done = false;
+                        this.delegate = null;
+                        this.method = \\"next\\";
+                        this.arg = undefined;
+                        this.tryEntries.forEach(resetTryEntry);
+                        if (!skipTempReset) {
+                            for (var name in this) {
+                                if (name.charAt(0) === \\"t\\" && hasOwn.call(this, name) && !isNaN(+name.slice(1))) {
+                                    this[name] = undefined;
+                                }
+                            }
+                        }
+                    },
+                    stop: function stop() {
+                        this.done = true;
+                        var rootEntry = this.tryEntries[0];
+                        var rootRecord = rootEntry.completion;
+                        if (rootRecord.type === \\"throw\\") {
+                            throw rootRecord.arg;
+                        }
+                        return this.rval;
+                    },
+                    dispatchException: function dispatchException(exception) {
+                        if (this.done) {
+                            throw exception;
+                        }
+                        var context = this;
+                        function handle(loc, caught) {
+                            record.type = \\"throw\\";
+                            record.arg = exception;
+                            context.next = loc;
+                            if (caught) {
+                                context.method = \\"next\\";
+                                context.arg = undefined;
+                            }
+                            return !!caught;
+                        }
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            var record = entry.completion;
+                            if (entry.tryLoc === \\"root\\") {
+                                return handle(\\"end\\");
+                            }
+                            if (entry.tryLoc <= this.prev) {
+                                var hasCatch = hasOwn.call(entry, \\"catchLoc\\");
+                                var hasFinally = hasOwn.call(entry, \\"finallyLoc\\");
+                                if (hasCatch && hasFinally) {
+                                    if (this.prev < entry.catchLoc) {
+                                        return handle(entry.catchLoc, true);
+                                    } else if (this.prev < entry.finallyLoc) {
+                                        return handle(entry.finallyLoc);
+                                    }
+                                } else if (hasCatch) {
+                                    if (this.prev < entry.catchLoc) {
+                                        return handle(entry.catchLoc, true);
+                                    }
+                                } else if (hasFinally) {
+                                    if (this.prev < entry.finallyLoc) {
+                                        return handle(entry.finallyLoc);
+                                    }
+                                } else {
+                                    throw new Error(\\"try statement without catch or finally\\");
+                                }
+                            }
+                        }
+                    },
+                    abrupt: function abrupt(type, arg) {
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            if (entry.tryLoc <= this.prev && hasOwn.call(entry, \\"finallyLoc\\") && this.prev < entry.finallyLoc) {
+                                var finallyEntry = entry;
+                                break;
+                            }
+                        }
+                        if (finallyEntry && (type === \\"break\\" || type === \\"continue\\") && finallyEntry.tryLoc <= arg && arg <= finallyEntry.finallyLoc) {
+                            finallyEntry = null;
+                        }
+                        var record = finallyEntry ? finallyEntry.completion : {};
+                        record.type = type;
+                        record.arg = arg;
+                        if (finallyEntry) {
+                            this.method = \\"next\\";
+                            this.next = finallyEntry.finallyLoc;
+                            return ContinueSentinel;
+                        }
+                        return this.complete(record);
+                    },
+                    complete: function complete(record, afterLoc) {
+                        if (record.type === \\"throw\\") {
+                            throw record.arg;
+                        }
+                        if (record.type === \\"break\\" || record.type === \\"continue\\") {
+                            this.next = record.arg;
+                        } else if (record.type === \\"return\\") {
+                            this.rval = this.arg = record.arg;
+                            this.method = \\"return\\";
+                            this.next = \\"end\\";
+                        } else if (record.type === \\"normal\\" && afterLoc) {
+                            this.next = afterLoc;
+                        }
+                        return ContinueSentinel;
+                    },
+                    finish: function finish(finallyLoc) {
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            if (entry.finallyLoc === finallyLoc) {
+                                this.complete(entry.completion, entry.afterLoc);
+                                resetTryEntry(entry);
+                                return ContinueSentinel;
+                            }
+                        }
+                    },
+                    catch: function _catch(tryLoc) {
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            if (entry.tryLoc === tryLoc) {
+                                var record = entry.completion;
+                                if (record.type === \\"throw\\") {
+                                    var thrown = record.arg;
+                                    resetTryEntry(entry);
+                                }
+                                return thrown;
+                            }
+                        }
+                        throw new Error(\\"illegal catch attempt\\");
+                    },
+                    delegateYield: function delegateYield(iterable, resultName, nextLoc) {
+                        this.delegate = {
+                            iterator: values(iterable),
+                            resultName: resultName,
+                            nextLoc: nextLoc
+                        };
+                        if (this.method === \\"next\\") {
+                            this.arg = undefined;
+                        }
+                        return ContinueSentinel;
+                    }
+                };
+            }(function() {
+                return this;
+            }() || Function(\\"return this\\")());
+        }).call(this, __webpack_require__(32)(module));
+    },
+    32: function(module, exports) {
+        module.exports = function(module) {
+            if (!module.webpackPolyfill) {
+                module.deprecate = function() {};
+                module.paths = [];
+                if (!module.children) module.children = [];
+                Object.defineProperty(module, \\"loaded\\", {
+                    enumerable: true,
+                    get: function get() {
+                        return module.l;
+                    }
+                });
+                Object.defineProperty(module, \\"id\\", {
+                    enumerable: true,
+                    get: function get() {
+                        return module.i;
+                    }
+                });
+                module.webpackPolyfill = 1;
+            }
+            return module;
+        };
+    },
+    33: function(module, exports, __webpack_require__) {},
+    34: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         __webpack_require__.r(__webpack_exports__);
         var runtime_esm = __webpack_require__(3);
+        var regenerator = __webpack_require__(15);
+        var regenerator_default = __webpack_require__.n(regenerator);
+        function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
+            try {
+                var info = gen[key](arg);
+                var value = info.value;
+            } catch (error) {
+                reject(error);
+                return;
+            }
+            if (info.done) {
+                resolve(value);
+            } else {
+                Promise.resolve(value).then(_next, _throw);
+            }
+        }
+        function _asyncToGenerator(fn) {
+            return function() {
+                var self = this, args = arguments;
+                return new Promise((function(resolve, reject) {
+                    var gen = fn.apply(self, args);
+                    function _next(value) {
+                        asyncGeneratorStep(gen, resolve, reject, _next, _throw, \\"next\\", value);
+                    }
+                    function _throw(err) {
+                        asyncGeneratorStep(gen, resolve, reject, _next, _throw, \\"throw\\", err);
+                    }
+                    _next(undefined);
+                }));
+            };
+        }
         var classCallCheck = __webpack_require__(0);
         var createClass = __webpack_require__(1);
         var possibleConstructorReturn = __webpack_require__(4);
@@ -5501,7 +6046,7 @@ object-assign
         var react = __webpack_require__(6);
         var react_default = __webpack_require__.n(react);
         var mini = __webpack_require__(12);
-        var index = __webpack_require__(29);
+        var index = __webpack_require__(33);
         var index_Index = function(_Component) {
             Object(inherits[\\"a\\"])(Index, _Component);
             function Index() {
@@ -5510,7 +6055,27 @@ object-assign
             }
             Object(createClass[\\"a\\"])(Index, [ {
                 key: \\"componentWillMount\\",
-                value: function componentWillMount() {}
+                value: function() {
+                    var _componentWillMount = _asyncToGenerator(regenerator_default.a.mark((function _callee() {
+                        return regenerator_default.a.wrap((function _callee$(_context) {
+                            while (1) {
+                                switch (_context.prev = _context.next) {
+                                  case 0:
+                                    _context.next = 2;
+                                    return Promise.resolve(1);
+
+                                  case 2:
+                                  case \\"end\\":
+                                    return _context.stop();
+                                }
+                            }
+                        }), _callee);
+                    })));
+                    function componentWillMount() {
+                        return _componentWillMount.apply(this, arguments);
+                    }
+                    return componentWillMount;
+                }()
             }, {
                 key: \\"componentDidMount\\",
                 value: function componentDidMount() {}
@@ -5540,7 +6105,7 @@ object-assign
         }(react[\\"Component\\"]);
         var inst = Page(Object(runtime_esm[\\"createPageConfig\\"])(index_Index, \\"pages/index/index\\"));
     }
-}, [ [ 31, 0, 1, 2 ] ] ]);
+}, [ [ 34, 0, 1, 2 ] ] ]);
 
 /** filePath: dist/pages/index/index.json **/
 {\\"navigationBarTitleText\\":\\"首页\\",\\"usingComponents\\":{\\"comp\\":\\"../../comp\\"}}
@@ -5731,12 +6296,12 @@ object-assign
         var MovableArea = \\"movable-area\\";
         var MovableView = \\"movable-view\\";
     },
-    16: function(module, __webpack_exports__, __webpack_require__) {
+    17: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         var _babel_runtime_helpers_esm_classCallCheck__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
         var _babel_runtime_helpers_esm_createClass__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(1);
         var _babel_runtime_helpers_esm_typeof__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(8);
-        var react_reconciler__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(17);
+        var react_reconciler__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(18);
         var react_reconciler__WEBPACK_IMPORTED_MODULE_3___default = __webpack_require__.n(react_reconciler__WEBPACK_IMPORTED_MODULE_3__);
         var scheduler__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(11);
         var scheduler__WEBPACK_IMPORTED_MODULE_4___default = __webpack_require__.n(scheduler__WEBPACK_IMPORTED_MODULE_4__);
@@ -6219,13 +6784,13 @@ object-assign
             __webpack_require__.d(__webpack_exports__, \\"window\\", (function() {
                 return window$1;
             }));
-            var _babel_runtime_helpers_esm_toConsumableArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(18);
-            var _babel_runtime_helpers_esm_set__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(19);
+            var _babel_runtime_helpers_esm_toConsumableArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(19);
+            var _babel_runtime_helpers_esm_set__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(20);
             var _babel_runtime_helpers_esm_possibleConstructorReturn__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(4);
             var _babel_runtime_helpers_esm_getPrototypeOf__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(2);
             var _babel_runtime_helpers_esm_assertThisInitialized__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(10);
             var _babel_runtime_helpers_esm_inherits__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(5);
-            var _babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(15);
+            var _babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(16);
             var _babel_runtime_helpers_esm_defineProperty__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(7);
             var _babel_runtime_helpers_esm_classCallCheck__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(0);
             var _babel_runtime_helpers_esm_createClass__WEBPACK_IMPORTED_MODULE_9__ = __webpack_require__(1);
@@ -9222,7 +9787,7 @@ object-assign
 }, function(module, exports, __webpack_require__) {
     \\"use strict\\";
     if (true) {
-        module.exports = __webpack_require__(22);
+        module.exports = __webpack_require__(23);
     } else {}
 }, function(module, __webpack_exports__, __webpack_require__) {
     \\"use strict\\";
@@ -9283,21 +9848,7 @@ object-assign
         }
         return self;
     }
-}, , , function(module, __webpack_exports__, __webpack_require__) {
-    \\"use strict\\";
-    __webpack_require__.d(__webpack_exports__, \\"a\\", (function() {
-        return _unsupportedIterableToArray;
-    }));
-    var _arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(9);
-    function _unsupportedIterableToArray(o, minLen) {
-        if (!o) return;
-        if (typeof o === \\"string\\") return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
-        var n = Object.prototype.toString.call(o).slice(8, -1);
-        if (n === \\"Object\\" && o.constructor) n = o.constructor.name;
-        if (n === \\"Map\\" || n === \\"Set\\") return Array.from(o);
-        if (n === \\"Arguments\\" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
-    }
-}, function(module, exports) {
+}, , , function(module, exports) {
     function _typeof(obj) {
         \\"@babel/helpers - typeof\\";
         if (typeof Symbol === \\"function\\" && typeof Symbol.iterator === \\"symbol\\") {
@@ -9313,6 +9864,20 @@ object-assign
     }
     module.exports = _typeof;
 }, function(module, __webpack_exports__, __webpack_require__) {
+    \\"use strict\\";
+    __webpack_require__.d(__webpack_exports__, \\"a\\", (function() {
+        return _unsupportedIterableToArray;
+    }));
+    var _arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(9);
+    function _unsupportedIterableToArray(o, minLen) {
+        if (!o) return;
+        if (typeof o === \\"string\\") return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
+        var n = Object.prototype.toString.call(o).slice(8, -1);
+        if (n === \\"Object\\" && o.constructor) n = o.constructor.name;
+        if (n === \\"Map\\" || n === \\"Set\\") return Array.from(o);
+        if (n === \\"Arguments\\" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
+    }
+}, , function(module, __webpack_exports__, __webpack_require__) {
     \\"use strict\\";
     __webpack_require__.d(__webpack_exports__, \\"a\\", (function() {
         return _slicedToArray;
@@ -9343,7 +9908,7 @@ object-assign
         }
         return _arr;
     }
-    var unsupportedIterableToArray = __webpack_require__(13);
+    var unsupportedIterableToArray = __webpack_require__(14);
     function _nonIterableRest() {
         throw new TypeError(\\"Invalid attempt to destructure non-iterable instance.\\\\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.\\");
     }
@@ -9362,7 +9927,7 @@ object-assign
     function _iterableToArray(iter) {
         if (typeof Symbol !== \\"undefined\\" && Symbol.iterator in Object(iter)) return Array.from(iter);
     }
-    var unsupportedIterableToArray = __webpack_require__(13);
+    var unsupportedIterableToArray = __webpack_require__(14);
     function _nonIterableSpread() {
         throw new TypeError(\\"Invalid attempt to spread non-iterable instance.\\\\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.\\");
     }
@@ -9423,8 +9988,8 @@ object-assign
     }
 }, , , function(module, exports, __webpack_require__) {
     \\"use strict\\";
-    var _typeof = __webpack_require__(14);
-    var l = __webpack_require__(23), n = \\"function\\" === typeof Symbol && Symbol.for, p = n ? Symbol.for(\\"react.element\\") : 60103, q = n ? Symbol.for(\\"react.portal\\") : 60106, r = n ? Symbol.for(\\"react.fragment\\") : 60107, t = n ? Symbol.for(\\"react.strict_mode\\") : 60108, u = n ? Symbol.for(\\"react.profiler\\") : 60114, v = n ? Symbol.for(\\"react.provider\\") : 60109, w = n ? Symbol.for(\\"react.context\\") : 60110, x = n ? Symbol.for(\\"react.forward_ref\\") : 60112, y = n ? Symbol.for(\\"react.suspense\\") : 60113, z = n ? Symbol.for(\\"react.memo\\") : 60115, A = n ? Symbol.for(\\"react.lazy\\") : 60116, B = \\"function\\" === typeof Symbol && Symbol.iterator;
+    var _typeof = __webpack_require__(13);
+    var l = __webpack_require__(24), n = \\"function\\" === typeof Symbol && Symbol.for, p = n ? Symbol.for(\\"react.element\\") : 60103, q = n ? Symbol.for(\\"react.portal\\") : 60106, r = n ? Symbol.for(\\"react.fragment\\") : 60107, t = n ? Symbol.for(\\"react.strict_mode\\") : 60108, u = n ? Symbol.for(\\"react.profiler\\") : 60114, v = n ? Symbol.for(\\"react.provider\\") : 60109, w = n ? Symbol.for(\\"react.context\\") : 60110, x = n ? Symbol.for(\\"react.forward_ref\\") : 60112, y = n ? Symbol.for(\\"react.suspense\\") : 60113, z = n ? Symbol.for(\\"react.memo\\") : 60115, A = n ? Symbol.for(\\"react.lazy\\") : 60116, B = \\"function\\" === typeof Symbol && Symbol.iterator;
     function C(a) {
         for (var b = \\"https://reactjs.org/docs/error-decoder.html?invariant=\\" + a, c = 1; c < arguments.length; c++) {
             b += \\"&args[]=\\" + encodeURIComponent(arguments[c]);

--- a/packages/taro-mini-runner/__tests__/__snapshots__/qq.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/qq.spec.ts.snap
@@ -16,21 +16,21 @@ require(\\"./taro\\");
     11: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         if (true) {
-            module.exports = __webpack_require__(27);
+            module.exports = __webpack_require__(28);
         } else {}
     },
-    17: function(module, exports, __webpack_require__) {
+    18: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         if (true) {
-            module.exports = __webpack_require__(25);
+            module.exports = __webpack_require__(26);
         } else {}
     },
-    24: function(module, exports, __webpack_require__) {},
-    25: function(module, exports, __webpack_require__) {
-        var _typeof = __webpack_require__(14);
+    25: function(module, exports, __webpack_require__) {},
+    26: function(module, exports, __webpack_require__) {
+        var _typeof = __webpack_require__(13);
         module.exports = function $$$reconciler($$$hostConfig) {
             \\"use strict\\";
-            var aa = __webpack_require__(26), ba = __webpack_require__(6), m = __webpack_require__(11);
+            var aa = __webpack_require__(27), ba = __webpack_require__(6), m = __webpack_require__(11);
             function n(a) {
                 for (var b = \\"https://reactjs.org/docs/error-decoder.html?invariant=\\" + a, c = 1; c < arguments.length; c++) {
                     b += \\"&args[]=\\" + encodeURIComponent(arguments[c]);
@@ -4017,7 +4017,7 @@ require(\\"./taro\\");
             return $$$renderer;
         };
     },
-    26: function(module, exports, __webpack_require__) {
+    27: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         var getOwnPropertySymbols = Object.getOwnPropertySymbols;
         var hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -4083,10 +4083,10 @@ require(\\"./taro\\");
             return to;
         };
     },
-    27: function(module, exports, __webpack_require__) {
+    28: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         (function(window) {
-            var _typeof = __webpack_require__(14);
+            var _typeof = __webpack_require__(13);
             Object.defineProperty(exports, \\"__esModule\\", {
                 value: !0
             });
@@ -4359,7 +4359,7 @@ require(\\"./taro\\");
             exports.unstable_Profiling = null;
         }).call(this, __webpack_require__(3)[\\"window\\"]);
     },
-    30: function(module, __webpack_exports__, __webpack_require__) {
+    35: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         __webpack_require__.r(__webpack_exports__);
         var runtime_esm = __webpack_require__(3);
@@ -4369,7 +4369,7 @@ require(\\"./taro\\");
         var getPrototypeOf = __webpack_require__(2);
         var inherits = __webpack_require__(5);
         var react = __webpack_require__(6);
-        var app = __webpack_require__(24);
+        var app = __webpack_require__(25);
         var app_App = function(_Component) {
             Object(inherits[\\"a\\"])(App, _Component);
             function App() {
@@ -4397,10 +4397,10 @@ require(\\"./taro\\");
             return App;
         }(react[\\"Component\\"]);
         var lib_src_app = app_App;
-        var react_esm = __webpack_require__(16);
+        var react_esm = __webpack_require__(17);
         var inst = App(Object(runtime_esm[\\"createReactApp\\"])(lib_src_app, react, react_esm[\\"a\\"]));
     }
-}, [ [ 30, 0, 1, 2 ] ] ]);
+}, [ [ 35, 0, 1, 2 ] ] ]);
 
 
 
@@ -5087,13 +5087,13 @@ object-assign
 
 /** filePath: dist/comp.js **/
 (wx[\\"webpackJsonp\\"] = wx[\\"webpackJsonp\\"] || []).push([ [ 5 ], {
-    28: function(module, __webpack_exports__, __webpack_require__) {
+    29: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         __webpack_require__.r(__webpack_exports__);
         var _tarojs_runtime__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(3);
         Component(Object(_tarojs_runtime__WEBPACK_IMPORTED_MODULE_0__[\\"createRecursiveComponentConfig\\"])());
     }
-}, [ [ 28, 0, 1, 2 ] ] ]);
+}, [ [ 29, 0, 1, 2 ] ] ]);
 
 /** filePath: dist/comp.json **/
 {\\"component\\":true,\\"usingComponents\\":{\\"comp\\":\\"./comp\\"}}
@@ -5104,11 +5104,556 @@ object-assign
 
 /** filePath: dist/pages/index/index.js **/
 (wx[\\"webpackJsonp\\"] = wx[\\"webpackJsonp\\"] || []).push([ [ 6 ], {
-    29: function(module, exports, __webpack_require__) {},
-    31: function(module, __webpack_exports__, __webpack_require__) {
+    15: function(module, exports, __webpack_require__) {
+        module.exports = __webpack_require__(30);
+    },
+    30: function(module, exports, __webpack_require__) {
+        var g = function() {
+            return this;
+        }() || Function(\\"return this\\")();
+        var hadRuntime = g.regeneratorRuntime && Object.getOwnPropertyNames(g).indexOf(\\"regeneratorRuntime\\") >= 0;
+        var oldRuntime = hadRuntime && g.regeneratorRuntime;
+        g.regeneratorRuntime = undefined;
+        module.exports = __webpack_require__(31);
+        if (hadRuntime) {
+            g.regeneratorRuntime = oldRuntime;
+        } else {
+            try {
+                delete g.regeneratorRuntime;
+            } catch (e) {
+                g.regeneratorRuntime = undefined;
+            }
+        }
+    },
+    31: function(module, exports, __webpack_require__) {
+        (function(module) {
+            var _typeof = __webpack_require__(13);
+            !function(global) {
+                \\"use strict\\";
+                var Op = Object.prototype;
+                var hasOwn = Op.hasOwnProperty;
+                var undefined;
+                var $Symbol = typeof Symbol === \\"function\\" ? Symbol : {};
+                var iteratorSymbol = $Symbol.iterator || \\"@@iterator\\";
+                var asyncIteratorSymbol = $Symbol.asyncIterator || \\"@@asyncIterator\\";
+                var toStringTagSymbol = $Symbol.toStringTag || \\"@@toStringTag\\";
+                var inModule = (false ? undefined : _typeof(module)) === \\"object\\";
+                var runtime = global.regeneratorRuntime;
+                if (runtime) {
+                    if (inModule) {
+                        module.exports = runtime;
+                    }
+                    return;
+                }
+                runtime = global.regeneratorRuntime = inModule ? module.exports : {};
+                function wrap(innerFn, outerFn, self, tryLocsList) {
+                    var protoGenerator = outerFn && outerFn.prototype instanceof Generator ? outerFn : Generator;
+                    var generator = Object.create(protoGenerator.prototype);
+                    var context = new Context(tryLocsList || []);
+                    generator._invoke = makeInvokeMethod(innerFn, self, context);
+                    return generator;
+                }
+                runtime.wrap = wrap;
+                function tryCatch(fn, obj, arg) {
+                    try {
+                        return {
+                            type: \\"normal\\",
+                            arg: fn.call(obj, arg)
+                        };
+                    } catch (err) {
+                        return {
+                            type: \\"throw\\",
+                            arg: err
+                        };
+                    }
+                }
+                var GenStateSuspendedStart = \\"suspendedStart\\";
+                var GenStateSuspendedYield = \\"suspendedYield\\";
+                var GenStateExecuting = \\"executing\\";
+                var GenStateCompleted = \\"completed\\";
+                var ContinueSentinel = {};
+                function Generator() {}
+                function GeneratorFunction() {}
+                function GeneratorFunctionPrototype() {}
+                var IteratorPrototype = {};
+                IteratorPrototype[iteratorSymbol] = function() {
+                    return this;
+                };
+                var getProto = Object.getPrototypeOf;
+                var NativeIteratorPrototype = getProto && getProto(getProto(values([])));
+                if (NativeIteratorPrototype && NativeIteratorPrototype !== Op && hasOwn.call(NativeIteratorPrototype, iteratorSymbol)) {
+                    IteratorPrototype = NativeIteratorPrototype;
+                }
+                var Gp = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(IteratorPrototype);
+                GeneratorFunction.prototype = Gp.constructor = GeneratorFunctionPrototype;
+                GeneratorFunctionPrototype.constructor = GeneratorFunction;
+                GeneratorFunctionPrototype[toStringTagSymbol] = GeneratorFunction.displayName = \\"GeneratorFunction\\";
+                function defineIteratorMethods(prototype) {
+                    [ \\"next\\", \\"throw\\", \\"return\\" ].forEach((function(method) {
+                        prototype[method] = function(arg) {
+                            return this._invoke(method, arg);
+                        };
+                    }));
+                }
+                runtime.isGeneratorFunction = function(genFun) {
+                    var ctor = typeof genFun === \\"function\\" && genFun.constructor;
+                    return ctor ? ctor === GeneratorFunction || (ctor.displayName || ctor.name) === \\"GeneratorFunction\\" : false;
+                };
+                runtime.mark = function(genFun) {
+                    if (Object.setPrototypeOf) {
+                        Object.setPrototypeOf(genFun, GeneratorFunctionPrototype);
+                    } else {
+                        genFun.__proto__ = GeneratorFunctionPrototype;
+                        if (!(toStringTagSymbol in genFun)) {
+                            genFun[toStringTagSymbol] = \\"GeneratorFunction\\";
+                        }
+                    }
+                    genFun.prototype = Object.create(Gp);
+                    return genFun;
+                };
+                runtime.awrap = function(arg) {
+                    return {
+                        __await: arg
+                    };
+                };
+                function AsyncIterator(generator) {
+                    function invoke(method, arg, resolve, reject) {
+                        var record = tryCatch(generator[method], generator, arg);
+                        if (record.type === \\"throw\\") {
+                            reject(record.arg);
+                        } else {
+                            var result = record.arg;
+                            var value = result.value;
+                            if (value && _typeof(value) === \\"object\\" && hasOwn.call(value, \\"__await\\")) {
+                                return Promise.resolve(value.__await).then((function(value) {
+                                    invoke(\\"next\\", value, resolve, reject);
+                                }), (function(err) {
+                                    invoke(\\"throw\\", err, resolve, reject);
+                                }));
+                            }
+                            return Promise.resolve(value).then((function(unwrapped) {
+                                result.value = unwrapped;
+                                resolve(result);
+                            }), reject);
+                        }
+                    }
+                    var previousPromise;
+                    function enqueue(method, arg) {
+                        function callInvokeWithMethodAndArg() {
+                            return new Promise((function(resolve, reject) {
+                                invoke(method, arg, resolve, reject);
+                            }));
+                        }
+                        return previousPromise = previousPromise ? previousPromise.then(callInvokeWithMethodAndArg, callInvokeWithMethodAndArg) : callInvokeWithMethodAndArg();
+                    }
+                    this._invoke = enqueue;
+                }
+                defineIteratorMethods(AsyncIterator.prototype);
+                AsyncIterator.prototype[asyncIteratorSymbol] = function() {
+                    return this;
+                };
+                runtime.AsyncIterator = AsyncIterator;
+                runtime.async = function(innerFn, outerFn, self, tryLocsList) {
+                    var iter = new AsyncIterator(wrap(innerFn, outerFn, self, tryLocsList));
+                    return runtime.isGeneratorFunction(outerFn) ? iter : iter.next().then((function(result) {
+                        return result.done ? result.value : iter.next();
+                    }));
+                };
+                function makeInvokeMethod(innerFn, self, context) {
+                    var state = GenStateSuspendedStart;
+                    return function invoke(method, arg) {
+                        if (state === GenStateExecuting) {
+                            throw new Error(\\"Generator is already running\\");
+                        }
+                        if (state === GenStateCompleted) {
+                            if (method === \\"throw\\") {
+                                throw arg;
+                            }
+                            return doneResult();
+                        }
+                        context.method = method;
+                        context.arg = arg;
+                        while (true) {
+                            var delegate = context.delegate;
+                            if (delegate) {
+                                var delegateResult = maybeInvokeDelegate(delegate, context);
+                                if (delegateResult) {
+                                    if (delegateResult === ContinueSentinel) continue;
+                                    return delegateResult;
+                                }
+                            }
+                            if (context.method === \\"next\\") {
+                                context.sent = context._sent = context.arg;
+                            } else if (context.method === \\"throw\\") {
+                                if (state === GenStateSuspendedStart) {
+                                    state = GenStateCompleted;
+                                    throw context.arg;
+                                }
+                                context.dispatchException(context.arg);
+                            } else if (context.method === \\"return\\") {
+                                context.abrupt(\\"return\\", context.arg);
+                            }
+                            state = GenStateExecuting;
+                            var record = tryCatch(innerFn, self, context);
+                            if (record.type === \\"normal\\") {
+                                state = context.done ? GenStateCompleted : GenStateSuspendedYield;
+                                if (record.arg === ContinueSentinel) {
+                                    continue;
+                                }
+                                return {
+                                    value: record.arg,
+                                    done: context.done
+                                };
+                            } else if (record.type === \\"throw\\") {
+                                state = GenStateCompleted;
+                                context.method = \\"throw\\";
+                                context.arg = record.arg;
+                            }
+                        }
+                    };
+                }
+                function maybeInvokeDelegate(delegate, context) {
+                    var method = delegate.iterator[context.method];
+                    if (method === undefined) {
+                        context.delegate = null;
+                        if (context.method === \\"throw\\") {
+                            if (delegate.iterator.return) {
+                                context.method = \\"return\\";
+                                context.arg = undefined;
+                                maybeInvokeDelegate(delegate, context);
+                                if (context.method === \\"throw\\") {
+                                    return ContinueSentinel;
+                                }
+                            }
+                            context.method = \\"throw\\";
+                            context.arg = new TypeError(\\"The iterator does not provide a 'throw' method\\");
+                        }
+                        return ContinueSentinel;
+                    }
+                    var record = tryCatch(method, delegate.iterator, context.arg);
+                    if (record.type === \\"throw\\") {
+                        context.method = \\"throw\\";
+                        context.arg = record.arg;
+                        context.delegate = null;
+                        return ContinueSentinel;
+                    }
+                    var info = record.arg;
+                    if (!info) {
+                        context.method = \\"throw\\";
+                        context.arg = new TypeError(\\"iterator result is not an object\\");
+                        context.delegate = null;
+                        return ContinueSentinel;
+                    }
+                    if (info.done) {
+                        context[delegate.resultName] = info.value;
+                        context.next = delegate.nextLoc;
+                        if (context.method !== \\"return\\") {
+                            context.method = \\"next\\";
+                            context.arg = undefined;
+                        }
+                    } else {
+                        return info;
+                    }
+                    context.delegate = null;
+                    return ContinueSentinel;
+                }
+                defineIteratorMethods(Gp);
+                Gp[toStringTagSymbol] = \\"Generator\\";
+                Gp[iteratorSymbol] = function() {
+                    return this;
+                };
+                Gp.toString = function() {
+                    return \\"[object Generator]\\";
+                };
+                function pushTryEntry(locs) {
+                    var entry = {
+                        tryLoc: locs[0]
+                    };
+                    if (1 in locs) {
+                        entry.catchLoc = locs[1];
+                    }
+                    if (2 in locs) {
+                        entry.finallyLoc = locs[2];
+                        entry.afterLoc = locs[3];
+                    }
+                    this.tryEntries.push(entry);
+                }
+                function resetTryEntry(entry) {
+                    var record = entry.completion || {};
+                    record.type = \\"normal\\";
+                    delete record.arg;
+                    entry.completion = record;
+                }
+                function Context(tryLocsList) {
+                    this.tryEntries = [ {
+                        tryLoc: \\"root\\"
+                    } ];
+                    tryLocsList.forEach(pushTryEntry, this);
+                    this.reset(true);
+                }
+                runtime.keys = function(object) {
+                    var keys = [];
+                    for (var key in object) {
+                        keys.push(key);
+                    }
+                    keys.reverse();
+                    return function next() {
+                        while (keys.length) {
+                            var key = keys.pop();
+                            if (key in object) {
+                                next.value = key;
+                                next.done = false;
+                                return next;
+                            }
+                        }
+                        next.done = true;
+                        return next;
+                    };
+                };
+                function values(iterable) {
+                    if (iterable) {
+                        var iteratorMethod = iterable[iteratorSymbol];
+                        if (iteratorMethod) {
+                            return iteratorMethod.call(iterable);
+                        }
+                        if (typeof iterable.next === \\"function\\") {
+                            return iterable;
+                        }
+                        if (!isNaN(iterable.length)) {
+                            var i = -1, next = function next() {
+                                while (++i < iterable.length) {
+                                    if (hasOwn.call(iterable, i)) {
+                                        next.value = iterable[i];
+                                        next.done = false;
+                                        return next;
+                                    }
+                                }
+                                next.value = undefined;
+                                next.done = true;
+                                return next;
+                            };
+                            return next.next = next;
+                        }
+                    }
+                    return {
+                        next: doneResult
+                    };
+                }
+                runtime.values = values;
+                function doneResult() {
+                    return {
+                        value: undefined,
+                        done: true
+                    };
+                }
+                Context.prototype = {
+                    constructor: Context,
+                    reset: function reset(skipTempReset) {
+                        this.prev = 0;
+                        this.next = 0;
+                        this.sent = this._sent = undefined;
+                        this.done = false;
+                        this.delegate = null;
+                        this.method = \\"next\\";
+                        this.arg = undefined;
+                        this.tryEntries.forEach(resetTryEntry);
+                        if (!skipTempReset) {
+                            for (var name in this) {
+                                if (name.charAt(0) === \\"t\\" && hasOwn.call(this, name) && !isNaN(+name.slice(1))) {
+                                    this[name] = undefined;
+                                }
+                            }
+                        }
+                    },
+                    stop: function stop() {
+                        this.done = true;
+                        var rootEntry = this.tryEntries[0];
+                        var rootRecord = rootEntry.completion;
+                        if (rootRecord.type === \\"throw\\") {
+                            throw rootRecord.arg;
+                        }
+                        return this.rval;
+                    },
+                    dispatchException: function dispatchException(exception) {
+                        if (this.done) {
+                            throw exception;
+                        }
+                        var context = this;
+                        function handle(loc, caught) {
+                            record.type = \\"throw\\";
+                            record.arg = exception;
+                            context.next = loc;
+                            if (caught) {
+                                context.method = \\"next\\";
+                                context.arg = undefined;
+                            }
+                            return !!caught;
+                        }
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            var record = entry.completion;
+                            if (entry.tryLoc === \\"root\\") {
+                                return handle(\\"end\\");
+                            }
+                            if (entry.tryLoc <= this.prev) {
+                                var hasCatch = hasOwn.call(entry, \\"catchLoc\\");
+                                var hasFinally = hasOwn.call(entry, \\"finallyLoc\\");
+                                if (hasCatch && hasFinally) {
+                                    if (this.prev < entry.catchLoc) {
+                                        return handle(entry.catchLoc, true);
+                                    } else if (this.prev < entry.finallyLoc) {
+                                        return handle(entry.finallyLoc);
+                                    }
+                                } else if (hasCatch) {
+                                    if (this.prev < entry.catchLoc) {
+                                        return handle(entry.catchLoc, true);
+                                    }
+                                } else if (hasFinally) {
+                                    if (this.prev < entry.finallyLoc) {
+                                        return handle(entry.finallyLoc);
+                                    }
+                                } else {
+                                    throw new Error(\\"try statement without catch or finally\\");
+                                }
+                            }
+                        }
+                    },
+                    abrupt: function abrupt(type, arg) {
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            if (entry.tryLoc <= this.prev && hasOwn.call(entry, \\"finallyLoc\\") && this.prev < entry.finallyLoc) {
+                                var finallyEntry = entry;
+                                break;
+                            }
+                        }
+                        if (finallyEntry && (type === \\"break\\" || type === \\"continue\\") && finallyEntry.tryLoc <= arg && arg <= finallyEntry.finallyLoc) {
+                            finallyEntry = null;
+                        }
+                        var record = finallyEntry ? finallyEntry.completion : {};
+                        record.type = type;
+                        record.arg = arg;
+                        if (finallyEntry) {
+                            this.method = \\"next\\";
+                            this.next = finallyEntry.finallyLoc;
+                            return ContinueSentinel;
+                        }
+                        return this.complete(record);
+                    },
+                    complete: function complete(record, afterLoc) {
+                        if (record.type === \\"throw\\") {
+                            throw record.arg;
+                        }
+                        if (record.type === \\"break\\" || record.type === \\"continue\\") {
+                            this.next = record.arg;
+                        } else if (record.type === \\"return\\") {
+                            this.rval = this.arg = record.arg;
+                            this.method = \\"return\\";
+                            this.next = \\"end\\";
+                        } else if (record.type === \\"normal\\" && afterLoc) {
+                            this.next = afterLoc;
+                        }
+                        return ContinueSentinel;
+                    },
+                    finish: function finish(finallyLoc) {
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            if (entry.finallyLoc === finallyLoc) {
+                                this.complete(entry.completion, entry.afterLoc);
+                                resetTryEntry(entry);
+                                return ContinueSentinel;
+                            }
+                        }
+                    },
+                    catch: function _catch(tryLoc) {
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            if (entry.tryLoc === tryLoc) {
+                                var record = entry.completion;
+                                if (record.type === \\"throw\\") {
+                                    var thrown = record.arg;
+                                    resetTryEntry(entry);
+                                }
+                                return thrown;
+                            }
+                        }
+                        throw new Error(\\"illegal catch attempt\\");
+                    },
+                    delegateYield: function delegateYield(iterable, resultName, nextLoc) {
+                        this.delegate = {
+                            iterator: values(iterable),
+                            resultName: resultName,
+                            nextLoc: nextLoc
+                        };
+                        if (this.method === \\"next\\") {
+                            this.arg = undefined;
+                        }
+                        return ContinueSentinel;
+                    }
+                };
+            }(function() {
+                return this;
+            }() || Function(\\"return this\\")());
+        }).call(this, __webpack_require__(32)(module));
+    },
+    32: function(module, exports) {
+        module.exports = function(module) {
+            if (!module.webpackPolyfill) {
+                module.deprecate = function() {};
+                module.paths = [];
+                if (!module.children) module.children = [];
+                Object.defineProperty(module, \\"loaded\\", {
+                    enumerable: true,
+                    get: function get() {
+                        return module.l;
+                    }
+                });
+                Object.defineProperty(module, \\"id\\", {
+                    enumerable: true,
+                    get: function get() {
+                        return module.i;
+                    }
+                });
+                module.webpackPolyfill = 1;
+            }
+            return module;
+        };
+    },
+    33: function(module, exports, __webpack_require__) {},
+    34: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         __webpack_require__.r(__webpack_exports__);
         var runtime_esm = __webpack_require__(3);
+        var regenerator = __webpack_require__(15);
+        var regenerator_default = __webpack_require__.n(regenerator);
+        function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
+            try {
+                var info = gen[key](arg);
+                var value = info.value;
+            } catch (error) {
+                reject(error);
+                return;
+            }
+            if (info.done) {
+                resolve(value);
+            } else {
+                Promise.resolve(value).then(_next, _throw);
+            }
+        }
+        function _asyncToGenerator(fn) {
+            return function() {
+                var self = this, args = arguments;
+                return new Promise((function(resolve, reject) {
+                    var gen = fn.apply(self, args);
+                    function _next(value) {
+                        asyncGeneratorStep(gen, resolve, reject, _next, _throw, \\"next\\", value);
+                    }
+                    function _throw(err) {
+                        asyncGeneratorStep(gen, resolve, reject, _next, _throw, \\"throw\\", err);
+                    }
+                    _next(undefined);
+                }));
+            };
+        }
         var classCallCheck = __webpack_require__(0);
         var createClass = __webpack_require__(1);
         var possibleConstructorReturn = __webpack_require__(4);
@@ -5117,7 +5662,7 @@ object-assign
         var react = __webpack_require__(6);
         var react_default = __webpack_require__.n(react);
         var mini = __webpack_require__(12);
-        var index = __webpack_require__(29);
+        var index = __webpack_require__(33);
         var index_Index = function(_Component) {
             Object(inherits[\\"a\\"])(Index, _Component);
             function Index() {
@@ -5126,7 +5671,27 @@ object-assign
             }
             Object(createClass[\\"a\\"])(Index, [ {
                 key: \\"componentWillMount\\",
-                value: function componentWillMount() {}
+                value: function() {
+                    var _componentWillMount = _asyncToGenerator(regenerator_default.a.mark((function _callee() {
+                        return regenerator_default.a.wrap((function _callee$(_context) {
+                            while (1) {
+                                switch (_context.prev = _context.next) {
+                                  case 0:
+                                    _context.next = 2;
+                                    return Promise.resolve(1);
+
+                                  case 2:
+                                  case \\"end\\":
+                                    return _context.stop();
+                                }
+                            }
+                        }), _callee);
+                    })));
+                    function componentWillMount() {
+                        return _componentWillMount.apply(this, arguments);
+                    }
+                    return componentWillMount;
+                }()
             }, {
                 key: \\"componentDidMount\\",
                 value: function componentDidMount() {}
@@ -5156,7 +5721,7 @@ object-assign
         }(react[\\"Component\\"]);
         var inst = Page(Object(runtime_esm[\\"createPageConfig\\"])(index_Index, \\"pages/index/index\\"));
     }
-}, [ [ 31, 0, 1, 2 ] ] ]);
+}, [ [ 34, 0, 1, 2 ] ] ]);
 
 /** filePath: dist/pages/index/index.json **/
 {\\"navigationBarTitleText\\":\\"首页\\",\\"usingComponents\\":{\\"comp\\":\\"../../comp\\"}}
@@ -5347,12 +5912,12 @@ object-assign
         var MovableArea = \\"movable-area\\";
         var MovableView = \\"movable-view\\";
     },
-    16: function(module, __webpack_exports__, __webpack_require__) {
+    17: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         var _babel_runtime_helpers_esm_classCallCheck__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
         var _babel_runtime_helpers_esm_createClass__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(1);
         var _babel_runtime_helpers_esm_typeof__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(8);
-        var react_reconciler__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(17);
+        var react_reconciler__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(18);
         var react_reconciler__WEBPACK_IMPORTED_MODULE_3___default = __webpack_require__.n(react_reconciler__WEBPACK_IMPORTED_MODULE_3__);
         var scheduler__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(11);
         var scheduler__WEBPACK_IMPORTED_MODULE_4___default = __webpack_require__.n(scheduler__WEBPACK_IMPORTED_MODULE_4__);
@@ -5835,13 +6400,13 @@ object-assign
             __webpack_require__.d(__webpack_exports__, \\"window\\", (function() {
                 return window$1;
             }));
-            var _babel_runtime_helpers_esm_toConsumableArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(18);
-            var _babel_runtime_helpers_esm_set__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(19);
+            var _babel_runtime_helpers_esm_toConsumableArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(19);
+            var _babel_runtime_helpers_esm_set__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(20);
             var _babel_runtime_helpers_esm_possibleConstructorReturn__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(4);
             var _babel_runtime_helpers_esm_getPrototypeOf__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(2);
             var _babel_runtime_helpers_esm_assertThisInitialized__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(10);
             var _babel_runtime_helpers_esm_inherits__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(5);
-            var _babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(15);
+            var _babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(16);
             var _babel_runtime_helpers_esm_defineProperty__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(7);
             var _babel_runtime_helpers_esm_classCallCheck__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(0);
             var _babel_runtime_helpers_esm_createClass__WEBPACK_IMPORTED_MODULE_9__ = __webpack_require__(1);
@@ -8837,7 +9402,7 @@ object-assign
 }, function(module, exports, __webpack_require__) {
     \\"use strict\\";
     if (true) {
-        module.exports = __webpack_require__(22);
+        module.exports = __webpack_require__(23);
     } else {}
 }, function(module, __webpack_exports__, __webpack_require__) {
     \\"use strict\\";
@@ -8898,21 +9463,7 @@ object-assign
         }
         return self;
     }
-}, , , function(module, __webpack_exports__, __webpack_require__) {
-    \\"use strict\\";
-    __webpack_require__.d(__webpack_exports__, \\"a\\", (function() {
-        return _unsupportedIterableToArray;
-    }));
-    var _arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(9);
-    function _unsupportedIterableToArray(o, minLen) {
-        if (!o) return;
-        if (typeof o === \\"string\\") return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
-        var n = Object.prototype.toString.call(o).slice(8, -1);
-        if (n === \\"Object\\" && o.constructor) n = o.constructor.name;
-        if (n === \\"Map\\" || n === \\"Set\\") return Array.from(o);
-        if (n === \\"Arguments\\" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
-    }
-}, function(module, exports) {
+}, , , function(module, exports) {
     function _typeof(obj) {
         \\"@babel/helpers - typeof\\";
         if (typeof Symbol === \\"function\\" && typeof Symbol.iterator === \\"symbol\\") {
@@ -8928,6 +9479,20 @@ object-assign
     }
     module.exports = _typeof;
 }, function(module, __webpack_exports__, __webpack_require__) {
+    \\"use strict\\";
+    __webpack_require__.d(__webpack_exports__, \\"a\\", (function() {
+        return _unsupportedIterableToArray;
+    }));
+    var _arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(9);
+    function _unsupportedIterableToArray(o, minLen) {
+        if (!o) return;
+        if (typeof o === \\"string\\") return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
+        var n = Object.prototype.toString.call(o).slice(8, -1);
+        if (n === \\"Object\\" && o.constructor) n = o.constructor.name;
+        if (n === \\"Map\\" || n === \\"Set\\") return Array.from(o);
+        if (n === \\"Arguments\\" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
+    }
+}, , function(module, __webpack_exports__, __webpack_require__) {
     \\"use strict\\";
     __webpack_require__.d(__webpack_exports__, \\"a\\", (function() {
         return _slicedToArray;
@@ -8958,7 +9523,7 @@ object-assign
         }
         return _arr;
     }
-    var unsupportedIterableToArray = __webpack_require__(13);
+    var unsupportedIterableToArray = __webpack_require__(14);
     function _nonIterableRest() {
         throw new TypeError(\\"Invalid attempt to destructure non-iterable instance.\\\\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.\\");
     }
@@ -8977,7 +9542,7 @@ object-assign
     function _iterableToArray(iter) {
         if (typeof Symbol !== \\"undefined\\" && Symbol.iterator in Object(iter)) return Array.from(iter);
     }
-    var unsupportedIterableToArray = __webpack_require__(13);
+    var unsupportedIterableToArray = __webpack_require__(14);
     function _nonIterableSpread() {
         throw new TypeError(\\"Invalid attempt to spread non-iterable instance.\\\\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.\\");
     }
@@ -9038,8 +9603,8 @@ object-assign
     }
 }, , , function(module, exports, __webpack_require__) {
     \\"use strict\\";
-    var _typeof = __webpack_require__(14);
-    var l = __webpack_require__(23), n = \\"function\\" === typeof Symbol && Symbol.for, p = n ? Symbol.for(\\"react.element\\") : 60103, q = n ? Symbol.for(\\"react.portal\\") : 60106, r = n ? Symbol.for(\\"react.fragment\\") : 60107, t = n ? Symbol.for(\\"react.strict_mode\\") : 60108, u = n ? Symbol.for(\\"react.profiler\\") : 60114, v = n ? Symbol.for(\\"react.provider\\") : 60109, w = n ? Symbol.for(\\"react.context\\") : 60110, x = n ? Symbol.for(\\"react.forward_ref\\") : 60112, y = n ? Symbol.for(\\"react.suspense\\") : 60113, z = n ? Symbol.for(\\"react.memo\\") : 60115, A = n ? Symbol.for(\\"react.lazy\\") : 60116, B = \\"function\\" === typeof Symbol && Symbol.iterator;
+    var _typeof = __webpack_require__(13);
+    var l = __webpack_require__(24), n = \\"function\\" === typeof Symbol && Symbol.for, p = n ? Symbol.for(\\"react.element\\") : 60103, q = n ? Symbol.for(\\"react.portal\\") : 60106, r = n ? Symbol.for(\\"react.fragment\\") : 60107, t = n ? Symbol.for(\\"react.strict_mode\\") : 60108, u = n ? Symbol.for(\\"react.profiler\\") : 60114, v = n ? Symbol.for(\\"react.provider\\") : 60109, w = n ? Symbol.for(\\"react.context\\") : 60110, x = n ? Symbol.for(\\"react.forward_ref\\") : 60112, y = n ? Symbol.for(\\"react.suspense\\") : 60113, z = n ? Symbol.for(\\"react.memo\\") : 60115, A = n ? Symbol.for(\\"react.lazy\\") : 60116, B = \\"function\\" === typeof Symbol && Symbol.iterator;
     function C(a) {
         for (var b = \\"https://reactjs.org/docs/error-decoder.html?invariant=\\" + a, c = 1; c < arguments.length; c++) {
             b += \\"&args[]=\\" + encodeURIComponent(arguments[c]);
@@ -9482,21 +10047,21 @@ require(\\"./taro\\");
     11: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         if (true) {
-            module.exports = __webpack_require__(27);
+            module.exports = __webpack_require__(28);
         } else {}
     },
-    17: function(module, exports, __webpack_require__) {
+    18: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         if (true) {
-            module.exports = __webpack_require__(25);
+            module.exports = __webpack_require__(26);
         } else {}
     },
-    24: function(module, exports, __webpack_require__) {},
-    25: function(module, exports, __webpack_require__) {
-        var _typeof = __webpack_require__(14);
+    25: function(module, exports, __webpack_require__) {},
+    26: function(module, exports, __webpack_require__) {
+        var _typeof = __webpack_require__(13);
         module.exports = function $$$reconciler($$$hostConfig) {
             \\"use strict\\";
-            var aa = __webpack_require__(26), ba = __webpack_require__(6), m = __webpack_require__(11);
+            var aa = __webpack_require__(27), ba = __webpack_require__(6), m = __webpack_require__(11);
             function n(a) {
                 for (var b = \\"https://reactjs.org/docs/error-decoder.html?invariant=\\" + a, c = 1; c < arguments.length; c++) {
                     b += \\"&args[]=\\" + encodeURIComponent(arguments[c]);
@@ -13483,7 +14048,7 @@ require(\\"./taro\\");
             return $$$renderer;
         };
     },
-    26: function(module, exports, __webpack_require__) {
+    27: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         var getOwnPropertySymbols = Object.getOwnPropertySymbols;
         var hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -13549,10 +14114,10 @@ require(\\"./taro\\");
             return to;
         };
     },
-    27: function(module, exports, __webpack_require__) {
+    28: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         (function(window) {
-            var _typeof = __webpack_require__(14);
+            var _typeof = __webpack_require__(13);
             Object.defineProperty(exports, \\"__esModule\\", {
                 value: !0
             });
@@ -13825,7 +14390,7 @@ require(\\"./taro\\");
             exports.unstable_Profiling = null;
         }).call(this, __webpack_require__(3)[\\"window\\"]);
     },
-    30: function(module, __webpack_exports__, __webpack_require__) {
+    35: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         __webpack_require__.r(__webpack_exports__);
         var runtime_esm = __webpack_require__(3);
@@ -13835,7 +14400,7 @@ require(\\"./taro\\");
         var getPrototypeOf = __webpack_require__(2);
         var inherits = __webpack_require__(5);
         var react = __webpack_require__(6);
-        var app = __webpack_require__(24);
+        var app = __webpack_require__(25);
         var app_App = function(_Component) {
             Object(inherits[\\"a\\"])(App, _Component);
             function App() {
@@ -13863,10 +14428,10 @@ require(\\"./taro\\");
             return App;
         }(react[\\"Component\\"]);
         var lib_src_app = app_App;
-        var react_esm = __webpack_require__(16);
+        var react_esm = __webpack_require__(17);
         var inst = App(Object(runtime_esm[\\"createReactApp\\"])(lib_src_app, react, react_esm[\\"a\\"]));
     }
-}, [ [ 30, 0, 1, 2 ] ] ]);
+}, [ [ 35, 0, 1, 2 ] ] ]);
 
 
 
@@ -14937,13 +15502,13 @@ object-assign
 
 /** filePath: dist/comp.js **/
 (wx[\\"webpackJsonp\\"] = wx[\\"webpackJsonp\\"] || []).push([ [ 5 ], {
-    28: function(module, __webpack_exports__, __webpack_require__) {
+    29: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         __webpack_require__.r(__webpack_exports__);
         var _tarojs_runtime__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(3);
         Component(Object(_tarojs_runtime__WEBPACK_IMPORTED_MODULE_0__[\\"createRecursiveComponentConfig\\"])());
     }
-}, [ [ 28, 0, 1, 2 ] ] ]);
+}, [ [ 29, 0, 1, 2 ] ] ]);
 
 /** filePath: dist/comp.json **/
 {\\"component\\":true,\\"usingComponents\\":{\\"comp\\":\\"./comp\\"}}
@@ -14954,11 +15519,556 @@ object-assign
 
 /** filePath: dist/pages/index/index.js **/
 (wx[\\"webpackJsonp\\"] = wx[\\"webpackJsonp\\"] || []).push([ [ 6 ], {
-    29: function(module, exports, __webpack_require__) {},
-    31: function(module, __webpack_exports__, __webpack_require__) {
+    15: function(module, exports, __webpack_require__) {
+        module.exports = __webpack_require__(30);
+    },
+    30: function(module, exports, __webpack_require__) {
+        var g = function() {
+            return this;
+        }() || Function(\\"return this\\")();
+        var hadRuntime = g.regeneratorRuntime && Object.getOwnPropertyNames(g).indexOf(\\"regeneratorRuntime\\") >= 0;
+        var oldRuntime = hadRuntime && g.regeneratorRuntime;
+        g.regeneratorRuntime = undefined;
+        module.exports = __webpack_require__(31);
+        if (hadRuntime) {
+            g.regeneratorRuntime = oldRuntime;
+        } else {
+            try {
+                delete g.regeneratorRuntime;
+            } catch (e) {
+                g.regeneratorRuntime = undefined;
+            }
+        }
+    },
+    31: function(module, exports, __webpack_require__) {
+        (function(module) {
+            var _typeof = __webpack_require__(13);
+            !function(global) {
+                \\"use strict\\";
+                var Op = Object.prototype;
+                var hasOwn = Op.hasOwnProperty;
+                var undefined;
+                var $Symbol = typeof Symbol === \\"function\\" ? Symbol : {};
+                var iteratorSymbol = $Symbol.iterator || \\"@@iterator\\";
+                var asyncIteratorSymbol = $Symbol.asyncIterator || \\"@@asyncIterator\\";
+                var toStringTagSymbol = $Symbol.toStringTag || \\"@@toStringTag\\";
+                var inModule = (false ? undefined : _typeof(module)) === \\"object\\";
+                var runtime = global.regeneratorRuntime;
+                if (runtime) {
+                    if (inModule) {
+                        module.exports = runtime;
+                    }
+                    return;
+                }
+                runtime = global.regeneratorRuntime = inModule ? module.exports : {};
+                function wrap(innerFn, outerFn, self, tryLocsList) {
+                    var protoGenerator = outerFn && outerFn.prototype instanceof Generator ? outerFn : Generator;
+                    var generator = Object.create(protoGenerator.prototype);
+                    var context = new Context(tryLocsList || []);
+                    generator._invoke = makeInvokeMethod(innerFn, self, context);
+                    return generator;
+                }
+                runtime.wrap = wrap;
+                function tryCatch(fn, obj, arg) {
+                    try {
+                        return {
+                            type: \\"normal\\",
+                            arg: fn.call(obj, arg)
+                        };
+                    } catch (err) {
+                        return {
+                            type: \\"throw\\",
+                            arg: err
+                        };
+                    }
+                }
+                var GenStateSuspendedStart = \\"suspendedStart\\";
+                var GenStateSuspendedYield = \\"suspendedYield\\";
+                var GenStateExecuting = \\"executing\\";
+                var GenStateCompleted = \\"completed\\";
+                var ContinueSentinel = {};
+                function Generator() {}
+                function GeneratorFunction() {}
+                function GeneratorFunctionPrototype() {}
+                var IteratorPrototype = {};
+                IteratorPrototype[iteratorSymbol] = function() {
+                    return this;
+                };
+                var getProto = Object.getPrototypeOf;
+                var NativeIteratorPrototype = getProto && getProto(getProto(values([])));
+                if (NativeIteratorPrototype && NativeIteratorPrototype !== Op && hasOwn.call(NativeIteratorPrototype, iteratorSymbol)) {
+                    IteratorPrototype = NativeIteratorPrototype;
+                }
+                var Gp = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(IteratorPrototype);
+                GeneratorFunction.prototype = Gp.constructor = GeneratorFunctionPrototype;
+                GeneratorFunctionPrototype.constructor = GeneratorFunction;
+                GeneratorFunctionPrototype[toStringTagSymbol] = GeneratorFunction.displayName = \\"GeneratorFunction\\";
+                function defineIteratorMethods(prototype) {
+                    [ \\"next\\", \\"throw\\", \\"return\\" ].forEach((function(method) {
+                        prototype[method] = function(arg) {
+                            return this._invoke(method, arg);
+                        };
+                    }));
+                }
+                runtime.isGeneratorFunction = function(genFun) {
+                    var ctor = typeof genFun === \\"function\\" && genFun.constructor;
+                    return ctor ? ctor === GeneratorFunction || (ctor.displayName || ctor.name) === \\"GeneratorFunction\\" : false;
+                };
+                runtime.mark = function(genFun) {
+                    if (Object.setPrototypeOf) {
+                        Object.setPrototypeOf(genFun, GeneratorFunctionPrototype);
+                    } else {
+                        genFun.__proto__ = GeneratorFunctionPrototype;
+                        if (!(toStringTagSymbol in genFun)) {
+                            genFun[toStringTagSymbol] = \\"GeneratorFunction\\";
+                        }
+                    }
+                    genFun.prototype = Object.create(Gp);
+                    return genFun;
+                };
+                runtime.awrap = function(arg) {
+                    return {
+                        __await: arg
+                    };
+                };
+                function AsyncIterator(generator) {
+                    function invoke(method, arg, resolve, reject) {
+                        var record = tryCatch(generator[method], generator, arg);
+                        if (record.type === \\"throw\\") {
+                            reject(record.arg);
+                        } else {
+                            var result = record.arg;
+                            var value = result.value;
+                            if (value && _typeof(value) === \\"object\\" && hasOwn.call(value, \\"__await\\")) {
+                                return Promise.resolve(value.__await).then((function(value) {
+                                    invoke(\\"next\\", value, resolve, reject);
+                                }), (function(err) {
+                                    invoke(\\"throw\\", err, resolve, reject);
+                                }));
+                            }
+                            return Promise.resolve(value).then((function(unwrapped) {
+                                result.value = unwrapped;
+                                resolve(result);
+                            }), reject);
+                        }
+                    }
+                    var previousPromise;
+                    function enqueue(method, arg) {
+                        function callInvokeWithMethodAndArg() {
+                            return new Promise((function(resolve, reject) {
+                                invoke(method, arg, resolve, reject);
+                            }));
+                        }
+                        return previousPromise = previousPromise ? previousPromise.then(callInvokeWithMethodAndArg, callInvokeWithMethodAndArg) : callInvokeWithMethodAndArg();
+                    }
+                    this._invoke = enqueue;
+                }
+                defineIteratorMethods(AsyncIterator.prototype);
+                AsyncIterator.prototype[asyncIteratorSymbol] = function() {
+                    return this;
+                };
+                runtime.AsyncIterator = AsyncIterator;
+                runtime.async = function(innerFn, outerFn, self, tryLocsList) {
+                    var iter = new AsyncIterator(wrap(innerFn, outerFn, self, tryLocsList));
+                    return runtime.isGeneratorFunction(outerFn) ? iter : iter.next().then((function(result) {
+                        return result.done ? result.value : iter.next();
+                    }));
+                };
+                function makeInvokeMethod(innerFn, self, context) {
+                    var state = GenStateSuspendedStart;
+                    return function invoke(method, arg) {
+                        if (state === GenStateExecuting) {
+                            throw new Error(\\"Generator is already running\\");
+                        }
+                        if (state === GenStateCompleted) {
+                            if (method === \\"throw\\") {
+                                throw arg;
+                            }
+                            return doneResult();
+                        }
+                        context.method = method;
+                        context.arg = arg;
+                        while (true) {
+                            var delegate = context.delegate;
+                            if (delegate) {
+                                var delegateResult = maybeInvokeDelegate(delegate, context);
+                                if (delegateResult) {
+                                    if (delegateResult === ContinueSentinel) continue;
+                                    return delegateResult;
+                                }
+                            }
+                            if (context.method === \\"next\\") {
+                                context.sent = context._sent = context.arg;
+                            } else if (context.method === \\"throw\\") {
+                                if (state === GenStateSuspendedStart) {
+                                    state = GenStateCompleted;
+                                    throw context.arg;
+                                }
+                                context.dispatchException(context.arg);
+                            } else if (context.method === \\"return\\") {
+                                context.abrupt(\\"return\\", context.arg);
+                            }
+                            state = GenStateExecuting;
+                            var record = tryCatch(innerFn, self, context);
+                            if (record.type === \\"normal\\") {
+                                state = context.done ? GenStateCompleted : GenStateSuspendedYield;
+                                if (record.arg === ContinueSentinel) {
+                                    continue;
+                                }
+                                return {
+                                    value: record.arg,
+                                    done: context.done
+                                };
+                            } else if (record.type === \\"throw\\") {
+                                state = GenStateCompleted;
+                                context.method = \\"throw\\";
+                                context.arg = record.arg;
+                            }
+                        }
+                    };
+                }
+                function maybeInvokeDelegate(delegate, context) {
+                    var method = delegate.iterator[context.method];
+                    if (method === undefined) {
+                        context.delegate = null;
+                        if (context.method === \\"throw\\") {
+                            if (delegate.iterator.return) {
+                                context.method = \\"return\\";
+                                context.arg = undefined;
+                                maybeInvokeDelegate(delegate, context);
+                                if (context.method === \\"throw\\") {
+                                    return ContinueSentinel;
+                                }
+                            }
+                            context.method = \\"throw\\";
+                            context.arg = new TypeError(\\"The iterator does not provide a 'throw' method\\");
+                        }
+                        return ContinueSentinel;
+                    }
+                    var record = tryCatch(method, delegate.iterator, context.arg);
+                    if (record.type === \\"throw\\") {
+                        context.method = \\"throw\\";
+                        context.arg = record.arg;
+                        context.delegate = null;
+                        return ContinueSentinel;
+                    }
+                    var info = record.arg;
+                    if (!info) {
+                        context.method = \\"throw\\";
+                        context.arg = new TypeError(\\"iterator result is not an object\\");
+                        context.delegate = null;
+                        return ContinueSentinel;
+                    }
+                    if (info.done) {
+                        context[delegate.resultName] = info.value;
+                        context.next = delegate.nextLoc;
+                        if (context.method !== \\"return\\") {
+                            context.method = \\"next\\";
+                            context.arg = undefined;
+                        }
+                    } else {
+                        return info;
+                    }
+                    context.delegate = null;
+                    return ContinueSentinel;
+                }
+                defineIteratorMethods(Gp);
+                Gp[toStringTagSymbol] = \\"Generator\\";
+                Gp[iteratorSymbol] = function() {
+                    return this;
+                };
+                Gp.toString = function() {
+                    return \\"[object Generator]\\";
+                };
+                function pushTryEntry(locs) {
+                    var entry = {
+                        tryLoc: locs[0]
+                    };
+                    if (1 in locs) {
+                        entry.catchLoc = locs[1];
+                    }
+                    if (2 in locs) {
+                        entry.finallyLoc = locs[2];
+                        entry.afterLoc = locs[3];
+                    }
+                    this.tryEntries.push(entry);
+                }
+                function resetTryEntry(entry) {
+                    var record = entry.completion || {};
+                    record.type = \\"normal\\";
+                    delete record.arg;
+                    entry.completion = record;
+                }
+                function Context(tryLocsList) {
+                    this.tryEntries = [ {
+                        tryLoc: \\"root\\"
+                    } ];
+                    tryLocsList.forEach(pushTryEntry, this);
+                    this.reset(true);
+                }
+                runtime.keys = function(object) {
+                    var keys = [];
+                    for (var key in object) {
+                        keys.push(key);
+                    }
+                    keys.reverse();
+                    return function next() {
+                        while (keys.length) {
+                            var key = keys.pop();
+                            if (key in object) {
+                                next.value = key;
+                                next.done = false;
+                                return next;
+                            }
+                        }
+                        next.done = true;
+                        return next;
+                    };
+                };
+                function values(iterable) {
+                    if (iterable) {
+                        var iteratorMethod = iterable[iteratorSymbol];
+                        if (iteratorMethod) {
+                            return iteratorMethod.call(iterable);
+                        }
+                        if (typeof iterable.next === \\"function\\") {
+                            return iterable;
+                        }
+                        if (!isNaN(iterable.length)) {
+                            var i = -1, next = function next() {
+                                while (++i < iterable.length) {
+                                    if (hasOwn.call(iterable, i)) {
+                                        next.value = iterable[i];
+                                        next.done = false;
+                                        return next;
+                                    }
+                                }
+                                next.value = undefined;
+                                next.done = true;
+                                return next;
+                            };
+                            return next.next = next;
+                        }
+                    }
+                    return {
+                        next: doneResult
+                    };
+                }
+                runtime.values = values;
+                function doneResult() {
+                    return {
+                        value: undefined,
+                        done: true
+                    };
+                }
+                Context.prototype = {
+                    constructor: Context,
+                    reset: function reset(skipTempReset) {
+                        this.prev = 0;
+                        this.next = 0;
+                        this.sent = this._sent = undefined;
+                        this.done = false;
+                        this.delegate = null;
+                        this.method = \\"next\\";
+                        this.arg = undefined;
+                        this.tryEntries.forEach(resetTryEntry);
+                        if (!skipTempReset) {
+                            for (var name in this) {
+                                if (name.charAt(0) === \\"t\\" && hasOwn.call(this, name) && !isNaN(+name.slice(1))) {
+                                    this[name] = undefined;
+                                }
+                            }
+                        }
+                    },
+                    stop: function stop() {
+                        this.done = true;
+                        var rootEntry = this.tryEntries[0];
+                        var rootRecord = rootEntry.completion;
+                        if (rootRecord.type === \\"throw\\") {
+                            throw rootRecord.arg;
+                        }
+                        return this.rval;
+                    },
+                    dispatchException: function dispatchException(exception) {
+                        if (this.done) {
+                            throw exception;
+                        }
+                        var context = this;
+                        function handle(loc, caught) {
+                            record.type = \\"throw\\";
+                            record.arg = exception;
+                            context.next = loc;
+                            if (caught) {
+                                context.method = \\"next\\";
+                                context.arg = undefined;
+                            }
+                            return !!caught;
+                        }
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            var record = entry.completion;
+                            if (entry.tryLoc === \\"root\\") {
+                                return handle(\\"end\\");
+                            }
+                            if (entry.tryLoc <= this.prev) {
+                                var hasCatch = hasOwn.call(entry, \\"catchLoc\\");
+                                var hasFinally = hasOwn.call(entry, \\"finallyLoc\\");
+                                if (hasCatch && hasFinally) {
+                                    if (this.prev < entry.catchLoc) {
+                                        return handle(entry.catchLoc, true);
+                                    } else if (this.prev < entry.finallyLoc) {
+                                        return handle(entry.finallyLoc);
+                                    }
+                                } else if (hasCatch) {
+                                    if (this.prev < entry.catchLoc) {
+                                        return handle(entry.catchLoc, true);
+                                    }
+                                } else if (hasFinally) {
+                                    if (this.prev < entry.finallyLoc) {
+                                        return handle(entry.finallyLoc);
+                                    }
+                                } else {
+                                    throw new Error(\\"try statement without catch or finally\\");
+                                }
+                            }
+                        }
+                    },
+                    abrupt: function abrupt(type, arg) {
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            if (entry.tryLoc <= this.prev && hasOwn.call(entry, \\"finallyLoc\\") && this.prev < entry.finallyLoc) {
+                                var finallyEntry = entry;
+                                break;
+                            }
+                        }
+                        if (finallyEntry && (type === \\"break\\" || type === \\"continue\\") && finallyEntry.tryLoc <= arg && arg <= finallyEntry.finallyLoc) {
+                            finallyEntry = null;
+                        }
+                        var record = finallyEntry ? finallyEntry.completion : {};
+                        record.type = type;
+                        record.arg = arg;
+                        if (finallyEntry) {
+                            this.method = \\"next\\";
+                            this.next = finallyEntry.finallyLoc;
+                            return ContinueSentinel;
+                        }
+                        return this.complete(record);
+                    },
+                    complete: function complete(record, afterLoc) {
+                        if (record.type === \\"throw\\") {
+                            throw record.arg;
+                        }
+                        if (record.type === \\"break\\" || record.type === \\"continue\\") {
+                            this.next = record.arg;
+                        } else if (record.type === \\"return\\") {
+                            this.rval = this.arg = record.arg;
+                            this.method = \\"return\\";
+                            this.next = \\"end\\";
+                        } else if (record.type === \\"normal\\" && afterLoc) {
+                            this.next = afterLoc;
+                        }
+                        return ContinueSentinel;
+                    },
+                    finish: function finish(finallyLoc) {
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            if (entry.finallyLoc === finallyLoc) {
+                                this.complete(entry.completion, entry.afterLoc);
+                                resetTryEntry(entry);
+                                return ContinueSentinel;
+                            }
+                        }
+                    },
+                    catch: function _catch(tryLoc) {
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            if (entry.tryLoc === tryLoc) {
+                                var record = entry.completion;
+                                if (record.type === \\"throw\\") {
+                                    var thrown = record.arg;
+                                    resetTryEntry(entry);
+                                }
+                                return thrown;
+                            }
+                        }
+                        throw new Error(\\"illegal catch attempt\\");
+                    },
+                    delegateYield: function delegateYield(iterable, resultName, nextLoc) {
+                        this.delegate = {
+                            iterator: values(iterable),
+                            resultName: resultName,
+                            nextLoc: nextLoc
+                        };
+                        if (this.method === \\"next\\") {
+                            this.arg = undefined;
+                        }
+                        return ContinueSentinel;
+                    }
+                };
+            }(function() {
+                return this;
+            }() || Function(\\"return this\\")());
+        }).call(this, __webpack_require__(32)(module));
+    },
+    32: function(module, exports) {
+        module.exports = function(module) {
+            if (!module.webpackPolyfill) {
+                module.deprecate = function() {};
+                module.paths = [];
+                if (!module.children) module.children = [];
+                Object.defineProperty(module, \\"loaded\\", {
+                    enumerable: true,
+                    get: function get() {
+                        return module.l;
+                    }
+                });
+                Object.defineProperty(module, \\"id\\", {
+                    enumerable: true,
+                    get: function get() {
+                        return module.i;
+                    }
+                });
+                module.webpackPolyfill = 1;
+            }
+            return module;
+        };
+    },
+    33: function(module, exports, __webpack_require__) {},
+    34: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         __webpack_require__.r(__webpack_exports__);
         var runtime_esm = __webpack_require__(3);
+        var regenerator = __webpack_require__(15);
+        var regenerator_default = __webpack_require__.n(regenerator);
+        function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
+            try {
+                var info = gen[key](arg);
+                var value = info.value;
+            } catch (error) {
+                reject(error);
+                return;
+            }
+            if (info.done) {
+                resolve(value);
+            } else {
+                Promise.resolve(value).then(_next, _throw);
+            }
+        }
+        function _asyncToGenerator(fn) {
+            return function() {
+                var self = this, args = arguments;
+                return new Promise((function(resolve, reject) {
+                    var gen = fn.apply(self, args);
+                    function _next(value) {
+                        asyncGeneratorStep(gen, resolve, reject, _next, _throw, \\"next\\", value);
+                    }
+                    function _throw(err) {
+                        asyncGeneratorStep(gen, resolve, reject, _next, _throw, \\"throw\\", err);
+                    }
+                    _next(undefined);
+                }));
+            };
+        }
         var classCallCheck = __webpack_require__(0);
         var createClass = __webpack_require__(1);
         var possibleConstructorReturn = __webpack_require__(4);
@@ -14967,7 +16077,7 @@ object-assign
         var react = __webpack_require__(6);
         var react_default = __webpack_require__.n(react);
         var mini = __webpack_require__(12);
-        var index = __webpack_require__(29);
+        var index = __webpack_require__(33);
         var index_Index = function(_Component) {
             Object(inherits[\\"a\\"])(Index, _Component);
             function Index() {
@@ -14976,7 +16086,27 @@ object-assign
             }
             Object(createClass[\\"a\\"])(Index, [ {
                 key: \\"componentWillMount\\",
-                value: function componentWillMount() {}
+                value: function() {
+                    var _componentWillMount = _asyncToGenerator(regenerator_default.a.mark((function _callee() {
+                        return regenerator_default.a.wrap((function _callee$(_context) {
+                            while (1) {
+                                switch (_context.prev = _context.next) {
+                                  case 0:
+                                    _context.next = 2;
+                                    return Promise.resolve(1);
+
+                                  case 2:
+                                  case \\"end\\":
+                                    return _context.stop();
+                                }
+                            }
+                        }), _callee);
+                    })));
+                    function componentWillMount() {
+                        return _componentWillMount.apply(this, arguments);
+                    }
+                    return componentWillMount;
+                }()
             }, {
                 key: \\"componentDidMount\\",
                 value: function componentDidMount() {}
@@ -15006,7 +16136,7 @@ object-assign
         }(react[\\"Component\\"]);
         var inst = Page(Object(runtime_esm[\\"createPageConfig\\"])(index_Index, \\"pages/index/index\\"));
     }
-}, [ [ 31, 0, 1, 2 ] ] ]);
+}, [ [ 34, 0, 1, 2 ] ] ]);
 
 /** filePath: dist/pages/index/index.json **/
 {\\"navigationBarTitleText\\":\\"首页\\",\\"usingComponents\\":{\\"comp\\":\\"../../comp\\"}}
@@ -15197,12 +16327,12 @@ object-assign
         var MovableArea = \\"movable-area\\";
         var MovableView = \\"movable-view\\";
     },
-    16: function(module, __webpack_exports__, __webpack_require__) {
+    17: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         var _babel_runtime_helpers_esm_classCallCheck__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
         var _babel_runtime_helpers_esm_createClass__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(1);
         var _babel_runtime_helpers_esm_typeof__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(8);
-        var react_reconciler__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(17);
+        var react_reconciler__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(18);
         var react_reconciler__WEBPACK_IMPORTED_MODULE_3___default = __webpack_require__.n(react_reconciler__WEBPACK_IMPORTED_MODULE_3__);
         var scheduler__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(11);
         var scheduler__WEBPACK_IMPORTED_MODULE_4___default = __webpack_require__.n(scheduler__WEBPACK_IMPORTED_MODULE_4__);
@@ -15685,13 +16815,13 @@ object-assign
             __webpack_require__.d(__webpack_exports__, \\"window\\", (function() {
                 return window$1;
             }));
-            var _babel_runtime_helpers_esm_toConsumableArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(18);
-            var _babel_runtime_helpers_esm_set__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(19);
+            var _babel_runtime_helpers_esm_toConsumableArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(19);
+            var _babel_runtime_helpers_esm_set__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(20);
             var _babel_runtime_helpers_esm_possibleConstructorReturn__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(4);
             var _babel_runtime_helpers_esm_getPrototypeOf__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(2);
             var _babel_runtime_helpers_esm_assertThisInitialized__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(10);
             var _babel_runtime_helpers_esm_inherits__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(5);
-            var _babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(15);
+            var _babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(16);
             var _babel_runtime_helpers_esm_defineProperty__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(7);
             var _babel_runtime_helpers_esm_classCallCheck__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(0);
             var _babel_runtime_helpers_esm_createClass__WEBPACK_IMPORTED_MODULE_9__ = __webpack_require__(1);
@@ -18687,7 +19817,7 @@ object-assign
 }, function(module, exports, __webpack_require__) {
     \\"use strict\\";
     if (true) {
-        module.exports = __webpack_require__(22);
+        module.exports = __webpack_require__(23);
     } else {}
 }, function(module, __webpack_exports__, __webpack_require__) {
     \\"use strict\\";
@@ -18748,21 +19878,7 @@ object-assign
         }
         return self;
     }
-}, , , function(module, __webpack_exports__, __webpack_require__) {
-    \\"use strict\\";
-    __webpack_require__.d(__webpack_exports__, \\"a\\", (function() {
-        return _unsupportedIterableToArray;
-    }));
-    var _arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(9);
-    function _unsupportedIterableToArray(o, minLen) {
-        if (!o) return;
-        if (typeof o === \\"string\\") return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
-        var n = Object.prototype.toString.call(o).slice(8, -1);
-        if (n === \\"Object\\" && o.constructor) n = o.constructor.name;
-        if (n === \\"Map\\" || n === \\"Set\\") return Array.from(o);
-        if (n === \\"Arguments\\" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
-    }
-}, function(module, exports) {
+}, , , function(module, exports) {
     function _typeof(obj) {
         \\"@babel/helpers - typeof\\";
         if (typeof Symbol === \\"function\\" && typeof Symbol.iterator === \\"symbol\\") {
@@ -18778,6 +19894,20 @@ object-assign
     }
     module.exports = _typeof;
 }, function(module, __webpack_exports__, __webpack_require__) {
+    \\"use strict\\";
+    __webpack_require__.d(__webpack_exports__, \\"a\\", (function() {
+        return _unsupportedIterableToArray;
+    }));
+    var _arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(9);
+    function _unsupportedIterableToArray(o, minLen) {
+        if (!o) return;
+        if (typeof o === \\"string\\") return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
+        var n = Object.prototype.toString.call(o).slice(8, -1);
+        if (n === \\"Object\\" && o.constructor) n = o.constructor.name;
+        if (n === \\"Map\\" || n === \\"Set\\") return Array.from(o);
+        if (n === \\"Arguments\\" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
+    }
+}, , function(module, __webpack_exports__, __webpack_require__) {
     \\"use strict\\";
     __webpack_require__.d(__webpack_exports__, \\"a\\", (function() {
         return _slicedToArray;
@@ -18808,7 +19938,7 @@ object-assign
         }
         return _arr;
     }
-    var unsupportedIterableToArray = __webpack_require__(13);
+    var unsupportedIterableToArray = __webpack_require__(14);
     function _nonIterableRest() {
         throw new TypeError(\\"Invalid attempt to destructure non-iterable instance.\\\\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.\\");
     }
@@ -18827,7 +19957,7 @@ object-assign
     function _iterableToArray(iter) {
         if (typeof Symbol !== \\"undefined\\" && Symbol.iterator in Object(iter)) return Array.from(iter);
     }
-    var unsupportedIterableToArray = __webpack_require__(13);
+    var unsupportedIterableToArray = __webpack_require__(14);
     function _nonIterableSpread() {
         throw new TypeError(\\"Invalid attempt to spread non-iterable instance.\\\\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.\\");
     }
@@ -18888,8 +20018,8 @@ object-assign
     }
 }, , , function(module, exports, __webpack_require__) {
     \\"use strict\\";
-    var _typeof = __webpack_require__(14);
-    var l = __webpack_require__(23), n = \\"function\\" === typeof Symbol && Symbol.for, p = n ? Symbol.for(\\"react.element\\") : 60103, q = n ? Symbol.for(\\"react.portal\\") : 60106, r = n ? Symbol.for(\\"react.fragment\\") : 60107, t = n ? Symbol.for(\\"react.strict_mode\\") : 60108, u = n ? Symbol.for(\\"react.profiler\\") : 60114, v = n ? Symbol.for(\\"react.provider\\") : 60109, w = n ? Symbol.for(\\"react.context\\") : 60110, x = n ? Symbol.for(\\"react.forward_ref\\") : 60112, y = n ? Symbol.for(\\"react.suspense\\") : 60113, z = n ? Symbol.for(\\"react.memo\\") : 60115, A = n ? Symbol.for(\\"react.lazy\\") : 60116, B = \\"function\\" === typeof Symbol && Symbol.iterator;
+    var _typeof = __webpack_require__(13);
+    var l = __webpack_require__(24), n = \\"function\\" === typeof Symbol && Symbol.for, p = n ? Symbol.for(\\"react.element\\") : 60103, q = n ? Symbol.for(\\"react.portal\\") : 60106, r = n ? Symbol.for(\\"react.fragment\\") : 60107, t = n ? Symbol.for(\\"react.strict_mode\\") : 60108, u = n ? Symbol.for(\\"react.profiler\\") : 60114, v = n ? Symbol.for(\\"react.provider\\") : 60109, w = n ? Symbol.for(\\"react.context\\") : 60110, x = n ? Symbol.for(\\"react.forward_ref\\") : 60112, y = n ? Symbol.for(\\"react.suspense\\") : 60113, z = n ? Symbol.for(\\"react.memo\\") : 60115, A = n ? Symbol.for(\\"react.lazy\\") : 60116, B = \\"function\\" === typeof Symbol && Symbol.iterator;
     function C(a) {
         for (var b = \\"https://reactjs.org/docs/error-decoder.html?invariant=\\" + a, c = 1; c < arguments.length; c++) {
             b += \\"&args[]=\\" + encodeURIComponent(arguments[c]);

--- a/packages/taro-mini-runner/__tests__/__snapshots__/react.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/react.spec.ts.snap
@@ -16,21 +16,21 @@ require(\\"./taro\\");
     11: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         if (true) {
-            module.exports = __webpack_require__(27);
+            module.exports = __webpack_require__(28);
         } else {}
     },
-    17: function(module, exports, __webpack_require__) {
+    18: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         if (true) {
-            module.exports = __webpack_require__(25);
+            module.exports = __webpack_require__(26);
         } else {}
     },
-    24: function(module, exports, __webpack_require__) {},
-    25: function(module, exports, __webpack_require__) {
-        var _typeof = __webpack_require__(14);
+    25: function(module, exports, __webpack_require__) {},
+    26: function(module, exports, __webpack_require__) {
+        var _typeof = __webpack_require__(13);
         module.exports = function $$$reconciler($$$hostConfig) {
             \\"use strict\\";
-            var aa = __webpack_require__(26), ba = __webpack_require__(6), m = __webpack_require__(11);
+            var aa = __webpack_require__(27), ba = __webpack_require__(6), m = __webpack_require__(11);
             function n(a) {
                 for (var b = \\"https://reactjs.org/docs/error-decoder.html?invariant=\\" + a, c = 1; c < arguments.length; c++) {
                     b += \\"&args[]=\\" + encodeURIComponent(arguments[c]);
@@ -4017,7 +4017,7 @@ require(\\"./taro\\");
             return $$$renderer;
         };
     },
-    26: function(module, exports, __webpack_require__) {
+    27: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         var getOwnPropertySymbols = Object.getOwnPropertySymbols;
         var hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -4083,10 +4083,10 @@ require(\\"./taro\\");
             return to;
         };
     },
-    27: function(module, exports, __webpack_require__) {
+    28: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         (function(window) {
-            var _typeof = __webpack_require__(14);
+            var _typeof = __webpack_require__(13);
             Object.defineProperty(exports, \\"__esModule\\", {
                 value: !0
             });
@@ -4359,7 +4359,7 @@ require(\\"./taro\\");
             exports.unstable_Profiling = null;
         }).call(this, __webpack_require__(3)[\\"window\\"]);
     },
-    30: function(module, __webpack_exports__, __webpack_require__) {
+    35: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         __webpack_require__.r(__webpack_exports__);
         var runtime_esm = __webpack_require__(3);
@@ -4369,7 +4369,7 @@ require(\\"./taro\\");
         var getPrototypeOf = __webpack_require__(2);
         var inherits = __webpack_require__(5);
         var react = __webpack_require__(6);
-        var app = __webpack_require__(24);
+        var app = __webpack_require__(25);
         var app_App = function(_Component) {
             Object(inherits[\\"a\\"])(App, _Component);
             function App() {
@@ -4397,10 +4397,10 @@ require(\\"./taro\\");
             return App;
         }(react[\\"Component\\"]);
         var lib_src_app = app_App;
-        var react_esm = __webpack_require__(16);
+        var react_esm = __webpack_require__(17);
         var inst = App(Object(runtime_esm[\\"createReactApp\\"])(lib_src_app, react, react_esm[\\"a\\"]));
     }
-}, [ [ 30, 0, 1, 2 ] ] ]);
+}, [ [ 35, 0, 1, 2 ] ] ]);
 
 
 
@@ -5471,13 +5471,13 @@ object-assign
 
 /** filePath: dist/comp.js **/
 (wx[\\"webpackJsonp\\"] = wx[\\"webpackJsonp\\"] || []).push([ [ 5 ], {
-    28: function(module, __webpack_exports__, __webpack_require__) {
+    29: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         __webpack_require__.r(__webpack_exports__);
         var _tarojs_runtime__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(3);
         Component(Object(_tarojs_runtime__WEBPACK_IMPORTED_MODULE_0__[\\"createRecursiveComponentConfig\\"])());
     }
-}, [ [ 28, 0, 1, 2 ] ] ]);
+}, [ [ 29, 0, 1, 2 ] ] ]);
 
 /** filePath: dist/comp.json **/
 {\\"component\\":true,\\"usingComponents\\":{\\"comp\\":\\"./comp\\"}}
@@ -5488,11 +5488,556 @@ object-assign
 
 /** filePath: dist/pages/index/index.js **/
 (wx[\\"webpackJsonp\\"] = wx[\\"webpackJsonp\\"] || []).push([ [ 6 ], {
-    29: function(module, exports, __webpack_require__) {},
-    31: function(module, __webpack_exports__, __webpack_require__) {
+    15: function(module, exports, __webpack_require__) {
+        module.exports = __webpack_require__(30);
+    },
+    30: function(module, exports, __webpack_require__) {
+        var g = function() {
+            return this;
+        }() || Function(\\"return this\\")();
+        var hadRuntime = g.regeneratorRuntime && Object.getOwnPropertyNames(g).indexOf(\\"regeneratorRuntime\\") >= 0;
+        var oldRuntime = hadRuntime && g.regeneratorRuntime;
+        g.regeneratorRuntime = undefined;
+        module.exports = __webpack_require__(31);
+        if (hadRuntime) {
+            g.regeneratorRuntime = oldRuntime;
+        } else {
+            try {
+                delete g.regeneratorRuntime;
+            } catch (e) {
+                g.regeneratorRuntime = undefined;
+            }
+        }
+    },
+    31: function(module, exports, __webpack_require__) {
+        (function(module) {
+            var _typeof = __webpack_require__(13);
+            !function(global) {
+                \\"use strict\\";
+                var Op = Object.prototype;
+                var hasOwn = Op.hasOwnProperty;
+                var undefined;
+                var $Symbol = typeof Symbol === \\"function\\" ? Symbol : {};
+                var iteratorSymbol = $Symbol.iterator || \\"@@iterator\\";
+                var asyncIteratorSymbol = $Symbol.asyncIterator || \\"@@asyncIterator\\";
+                var toStringTagSymbol = $Symbol.toStringTag || \\"@@toStringTag\\";
+                var inModule = (false ? undefined : _typeof(module)) === \\"object\\";
+                var runtime = global.regeneratorRuntime;
+                if (runtime) {
+                    if (inModule) {
+                        module.exports = runtime;
+                    }
+                    return;
+                }
+                runtime = global.regeneratorRuntime = inModule ? module.exports : {};
+                function wrap(innerFn, outerFn, self, tryLocsList) {
+                    var protoGenerator = outerFn && outerFn.prototype instanceof Generator ? outerFn : Generator;
+                    var generator = Object.create(protoGenerator.prototype);
+                    var context = new Context(tryLocsList || []);
+                    generator._invoke = makeInvokeMethod(innerFn, self, context);
+                    return generator;
+                }
+                runtime.wrap = wrap;
+                function tryCatch(fn, obj, arg) {
+                    try {
+                        return {
+                            type: \\"normal\\",
+                            arg: fn.call(obj, arg)
+                        };
+                    } catch (err) {
+                        return {
+                            type: \\"throw\\",
+                            arg: err
+                        };
+                    }
+                }
+                var GenStateSuspendedStart = \\"suspendedStart\\";
+                var GenStateSuspendedYield = \\"suspendedYield\\";
+                var GenStateExecuting = \\"executing\\";
+                var GenStateCompleted = \\"completed\\";
+                var ContinueSentinel = {};
+                function Generator() {}
+                function GeneratorFunction() {}
+                function GeneratorFunctionPrototype() {}
+                var IteratorPrototype = {};
+                IteratorPrototype[iteratorSymbol] = function() {
+                    return this;
+                };
+                var getProto = Object.getPrototypeOf;
+                var NativeIteratorPrototype = getProto && getProto(getProto(values([])));
+                if (NativeIteratorPrototype && NativeIteratorPrototype !== Op && hasOwn.call(NativeIteratorPrototype, iteratorSymbol)) {
+                    IteratorPrototype = NativeIteratorPrototype;
+                }
+                var Gp = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(IteratorPrototype);
+                GeneratorFunction.prototype = Gp.constructor = GeneratorFunctionPrototype;
+                GeneratorFunctionPrototype.constructor = GeneratorFunction;
+                GeneratorFunctionPrototype[toStringTagSymbol] = GeneratorFunction.displayName = \\"GeneratorFunction\\";
+                function defineIteratorMethods(prototype) {
+                    [ \\"next\\", \\"throw\\", \\"return\\" ].forEach((function(method) {
+                        prototype[method] = function(arg) {
+                            return this._invoke(method, arg);
+                        };
+                    }));
+                }
+                runtime.isGeneratorFunction = function(genFun) {
+                    var ctor = typeof genFun === \\"function\\" && genFun.constructor;
+                    return ctor ? ctor === GeneratorFunction || (ctor.displayName || ctor.name) === \\"GeneratorFunction\\" : false;
+                };
+                runtime.mark = function(genFun) {
+                    if (Object.setPrototypeOf) {
+                        Object.setPrototypeOf(genFun, GeneratorFunctionPrototype);
+                    } else {
+                        genFun.__proto__ = GeneratorFunctionPrototype;
+                        if (!(toStringTagSymbol in genFun)) {
+                            genFun[toStringTagSymbol] = \\"GeneratorFunction\\";
+                        }
+                    }
+                    genFun.prototype = Object.create(Gp);
+                    return genFun;
+                };
+                runtime.awrap = function(arg) {
+                    return {
+                        __await: arg
+                    };
+                };
+                function AsyncIterator(generator) {
+                    function invoke(method, arg, resolve, reject) {
+                        var record = tryCatch(generator[method], generator, arg);
+                        if (record.type === \\"throw\\") {
+                            reject(record.arg);
+                        } else {
+                            var result = record.arg;
+                            var value = result.value;
+                            if (value && _typeof(value) === \\"object\\" && hasOwn.call(value, \\"__await\\")) {
+                                return Promise.resolve(value.__await).then((function(value) {
+                                    invoke(\\"next\\", value, resolve, reject);
+                                }), (function(err) {
+                                    invoke(\\"throw\\", err, resolve, reject);
+                                }));
+                            }
+                            return Promise.resolve(value).then((function(unwrapped) {
+                                result.value = unwrapped;
+                                resolve(result);
+                            }), reject);
+                        }
+                    }
+                    var previousPromise;
+                    function enqueue(method, arg) {
+                        function callInvokeWithMethodAndArg() {
+                            return new Promise((function(resolve, reject) {
+                                invoke(method, arg, resolve, reject);
+                            }));
+                        }
+                        return previousPromise = previousPromise ? previousPromise.then(callInvokeWithMethodAndArg, callInvokeWithMethodAndArg) : callInvokeWithMethodAndArg();
+                    }
+                    this._invoke = enqueue;
+                }
+                defineIteratorMethods(AsyncIterator.prototype);
+                AsyncIterator.prototype[asyncIteratorSymbol] = function() {
+                    return this;
+                };
+                runtime.AsyncIterator = AsyncIterator;
+                runtime.async = function(innerFn, outerFn, self, tryLocsList) {
+                    var iter = new AsyncIterator(wrap(innerFn, outerFn, self, tryLocsList));
+                    return runtime.isGeneratorFunction(outerFn) ? iter : iter.next().then((function(result) {
+                        return result.done ? result.value : iter.next();
+                    }));
+                };
+                function makeInvokeMethod(innerFn, self, context) {
+                    var state = GenStateSuspendedStart;
+                    return function invoke(method, arg) {
+                        if (state === GenStateExecuting) {
+                            throw new Error(\\"Generator is already running\\");
+                        }
+                        if (state === GenStateCompleted) {
+                            if (method === \\"throw\\") {
+                                throw arg;
+                            }
+                            return doneResult();
+                        }
+                        context.method = method;
+                        context.arg = arg;
+                        while (true) {
+                            var delegate = context.delegate;
+                            if (delegate) {
+                                var delegateResult = maybeInvokeDelegate(delegate, context);
+                                if (delegateResult) {
+                                    if (delegateResult === ContinueSentinel) continue;
+                                    return delegateResult;
+                                }
+                            }
+                            if (context.method === \\"next\\") {
+                                context.sent = context._sent = context.arg;
+                            } else if (context.method === \\"throw\\") {
+                                if (state === GenStateSuspendedStart) {
+                                    state = GenStateCompleted;
+                                    throw context.arg;
+                                }
+                                context.dispatchException(context.arg);
+                            } else if (context.method === \\"return\\") {
+                                context.abrupt(\\"return\\", context.arg);
+                            }
+                            state = GenStateExecuting;
+                            var record = tryCatch(innerFn, self, context);
+                            if (record.type === \\"normal\\") {
+                                state = context.done ? GenStateCompleted : GenStateSuspendedYield;
+                                if (record.arg === ContinueSentinel) {
+                                    continue;
+                                }
+                                return {
+                                    value: record.arg,
+                                    done: context.done
+                                };
+                            } else if (record.type === \\"throw\\") {
+                                state = GenStateCompleted;
+                                context.method = \\"throw\\";
+                                context.arg = record.arg;
+                            }
+                        }
+                    };
+                }
+                function maybeInvokeDelegate(delegate, context) {
+                    var method = delegate.iterator[context.method];
+                    if (method === undefined) {
+                        context.delegate = null;
+                        if (context.method === \\"throw\\") {
+                            if (delegate.iterator.return) {
+                                context.method = \\"return\\";
+                                context.arg = undefined;
+                                maybeInvokeDelegate(delegate, context);
+                                if (context.method === \\"throw\\") {
+                                    return ContinueSentinel;
+                                }
+                            }
+                            context.method = \\"throw\\";
+                            context.arg = new TypeError(\\"The iterator does not provide a 'throw' method\\");
+                        }
+                        return ContinueSentinel;
+                    }
+                    var record = tryCatch(method, delegate.iterator, context.arg);
+                    if (record.type === \\"throw\\") {
+                        context.method = \\"throw\\";
+                        context.arg = record.arg;
+                        context.delegate = null;
+                        return ContinueSentinel;
+                    }
+                    var info = record.arg;
+                    if (!info) {
+                        context.method = \\"throw\\";
+                        context.arg = new TypeError(\\"iterator result is not an object\\");
+                        context.delegate = null;
+                        return ContinueSentinel;
+                    }
+                    if (info.done) {
+                        context[delegate.resultName] = info.value;
+                        context.next = delegate.nextLoc;
+                        if (context.method !== \\"return\\") {
+                            context.method = \\"next\\";
+                            context.arg = undefined;
+                        }
+                    } else {
+                        return info;
+                    }
+                    context.delegate = null;
+                    return ContinueSentinel;
+                }
+                defineIteratorMethods(Gp);
+                Gp[toStringTagSymbol] = \\"Generator\\";
+                Gp[iteratorSymbol] = function() {
+                    return this;
+                };
+                Gp.toString = function() {
+                    return \\"[object Generator]\\";
+                };
+                function pushTryEntry(locs) {
+                    var entry = {
+                        tryLoc: locs[0]
+                    };
+                    if (1 in locs) {
+                        entry.catchLoc = locs[1];
+                    }
+                    if (2 in locs) {
+                        entry.finallyLoc = locs[2];
+                        entry.afterLoc = locs[3];
+                    }
+                    this.tryEntries.push(entry);
+                }
+                function resetTryEntry(entry) {
+                    var record = entry.completion || {};
+                    record.type = \\"normal\\";
+                    delete record.arg;
+                    entry.completion = record;
+                }
+                function Context(tryLocsList) {
+                    this.tryEntries = [ {
+                        tryLoc: \\"root\\"
+                    } ];
+                    tryLocsList.forEach(pushTryEntry, this);
+                    this.reset(true);
+                }
+                runtime.keys = function(object) {
+                    var keys = [];
+                    for (var key in object) {
+                        keys.push(key);
+                    }
+                    keys.reverse();
+                    return function next() {
+                        while (keys.length) {
+                            var key = keys.pop();
+                            if (key in object) {
+                                next.value = key;
+                                next.done = false;
+                                return next;
+                            }
+                        }
+                        next.done = true;
+                        return next;
+                    };
+                };
+                function values(iterable) {
+                    if (iterable) {
+                        var iteratorMethod = iterable[iteratorSymbol];
+                        if (iteratorMethod) {
+                            return iteratorMethod.call(iterable);
+                        }
+                        if (typeof iterable.next === \\"function\\") {
+                            return iterable;
+                        }
+                        if (!isNaN(iterable.length)) {
+                            var i = -1, next = function next() {
+                                while (++i < iterable.length) {
+                                    if (hasOwn.call(iterable, i)) {
+                                        next.value = iterable[i];
+                                        next.done = false;
+                                        return next;
+                                    }
+                                }
+                                next.value = undefined;
+                                next.done = true;
+                                return next;
+                            };
+                            return next.next = next;
+                        }
+                    }
+                    return {
+                        next: doneResult
+                    };
+                }
+                runtime.values = values;
+                function doneResult() {
+                    return {
+                        value: undefined,
+                        done: true
+                    };
+                }
+                Context.prototype = {
+                    constructor: Context,
+                    reset: function reset(skipTempReset) {
+                        this.prev = 0;
+                        this.next = 0;
+                        this.sent = this._sent = undefined;
+                        this.done = false;
+                        this.delegate = null;
+                        this.method = \\"next\\";
+                        this.arg = undefined;
+                        this.tryEntries.forEach(resetTryEntry);
+                        if (!skipTempReset) {
+                            for (var name in this) {
+                                if (name.charAt(0) === \\"t\\" && hasOwn.call(this, name) && !isNaN(+name.slice(1))) {
+                                    this[name] = undefined;
+                                }
+                            }
+                        }
+                    },
+                    stop: function stop() {
+                        this.done = true;
+                        var rootEntry = this.tryEntries[0];
+                        var rootRecord = rootEntry.completion;
+                        if (rootRecord.type === \\"throw\\") {
+                            throw rootRecord.arg;
+                        }
+                        return this.rval;
+                    },
+                    dispatchException: function dispatchException(exception) {
+                        if (this.done) {
+                            throw exception;
+                        }
+                        var context = this;
+                        function handle(loc, caught) {
+                            record.type = \\"throw\\";
+                            record.arg = exception;
+                            context.next = loc;
+                            if (caught) {
+                                context.method = \\"next\\";
+                                context.arg = undefined;
+                            }
+                            return !!caught;
+                        }
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            var record = entry.completion;
+                            if (entry.tryLoc === \\"root\\") {
+                                return handle(\\"end\\");
+                            }
+                            if (entry.tryLoc <= this.prev) {
+                                var hasCatch = hasOwn.call(entry, \\"catchLoc\\");
+                                var hasFinally = hasOwn.call(entry, \\"finallyLoc\\");
+                                if (hasCatch && hasFinally) {
+                                    if (this.prev < entry.catchLoc) {
+                                        return handle(entry.catchLoc, true);
+                                    } else if (this.prev < entry.finallyLoc) {
+                                        return handle(entry.finallyLoc);
+                                    }
+                                } else if (hasCatch) {
+                                    if (this.prev < entry.catchLoc) {
+                                        return handle(entry.catchLoc, true);
+                                    }
+                                } else if (hasFinally) {
+                                    if (this.prev < entry.finallyLoc) {
+                                        return handle(entry.finallyLoc);
+                                    }
+                                } else {
+                                    throw new Error(\\"try statement without catch or finally\\");
+                                }
+                            }
+                        }
+                    },
+                    abrupt: function abrupt(type, arg) {
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            if (entry.tryLoc <= this.prev && hasOwn.call(entry, \\"finallyLoc\\") && this.prev < entry.finallyLoc) {
+                                var finallyEntry = entry;
+                                break;
+                            }
+                        }
+                        if (finallyEntry && (type === \\"break\\" || type === \\"continue\\") && finallyEntry.tryLoc <= arg && arg <= finallyEntry.finallyLoc) {
+                            finallyEntry = null;
+                        }
+                        var record = finallyEntry ? finallyEntry.completion : {};
+                        record.type = type;
+                        record.arg = arg;
+                        if (finallyEntry) {
+                            this.method = \\"next\\";
+                            this.next = finallyEntry.finallyLoc;
+                            return ContinueSentinel;
+                        }
+                        return this.complete(record);
+                    },
+                    complete: function complete(record, afterLoc) {
+                        if (record.type === \\"throw\\") {
+                            throw record.arg;
+                        }
+                        if (record.type === \\"break\\" || record.type === \\"continue\\") {
+                            this.next = record.arg;
+                        } else if (record.type === \\"return\\") {
+                            this.rval = this.arg = record.arg;
+                            this.method = \\"return\\";
+                            this.next = \\"end\\";
+                        } else if (record.type === \\"normal\\" && afterLoc) {
+                            this.next = afterLoc;
+                        }
+                        return ContinueSentinel;
+                    },
+                    finish: function finish(finallyLoc) {
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            if (entry.finallyLoc === finallyLoc) {
+                                this.complete(entry.completion, entry.afterLoc);
+                                resetTryEntry(entry);
+                                return ContinueSentinel;
+                            }
+                        }
+                    },
+                    catch: function _catch(tryLoc) {
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            if (entry.tryLoc === tryLoc) {
+                                var record = entry.completion;
+                                if (record.type === \\"throw\\") {
+                                    var thrown = record.arg;
+                                    resetTryEntry(entry);
+                                }
+                                return thrown;
+                            }
+                        }
+                        throw new Error(\\"illegal catch attempt\\");
+                    },
+                    delegateYield: function delegateYield(iterable, resultName, nextLoc) {
+                        this.delegate = {
+                            iterator: values(iterable),
+                            resultName: resultName,
+                            nextLoc: nextLoc
+                        };
+                        if (this.method === \\"next\\") {
+                            this.arg = undefined;
+                        }
+                        return ContinueSentinel;
+                    }
+                };
+            }(function() {
+                return this;
+            }() || Function(\\"return this\\")());
+        }).call(this, __webpack_require__(32)(module));
+    },
+    32: function(module, exports) {
+        module.exports = function(module) {
+            if (!module.webpackPolyfill) {
+                module.deprecate = function() {};
+                module.paths = [];
+                if (!module.children) module.children = [];
+                Object.defineProperty(module, \\"loaded\\", {
+                    enumerable: true,
+                    get: function get() {
+                        return module.l;
+                    }
+                });
+                Object.defineProperty(module, \\"id\\", {
+                    enumerable: true,
+                    get: function get() {
+                        return module.i;
+                    }
+                });
+                module.webpackPolyfill = 1;
+            }
+            return module;
+        };
+    },
+    33: function(module, exports, __webpack_require__) {},
+    34: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         __webpack_require__.r(__webpack_exports__);
         var runtime_esm = __webpack_require__(3);
+        var regenerator = __webpack_require__(15);
+        var regenerator_default = __webpack_require__.n(regenerator);
+        function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
+            try {
+                var info = gen[key](arg);
+                var value = info.value;
+            } catch (error) {
+                reject(error);
+                return;
+            }
+            if (info.done) {
+                resolve(value);
+            } else {
+                Promise.resolve(value).then(_next, _throw);
+            }
+        }
+        function _asyncToGenerator(fn) {
+            return function() {
+                var self = this, args = arguments;
+                return new Promise((function(resolve, reject) {
+                    var gen = fn.apply(self, args);
+                    function _next(value) {
+                        asyncGeneratorStep(gen, resolve, reject, _next, _throw, \\"next\\", value);
+                    }
+                    function _throw(err) {
+                        asyncGeneratorStep(gen, resolve, reject, _next, _throw, \\"throw\\", err);
+                    }
+                    _next(undefined);
+                }));
+            };
+        }
         var classCallCheck = __webpack_require__(0);
         var createClass = __webpack_require__(1);
         var possibleConstructorReturn = __webpack_require__(4);
@@ -5501,7 +6046,7 @@ object-assign
         var react = __webpack_require__(6);
         var react_default = __webpack_require__.n(react);
         var mini = __webpack_require__(12);
-        var index = __webpack_require__(29);
+        var index = __webpack_require__(33);
         var index_Index = function(_Component) {
             Object(inherits[\\"a\\"])(Index, _Component);
             function Index() {
@@ -5510,7 +6055,27 @@ object-assign
             }
             Object(createClass[\\"a\\"])(Index, [ {
                 key: \\"componentWillMount\\",
-                value: function componentWillMount() {}
+                value: function() {
+                    var _componentWillMount = _asyncToGenerator(regenerator_default.a.mark((function _callee() {
+                        return regenerator_default.a.wrap((function _callee$(_context) {
+                            while (1) {
+                                switch (_context.prev = _context.next) {
+                                  case 0:
+                                    _context.next = 2;
+                                    return Promise.resolve(1);
+
+                                  case 2:
+                                  case \\"end\\":
+                                    return _context.stop();
+                                }
+                            }
+                        }), _callee);
+                    })));
+                    function componentWillMount() {
+                        return _componentWillMount.apply(this, arguments);
+                    }
+                    return componentWillMount;
+                }()
             }, {
                 key: \\"componentDidMount\\",
                 value: function componentDidMount() {}
@@ -5540,7 +6105,7 @@ object-assign
         }(react[\\"Component\\"]);
         var inst = Page(Object(runtime_esm[\\"createPageConfig\\"])(index_Index, \\"pages/index/index\\"));
     }
-}, [ [ 31, 0, 1, 2 ] ] ]);
+}, [ [ 34, 0, 1, 2 ] ] ]);
 
 /** filePath: dist/pages/index/index.json **/
 {\\"navigationBarTitleText\\":\\"首页\\",\\"usingComponents\\":{\\"comp\\":\\"../../comp\\"}}
@@ -5731,12 +6296,12 @@ object-assign
         var MovableArea = \\"movable-area\\";
         var MovableView = \\"movable-view\\";
     },
-    16: function(module, __webpack_exports__, __webpack_require__) {
+    17: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         var _babel_runtime_helpers_esm_classCallCheck__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
         var _babel_runtime_helpers_esm_createClass__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(1);
         var _babel_runtime_helpers_esm_typeof__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(8);
-        var react_reconciler__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(17);
+        var react_reconciler__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(18);
         var react_reconciler__WEBPACK_IMPORTED_MODULE_3___default = __webpack_require__.n(react_reconciler__WEBPACK_IMPORTED_MODULE_3__);
         var scheduler__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(11);
         var scheduler__WEBPACK_IMPORTED_MODULE_4___default = __webpack_require__.n(scheduler__WEBPACK_IMPORTED_MODULE_4__);
@@ -6219,13 +6784,13 @@ object-assign
             __webpack_require__.d(__webpack_exports__, \\"window\\", (function() {
                 return window$1;
             }));
-            var _babel_runtime_helpers_esm_toConsumableArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(18);
-            var _babel_runtime_helpers_esm_set__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(19);
+            var _babel_runtime_helpers_esm_toConsumableArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(19);
+            var _babel_runtime_helpers_esm_set__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(20);
             var _babel_runtime_helpers_esm_possibleConstructorReturn__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(4);
             var _babel_runtime_helpers_esm_getPrototypeOf__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(2);
             var _babel_runtime_helpers_esm_assertThisInitialized__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(10);
             var _babel_runtime_helpers_esm_inherits__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(5);
-            var _babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(15);
+            var _babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(16);
             var _babel_runtime_helpers_esm_defineProperty__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(7);
             var _babel_runtime_helpers_esm_classCallCheck__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(0);
             var _babel_runtime_helpers_esm_createClass__WEBPACK_IMPORTED_MODULE_9__ = __webpack_require__(1);
@@ -9217,7 +9782,7 @@ object-assign
 }, function(module, exports, __webpack_require__) {
     \\"use strict\\";
     if (true) {
-        module.exports = __webpack_require__(22);
+        module.exports = __webpack_require__(23);
     } else {}
 }, function(module, __webpack_exports__, __webpack_require__) {
     \\"use strict\\";
@@ -9278,21 +9843,7 @@ object-assign
         }
         return self;
     }
-}, , , function(module, __webpack_exports__, __webpack_require__) {
-    \\"use strict\\";
-    __webpack_require__.d(__webpack_exports__, \\"a\\", (function() {
-        return _unsupportedIterableToArray;
-    }));
-    var _arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(9);
-    function _unsupportedIterableToArray(o, minLen) {
-        if (!o) return;
-        if (typeof o === \\"string\\") return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
-        var n = Object.prototype.toString.call(o).slice(8, -1);
-        if (n === \\"Object\\" && o.constructor) n = o.constructor.name;
-        if (n === \\"Map\\" || n === \\"Set\\") return Array.from(o);
-        if (n === \\"Arguments\\" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
-    }
-}, function(module, exports) {
+}, , , function(module, exports) {
     function _typeof(obj) {
         \\"@babel/helpers - typeof\\";
         if (typeof Symbol === \\"function\\" && typeof Symbol.iterator === \\"symbol\\") {
@@ -9308,6 +9859,20 @@ object-assign
     }
     module.exports = _typeof;
 }, function(module, __webpack_exports__, __webpack_require__) {
+    \\"use strict\\";
+    __webpack_require__.d(__webpack_exports__, \\"a\\", (function() {
+        return _unsupportedIterableToArray;
+    }));
+    var _arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(9);
+    function _unsupportedIterableToArray(o, minLen) {
+        if (!o) return;
+        if (typeof o === \\"string\\") return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
+        var n = Object.prototype.toString.call(o).slice(8, -1);
+        if (n === \\"Object\\" && o.constructor) n = o.constructor.name;
+        if (n === \\"Map\\" || n === \\"Set\\") return Array.from(o);
+        if (n === \\"Arguments\\" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
+    }
+}, , function(module, __webpack_exports__, __webpack_require__) {
     \\"use strict\\";
     __webpack_require__.d(__webpack_exports__, \\"a\\", (function() {
         return _slicedToArray;
@@ -9338,7 +9903,7 @@ object-assign
         }
         return _arr;
     }
-    var unsupportedIterableToArray = __webpack_require__(13);
+    var unsupportedIterableToArray = __webpack_require__(14);
     function _nonIterableRest() {
         throw new TypeError(\\"Invalid attempt to destructure non-iterable instance.\\\\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.\\");
     }
@@ -9357,7 +9922,7 @@ object-assign
     function _iterableToArray(iter) {
         if (typeof Symbol !== \\"undefined\\" && Symbol.iterator in Object(iter)) return Array.from(iter);
     }
-    var unsupportedIterableToArray = __webpack_require__(13);
+    var unsupportedIterableToArray = __webpack_require__(14);
     function _nonIterableSpread() {
         throw new TypeError(\\"Invalid attempt to spread non-iterable instance.\\\\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.\\");
     }
@@ -9418,8 +9983,8 @@ object-assign
     }
 }, , , function(module, exports, __webpack_require__) {
     \\"use strict\\";
-    var _typeof = __webpack_require__(14);
-    var l = __webpack_require__(23), n = \\"function\\" === typeof Symbol && Symbol.for, p = n ? Symbol.for(\\"react.element\\") : 60103, q = n ? Symbol.for(\\"react.portal\\") : 60106, r = n ? Symbol.for(\\"react.fragment\\") : 60107, t = n ? Symbol.for(\\"react.strict_mode\\") : 60108, u = n ? Symbol.for(\\"react.profiler\\") : 60114, v = n ? Symbol.for(\\"react.provider\\") : 60109, w = n ? Symbol.for(\\"react.context\\") : 60110, x = n ? Symbol.for(\\"react.forward_ref\\") : 60112, y = n ? Symbol.for(\\"react.suspense\\") : 60113, z = n ? Symbol.for(\\"react.memo\\") : 60115, A = n ? Symbol.for(\\"react.lazy\\") : 60116, B = \\"function\\" === typeof Symbol && Symbol.iterator;
+    var _typeof = __webpack_require__(13);
+    var l = __webpack_require__(24), n = \\"function\\" === typeof Symbol && Symbol.for, p = n ? Symbol.for(\\"react.element\\") : 60103, q = n ? Symbol.for(\\"react.portal\\") : 60106, r = n ? Symbol.for(\\"react.fragment\\") : 60107, t = n ? Symbol.for(\\"react.strict_mode\\") : 60108, u = n ? Symbol.for(\\"react.profiler\\") : 60114, v = n ? Symbol.for(\\"react.provider\\") : 60109, w = n ? Symbol.for(\\"react.context\\") : 60110, x = n ? Symbol.for(\\"react.forward_ref\\") : 60112, y = n ? Symbol.for(\\"react.suspense\\") : 60113, z = n ? Symbol.for(\\"react.memo\\") : 60115, A = n ? Symbol.for(\\"react.lazy\\") : 60116, B = \\"function\\" === typeof Symbol && Symbol.iterator;
     function C(a) {
         for (var b = \\"https://reactjs.org/docs/error-decoder.html?invariant=\\" + a, c = 1; c < arguments.length; c++) {
             b += \\"&args[]=\\" + encodeURIComponent(arguments[c]);

--- a/packages/taro-mini-runner/__tests__/__snapshots__/swan.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/swan.spec.ts.snap
@@ -16,21 +16,21 @@ require(\\"./taro\\");
     11: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         if (true) {
-            module.exports = __webpack_require__(27);
+            module.exports = __webpack_require__(28);
         } else {}
     },
-    17: function(module, exports, __webpack_require__) {
+    18: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         if (true) {
-            module.exports = __webpack_require__(25);
+            module.exports = __webpack_require__(26);
         } else {}
     },
-    24: function(module, exports, __webpack_require__) {},
-    25: function(module, exports, __webpack_require__) {
-        var _typeof = __webpack_require__(14);
+    25: function(module, exports, __webpack_require__) {},
+    26: function(module, exports, __webpack_require__) {
+        var _typeof = __webpack_require__(13);
         module.exports = function $$$reconciler($$$hostConfig) {
             \\"use strict\\";
-            var aa = __webpack_require__(26), ba = __webpack_require__(6), m = __webpack_require__(11);
+            var aa = __webpack_require__(27), ba = __webpack_require__(6), m = __webpack_require__(11);
             function n(a) {
                 for (var b = \\"https://reactjs.org/docs/error-decoder.html?invariant=\\" + a, c = 1; c < arguments.length; c++) {
                     b += \\"&args[]=\\" + encodeURIComponent(arguments[c]);
@@ -4017,7 +4017,7 @@ require(\\"./taro\\");
             return $$$renderer;
         };
     },
-    26: function(module, exports, __webpack_require__) {
+    27: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         var getOwnPropertySymbols = Object.getOwnPropertySymbols;
         var hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -4083,10 +4083,10 @@ require(\\"./taro\\");
             return to;
         };
     },
-    27: function(module, exports, __webpack_require__) {
+    28: function(module, exports, __webpack_require__) {
         \\"use strict\\";
         (function(window) {
-            var _typeof = __webpack_require__(14);
+            var _typeof = __webpack_require__(13);
             Object.defineProperty(exports, \\"__esModule\\", {
                 value: !0
             });
@@ -4359,7 +4359,7 @@ require(\\"./taro\\");
             exports.unstable_Profiling = null;
         }).call(this, __webpack_require__(3)[\\"window\\"]);
     },
-    30: function(module, __webpack_exports__, __webpack_require__) {
+    35: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         __webpack_require__.r(__webpack_exports__);
         var runtime_esm = __webpack_require__(3);
@@ -4369,7 +4369,7 @@ require(\\"./taro\\");
         var getPrototypeOf = __webpack_require__(2);
         var inherits = __webpack_require__(5);
         var react = __webpack_require__(6);
-        var app = __webpack_require__(24);
+        var app = __webpack_require__(25);
         var app_App = function(_Component) {
             Object(inherits[\\"a\\"])(App, _Component);
             function App() {
@@ -4397,10 +4397,10 @@ require(\\"./taro\\");
             return App;
         }(react[\\"Component\\"]);
         var lib_src_app = app_App;
-        var react_esm = __webpack_require__(16);
+        var react_esm = __webpack_require__(17);
         var inst = App(Object(runtime_esm[\\"createReactApp\\"])(lib_src_app, react, react_esm[\\"a\\"]));
     }
-}, [ [ 30, 0, 1, 2 ] ] ]);
+}, [ [ 35, 0, 1, 2 ] ] ]);
 
 
 
@@ -5471,13 +5471,13 @@ object-assign
 
 /** filePath: dist/comp.js **/
 (wx[\\"webpackJsonp\\"] = wx[\\"webpackJsonp\\"] || []).push([ [ 5 ], {
-    28: function(module, __webpack_exports__, __webpack_require__) {
+    29: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         __webpack_require__.r(__webpack_exports__);
         var _tarojs_runtime__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(3);
         Component(Object(_tarojs_runtime__WEBPACK_IMPORTED_MODULE_0__[\\"createRecursiveComponentConfig\\"])());
     }
-}, [ [ 28, 0, 1, 2 ] ] ]);
+}, [ [ 29, 0, 1, 2 ] ] ]);
 
 /** filePath: dist/comp.json **/
 {\\"component\\":true,\\"usingComponents\\":{\\"comp\\":\\"./comp\\"}}
@@ -5488,11 +5488,556 @@ object-assign
 
 /** filePath: dist/pages/index/index.js **/
 (wx[\\"webpackJsonp\\"] = wx[\\"webpackJsonp\\"] || []).push([ [ 6 ], {
-    29: function(module, exports, __webpack_require__) {},
-    31: function(module, __webpack_exports__, __webpack_require__) {
+    15: function(module, exports, __webpack_require__) {
+        module.exports = __webpack_require__(30);
+    },
+    30: function(module, exports, __webpack_require__) {
+        var g = function() {
+            return this;
+        }() || Function(\\"return this\\")();
+        var hadRuntime = g.regeneratorRuntime && Object.getOwnPropertyNames(g).indexOf(\\"regeneratorRuntime\\") >= 0;
+        var oldRuntime = hadRuntime && g.regeneratorRuntime;
+        g.regeneratorRuntime = undefined;
+        module.exports = __webpack_require__(31);
+        if (hadRuntime) {
+            g.regeneratorRuntime = oldRuntime;
+        } else {
+            try {
+                delete g.regeneratorRuntime;
+            } catch (e) {
+                g.regeneratorRuntime = undefined;
+            }
+        }
+    },
+    31: function(module, exports, __webpack_require__) {
+        (function(module) {
+            var _typeof = __webpack_require__(13);
+            !function(global) {
+                \\"use strict\\";
+                var Op = Object.prototype;
+                var hasOwn = Op.hasOwnProperty;
+                var undefined;
+                var $Symbol = typeof Symbol === \\"function\\" ? Symbol : {};
+                var iteratorSymbol = $Symbol.iterator || \\"@@iterator\\";
+                var asyncIteratorSymbol = $Symbol.asyncIterator || \\"@@asyncIterator\\";
+                var toStringTagSymbol = $Symbol.toStringTag || \\"@@toStringTag\\";
+                var inModule = (false ? undefined : _typeof(module)) === \\"object\\";
+                var runtime = global.regeneratorRuntime;
+                if (runtime) {
+                    if (inModule) {
+                        module.exports = runtime;
+                    }
+                    return;
+                }
+                runtime = global.regeneratorRuntime = inModule ? module.exports : {};
+                function wrap(innerFn, outerFn, self, tryLocsList) {
+                    var protoGenerator = outerFn && outerFn.prototype instanceof Generator ? outerFn : Generator;
+                    var generator = Object.create(protoGenerator.prototype);
+                    var context = new Context(tryLocsList || []);
+                    generator._invoke = makeInvokeMethod(innerFn, self, context);
+                    return generator;
+                }
+                runtime.wrap = wrap;
+                function tryCatch(fn, obj, arg) {
+                    try {
+                        return {
+                            type: \\"normal\\",
+                            arg: fn.call(obj, arg)
+                        };
+                    } catch (err) {
+                        return {
+                            type: \\"throw\\",
+                            arg: err
+                        };
+                    }
+                }
+                var GenStateSuspendedStart = \\"suspendedStart\\";
+                var GenStateSuspendedYield = \\"suspendedYield\\";
+                var GenStateExecuting = \\"executing\\";
+                var GenStateCompleted = \\"completed\\";
+                var ContinueSentinel = {};
+                function Generator() {}
+                function GeneratorFunction() {}
+                function GeneratorFunctionPrototype() {}
+                var IteratorPrototype = {};
+                IteratorPrototype[iteratorSymbol] = function() {
+                    return this;
+                };
+                var getProto = Object.getPrototypeOf;
+                var NativeIteratorPrototype = getProto && getProto(getProto(values([])));
+                if (NativeIteratorPrototype && NativeIteratorPrototype !== Op && hasOwn.call(NativeIteratorPrototype, iteratorSymbol)) {
+                    IteratorPrototype = NativeIteratorPrototype;
+                }
+                var Gp = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(IteratorPrototype);
+                GeneratorFunction.prototype = Gp.constructor = GeneratorFunctionPrototype;
+                GeneratorFunctionPrototype.constructor = GeneratorFunction;
+                GeneratorFunctionPrototype[toStringTagSymbol] = GeneratorFunction.displayName = \\"GeneratorFunction\\";
+                function defineIteratorMethods(prototype) {
+                    [ \\"next\\", \\"throw\\", \\"return\\" ].forEach((function(method) {
+                        prototype[method] = function(arg) {
+                            return this._invoke(method, arg);
+                        };
+                    }));
+                }
+                runtime.isGeneratorFunction = function(genFun) {
+                    var ctor = typeof genFun === \\"function\\" && genFun.constructor;
+                    return ctor ? ctor === GeneratorFunction || (ctor.displayName || ctor.name) === \\"GeneratorFunction\\" : false;
+                };
+                runtime.mark = function(genFun) {
+                    if (Object.setPrototypeOf) {
+                        Object.setPrototypeOf(genFun, GeneratorFunctionPrototype);
+                    } else {
+                        genFun.__proto__ = GeneratorFunctionPrototype;
+                        if (!(toStringTagSymbol in genFun)) {
+                            genFun[toStringTagSymbol] = \\"GeneratorFunction\\";
+                        }
+                    }
+                    genFun.prototype = Object.create(Gp);
+                    return genFun;
+                };
+                runtime.awrap = function(arg) {
+                    return {
+                        __await: arg
+                    };
+                };
+                function AsyncIterator(generator) {
+                    function invoke(method, arg, resolve, reject) {
+                        var record = tryCatch(generator[method], generator, arg);
+                        if (record.type === \\"throw\\") {
+                            reject(record.arg);
+                        } else {
+                            var result = record.arg;
+                            var value = result.value;
+                            if (value && _typeof(value) === \\"object\\" && hasOwn.call(value, \\"__await\\")) {
+                                return Promise.resolve(value.__await).then((function(value) {
+                                    invoke(\\"next\\", value, resolve, reject);
+                                }), (function(err) {
+                                    invoke(\\"throw\\", err, resolve, reject);
+                                }));
+                            }
+                            return Promise.resolve(value).then((function(unwrapped) {
+                                result.value = unwrapped;
+                                resolve(result);
+                            }), reject);
+                        }
+                    }
+                    var previousPromise;
+                    function enqueue(method, arg) {
+                        function callInvokeWithMethodAndArg() {
+                            return new Promise((function(resolve, reject) {
+                                invoke(method, arg, resolve, reject);
+                            }));
+                        }
+                        return previousPromise = previousPromise ? previousPromise.then(callInvokeWithMethodAndArg, callInvokeWithMethodAndArg) : callInvokeWithMethodAndArg();
+                    }
+                    this._invoke = enqueue;
+                }
+                defineIteratorMethods(AsyncIterator.prototype);
+                AsyncIterator.prototype[asyncIteratorSymbol] = function() {
+                    return this;
+                };
+                runtime.AsyncIterator = AsyncIterator;
+                runtime.async = function(innerFn, outerFn, self, tryLocsList) {
+                    var iter = new AsyncIterator(wrap(innerFn, outerFn, self, tryLocsList));
+                    return runtime.isGeneratorFunction(outerFn) ? iter : iter.next().then((function(result) {
+                        return result.done ? result.value : iter.next();
+                    }));
+                };
+                function makeInvokeMethod(innerFn, self, context) {
+                    var state = GenStateSuspendedStart;
+                    return function invoke(method, arg) {
+                        if (state === GenStateExecuting) {
+                            throw new Error(\\"Generator is already running\\");
+                        }
+                        if (state === GenStateCompleted) {
+                            if (method === \\"throw\\") {
+                                throw arg;
+                            }
+                            return doneResult();
+                        }
+                        context.method = method;
+                        context.arg = arg;
+                        while (true) {
+                            var delegate = context.delegate;
+                            if (delegate) {
+                                var delegateResult = maybeInvokeDelegate(delegate, context);
+                                if (delegateResult) {
+                                    if (delegateResult === ContinueSentinel) continue;
+                                    return delegateResult;
+                                }
+                            }
+                            if (context.method === \\"next\\") {
+                                context.sent = context._sent = context.arg;
+                            } else if (context.method === \\"throw\\") {
+                                if (state === GenStateSuspendedStart) {
+                                    state = GenStateCompleted;
+                                    throw context.arg;
+                                }
+                                context.dispatchException(context.arg);
+                            } else if (context.method === \\"return\\") {
+                                context.abrupt(\\"return\\", context.arg);
+                            }
+                            state = GenStateExecuting;
+                            var record = tryCatch(innerFn, self, context);
+                            if (record.type === \\"normal\\") {
+                                state = context.done ? GenStateCompleted : GenStateSuspendedYield;
+                                if (record.arg === ContinueSentinel) {
+                                    continue;
+                                }
+                                return {
+                                    value: record.arg,
+                                    done: context.done
+                                };
+                            } else if (record.type === \\"throw\\") {
+                                state = GenStateCompleted;
+                                context.method = \\"throw\\";
+                                context.arg = record.arg;
+                            }
+                        }
+                    };
+                }
+                function maybeInvokeDelegate(delegate, context) {
+                    var method = delegate.iterator[context.method];
+                    if (method === undefined) {
+                        context.delegate = null;
+                        if (context.method === \\"throw\\") {
+                            if (delegate.iterator.return) {
+                                context.method = \\"return\\";
+                                context.arg = undefined;
+                                maybeInvokeDelegate(delegate, context);
+                                if (context.method === \\"throw\\") {
+                                    return ContinueSentinel;
+                                }
+                            }
+                            context.method = \\"throw\\";
+                            context.arg = new TypeError(\\"The iterator does not provide a 'throw' method\\");
+                        }
+                        return ContinueSentinel;
+                    }
+                    var record = tryCatch(method, delegate.iterator, context.arg);
+                    if (record.type === \\"throw\\") {
+                        context.method = \\"throw\\";
+                        context.arg = record.arg;
+                        context.delegate = null;
+                        return ContinueSentinel;
+                    }
+                    var info = record.arg;
+                    if (!info) {
+                        context.method = \\"throw\\";
+                        context.arg = new TypeError(\\"iterator result is not an object\\");
+                        context.delegate = null;
+                        return ContinueSentinel;
+                    }
+                    if (info.done) {
+                        context[delegate.resultName] = info.value;
+                        context.next = delegate.nextLoc;
+                        if (context.method !== \\"return\\") {
+                            context.method = \\"next\\";
+                            context.arg = undefined;
+                        }
+                    } else {
+                        return info;
+                    }
+                    context.delegate = null;
+                    return ContinueSentinel;
+                }
+                defineIteratorMethods(Gp);
+                Gp[toStringTagSymbol] = \\"Generator\\";
+                Gp[iteratorSymbol] = function() {
+                    return this;
+                };
+                Gp.toString = function() {
+                    return \\"[object Generator]\\";
+                };
+                function pushTryEntry(locs) {
+                    var entry = {
+                        tryLoc: locs[0]
+                    };
+                    if (1 in locs) {
+                        entry.catchLoc = locs[1];
+                    }
+                    if (2 in locs) {
+                        entry.finallyLoc = locs[2];
+                        entry.afterLoc = locs[3];
+                    }
+                    this.tryEntries.push(entry);
+                }
+                function resetTryEntry(entry) {
+                    var record = entry.completion || {};
+                    record.type = \\"normal\\";
+                    delete record.arg;
+                    entry.completion = record;
+                }
+                function Context(tryLocsList) {
+                    this.tryEntries = [ {
+                        tryLoc: \\"root\\"
+                    } ];
+                    tryLocsList.forEach(pushTryEntry, this);
+                    this.reset(true);
+                }
+                runtime.keys = function(object) {
+                    var keys = [];
+                    for (var key in object) {
+                        keys.push(key);
+                    }
+                    keys.reverse();
+                    return function next() {
+                        while (keys.length) {
+                            var key = keys.pop();
+                            if (key in object) {
+                                next.value = key;
+                                next.done = false;
+                                return next;
+                            }
+                        }
+                        next.done = true;
+                        return next;
+                    };
+                };
+                function values(iterable) {
+                    if (iterable) {
+                        var iteratorMethod = iterable[iteratorSymbol];
+                        if (iteratorMethod) {
+                            return iteratorMethod.call(iterable);
+                        }
+                        if (typeof iterable.next === \\"function\\") {
+                            return iterable;
+                        }
+                        if (!isNaN(iterable.length)) {
+                            var i = -1, next = function next() {
+                                while (++i < iterable.length) {
+                                    if (hasOwn.call(iterable, i)) {
+                                        next.value = iterable[i];
+                                        next.done = false;
+                                        return next;
+                                    }
+                                }
+                                next.value = undefined;
+                                next.done = true;
+                                return next;
+                            };
+                            return next.next = next;
+                        }
+                    }
+                    return {
+                        next: doneResult
+                    };
+                }
+                runtime.values = values;
+                function doneResult() {
+                    return {
+                        value: undefined,
+                        done: true
+                    };
+                }
+                Context.prototype = {
+                    constructor: Context,
+                    reset: function reset(skipTempReset) {
+                        this.prev = 0;
+                        this.next = 0;
+                        this.sent = this._sent = undefined;
+                        this.done = false;
+                        this.delegate = null;
+                        this.method = \\"next\\";
+                        this.arg = undefined;
+                        this.tryEntries.forEach(resetTryEntry);
+                        if (!skipTempReset) {
+                            for (var name in this) {
+                                if (name.charAt(0) === \\"t\\" && hasOwn.call(this, name) && !isNaN(+name.slice(1))) {
+                                    this[name] = undefined;
+                                }
+                            }
+                        }
+                    },
+                    stop: function stop() {
+                        this.done = true;
+                        var rootEntry = this.tryEntries[0];
+                        var rootRecord = rootEntry.completion;
+                        if (rootRecord.type === \\"throw\\") {
+                            throw rootRecord.arg;
+                        }
+                        return this.rval;
+                    },
+                    dispatchException: function dispatchException(exception) {
+                        if (this.done) {
+                            throw exception;
+                        }
+                        var context = this;
+                        function handle(loc, caught) {
+                            record.type = \\"throw\\";
+                            record.arg = exception;
+                            context.next = loc;
+                            if (caught) {
+                                context.method = \\"next\\";
+                                context.arg = undefined;
+                            }
+                            return !!caught;
+                        }
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            var record = entry.completion;
+                            if (entry.tryLoc === \\"root\\") {
+                                return handle(\\"end\\");
+                            }
+                            if (entry.tryLoc <= this.prev) {
+                                var hasCatch = hasOwn.call(entry, \\"catchLoc\\");
+                                var hasFinally = hasOwn.call(entry, \\"finallyLoc\\");
+                                if (hasCatch && hasFinally) {
+                                    if (this.prev < entry.catchLoc) {
+                                        return handle(entry.catchLoc, true);
+                                    } else if (this.prev < entry.finallyLoc) {
+                                        return handle(entry.finallyLoc);
+                                    }
+                                } else if (hasCatch) {
+                                    if (this.prev < entry.catchLoc) {
+                                        return handle(entry.catchLoc, true);
+                                    }
+                                } else if (hasFinally) {
+                                    if (this.prev < entry.finallyLoc) {
+                                        return handle(entry.finallyLoc);
+                                    }
+                                } else {
+                                    throw new Error(\\"try statement without catch or finally\\");
+                                }
+                            }
+                        }
+                    },
+                    abrupt: function abrupt(type, arg) {
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            if (entry.tryLoc <= this.prev && hasOwn.call(entry, \\"finallyLoc\\") && this.prev < entry.finallyLoc) {
+                                var finallyEntry = entry;
+                                break;
+                            }
+                        }
+                        if (finallyEntry && (type === \\"break\\" || type === \\"continue\\") && finallyEntry.tryLoc <= arg && arg <= finallyEntry.finallyLoc) {
+                            finallyEntry = null;
+                        }
+                        var record = finallyEntry ? finallyEntry.completion : {};
+                        record.type = type;
+                        record.arg = arg;
+                        if (finallyEntry) {
+                            this.method = \\"next\\";
+                            this.next = finallyEntry.finallyLoc;
+                            return ContinueSentinel;
+                        }
+                        return this.complete(record);
+                    },
+                    complete: function complete(record, afterLoc) {
+                        if (record.type === \\"throw\\") {
+                            throw record.arg;
+                        }
+                        if (record.type === \\"break\\" || record.type === \\"continue\\") {
+                            this.next = record.arg;
+                        } else if (record.type === \\"return\\") {
+                            this.rval = this.arg = record.arg;
+                            this.method = \\"return\\";
+                            this.next = \\"end\\";
+                        } else if (record.type === \\"normal\\" && afterLoc) {
+                            this.next = afterLoc;
+                        }
+                        return ContinueSentinel;
+                    },
+                    finish: function finish(finallyLoc) {
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            if (entry.finallyLoc === finallyLoc) {
+                                this.complete(entry.completion, entry.afterLoc);
+                                resetTryEntry(entry);
+                                return ContinueSentinel;
+                            }
+                        }
+                    },
+                    catch: function _catch(tryLoc) {
+                        for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+                            var entry = this.tryEntries[i];
+                            if (entry.tryLoc === tryLoc) {
+                                var record = entry.completion;
+                                if (record.type === \\"throw\\") {
+                                    var thrown = record.arg;
+                                    resetTryEntry(entry);
+                                }
+                                return thrown;
+                            }
+                        }
+                        throw new Error(\\"illegal catch attempt\\");
+                    },
+                    delegateYield: function delegateYield(iterable, resultName, nextLoc) {
+                        this.delegate = {
+                            iterator: values(iterable),
+                            resultName: resultName,
+                            nextLoc: nextLoc
+                        };
+                        if (this.method === \\"next\\") {
+                            this.arg = undefined;
+                        }
+                        return ContinueSentinel;
+                    }
+                };
+            }(function() {
+                return this;
+            }() || Function(\\"return this\\")());
+        }).call(this, __webpack_require__(32)(module));
+    },
+    32: function(module, exports) {
+        module.exports = function(module) {
+            if (!module.webpackPolyfill) {
+                module.deprecate = function() {};
+                module.paths = [];
+                if (!module.children) module.children = [];
+                Object.defineProperty(module, \\"loaded\\", {
+                    enumerable: true,
+                    get: function get() {
+                        return module.l;
+                    }
+                });
+                Object.defineProperty(module, \\"id\\", {
+                    enumerable: true,
+                    get: function get() {
+                        return module.i;
+                    }
+                });
+                module.webpackPolyfill = 1;
+            }
+            return module;
+        };
+    },
+    33: function(module, exports, __webpack_require__) {},
+    34: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         __webpack_require__.r(__webpack_exports__);
         var runtime_esm = __webpack_require__(3);
+        var regenerator = __webpack_require__(15);
+        var regenerator_default = __webpack_require__.n(regenerator);
+        function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
+            try {
+                var info = gen[key](arg);
+                var value = info.value;
+            } catch (error) {
+                reject(error);
+                return;
+            }
+            if (info.done) {
+                resolve(value);
+            } else {
+                Promise.resolve(value).then(_next, _throw);
+            }
+        }
+        function _asyncToGenerator(fn) {
+            return function() {
+                var self = this, args = arguments;
+                return new Promise((function(resolve, reject) {
+                    var gen = fn.apply(self, args);
+                    function _next(value) {
+                        asyncGeneratorStep(gen, resolve, reject, _next, _throw, \\"next\\", value);
+                    }
+                    function _throw(err) {
+                        asyncGeneratorStep(gen, resolve, reject, _next, _throw, \\"throw\\", err);
+                    }
+                    _next(undefined);
+                }));
+            };
+        }
         var classCallCheck = __webpack_require__(0);
         var createClass = __webpack_require__(1);
         var possibleConstructorReturn = __webpack_require__(4);
@@ -5501,7 +6046,7 @@ object-assign
         var react = __webpack_require__(6);
         var react_default = __webpack_require__.n(react);
         var mini = __webpack_require__(12);
-        var index = __webpack_require__(29);
+        var index = __webpack_require__(33);
         var index_Index = function(_Component) {
             Object(inherits[\\"a\\"])(Index, _Component);
             function Index() {
@@ -5510,7 +6055,27 @@ object-assign
             }
             Object(createClass[\\"a\\"])(Index, [ {
                 key: \\"componentWillMount\\",
-                value: function componentWillMount() {}
+                value: function() {
+                    var _componentWillMount = _asyncToGenerator(regenerator_default.a.mark((function _callee() {
+                        return regenerator_default.a.wrap((function _callee$(_context) {
+                            while (1) {
+                                switch (_context.prev = _context.next) {
+                                  case 0:
+                                    _context.next = 2;
+                                    return Promise.resolve(1);
+
+                                  case 2:
+                                  case \\"end\\":
+                                    return _context.stop();
+                                }
+                            }
+                        }), _callee);
+                    })));
+                    function componentWillMount() {
+                        return _componentWillMount.apply(this, arguments);
+                    }
+                    return componentWillMount;
+                }()
             }, {
                 key: \\"componentDidMount\\",
                 value: function componentDidMount() {}
@@ -5540,7 +6105,7 @@ object-assign
         }(react[\\"Component\\"]);
         var inst = Page(Object(runtime_esm[\\"createPageConfig\\"])(index_Index, \\"pages/index/index\\"));
     }
-}, [ [ 31, 0, 1, 2 ] ] ]);
+}, [ [ 34, 0, 1, 2 ] ] ]);
 
 /** filePath: dist/pages/index/index.json **/
 {\\"navigationBarTitleText\\":\\"首页\\",\\"usingComponents\\":{\\"comp\\":\\"../../comp\\"}}
@@ -5731,12 +6296,12 @@ object-assign
         var MovableArea = \\"movable-area\\";
         var MovableView = \\"movable-view\\";
     },
-    16: function(module, __webpack_exports__, __webpack_require__) {
+    17: function(module, __webpack_exports__, __webpack_require__) {
         \\"use strict\\";
         var _babel_runtime_helpers_esm_classCallCheck__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
         var _babel_runtime_helpers_esm_createClass__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(1);
         var _babel_runtime_helpers_esm_typeof__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(8);
-        var react_reconciler__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(17);
+        var react_reconciler__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(18);
         var react_reconciler__WEBPACK_IMPORTED_MODULE_3___default = __webpack_require__.n(react_reconciler__WEBPACK_IMPORTED_MODULE_3__);
         var scheduler__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(11);
         var scheduler__WEBPACK_IMPORTED_MODULE_4___default = __webpack_require__.n(scheduler__WEBPACK_IMPORTED_MODULE_4__);
@@ -6219,13 +6784,13 @@ object-assign
             __webpack_require__.d(__webpack_exports__, \\"window\\", (function() {
                 return window$1;
             }));
-            var _babel_runtime_helpers_esm_toConsumableArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(18);
-            var _babel_runtime_helpers_esm_set__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(19);
+            var _babel_runtime_helpers_esm_toConsumableArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(19);
+            var _babel_runtime_helpers_esm_set__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(20);
             var _babel_runtime_helpers_esm_possibleConstructorReturn__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(4);
             var _babel_runtime_helpers_esm_getPrototypeOf__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(2);
             var _babel_runtime_helpers_esm_assertThisInitialized__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(10);
             var _babel_runtime_helpers_esm_inherits__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(5);
-            var _babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(15);
+            var _babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(16);
             var _babel_runtime_helpers_esm_defineProperty__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(7);
             var _babel_runtime_helpers_esm_classCallCheck__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(0);
             var _babel_runtime_helpers_esm_createClass__WEBPACK_IMPORTED_MODULE_9__ = __webpack_require__(1);
@@ -9222,7 +9787,7 @@ object-assign
 }, function(module, exports, __webpack_require__) {
     \\"use strict\\";
     if (true) {
-        module.exports = __webpack_require__(22);
+        module.exports = __webpack_require__(23);
     } else {}
 }, function(module, __webpack_exports__, __webpack_require__) {
     \\"use strict\\";
@@ -9283,21 +9848,7 @@ object-assign
         }
         return self;
     }
-}, , , function(module, __webpack_exports__, __webpack_require__) {
-    \\"use strict\\";
-    __webpack_require__.d(__webpack_exports__, \\"a\\", (function() {
-        return _unsupportedIterableToArray;
-    }));
-    var _arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(9);
-    function _unsupportedIterableToArray(o, minLen) {
-        if (!o) return;
-        if (typeof o === \\"string\\") return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
-        var n = Object.prototype.toString.call(o).slice(8, -1);
-        if (n === \\"Object\\" && o.constructor) n = o.constructor.name;
-        if (n === \\"Map\\" || n === \\"Set\\") return Array.from(o);
-        if (n === \\"Arguments\\" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
-    }
-}, function(module, exports) {
+}, , , function(module, exports) {
     function _typeof(obj) {
         \\"@babel/helpers - typeof\\";
         if (typeof Symbol === \\"function\\" && typeof Symbol.iterator === \\"symbol\\") {
@@ -9313,6 +9864,20 @@ object-assign
     }
     module.exports = _typeof;
 }, function(module, __webpack_exports__, __webpack_require__) {
+    \\"use strict\\";
+    __webpack_require__.d(__webpack_exports__, \\"a\\", (function() {
+        return _unsupportedIterableToArray;
+    }));
+    var _arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(9);
+    function _unsupportedIterableToArray(o, minLen) {
+        if (!o) return;
+        if (typeof o === \\"string\\") return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
+        var n = Object.prototype.toString.call(o).slice(8, -1);
+        if (n === \\"Object\\" && o.constructor) n = o.constructor.name;
+        if (n === \\"Map\\" || n === \\"Set\\") return Array.from(o);
+        if (n === \\"Arguments\\" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return Object(_arrayLikeToArray__WEBPACK_IMPORTED_MODULE_0__[\\"a\\"])(o, minLen);
+    }
+}, , function(module, __webpack_exports__, __webpack_require__) {
     \\"use strict\\";
     __webpack_require__.d(__webpack_exports__, \\"a\\", (function() {
         return _slicedToArray;
@@ -9343,7 +9908,7 @@ object-assign
         }
         return _arr;
     }
-    var unsupportedIterableToArray = __webpack_require__(13);
+    var unsupportedIterableToArray = __webpack_require__(14);
     function _nonIterableRest() {
         throw new TypeError(\\"Invalid attempt to destructure non-iterable instance.\\\\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.\\");
     }
@@ -9362,7 +9927,7 @@ object-assign
     function _iterableToArray(iter) {
         if (typeof Symbol !== \\"undefined\\" && Symbol.iterator in Object(iter)) return Array.from(iter);
     }
-    var unsupportedIterableToArray = __webpack_require__(13);
+    var unsupportedIterableToArray = __webpack_require__(14);
     function _nonIterableSpread() {
         throw new TypeError(\\"Invalid attempt to spread non-iterable instance.\\\\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.\\");
     }
@@ -9423,8 +9988,8 @@ object-assign
     }
 }, , , function(module, exports, __webpack_require__) {
     \\"use strict\\";
-    var _typeof = __webpack_require__(14);
-    var l = __webpack_require__(23), n = \\"function\\" === typeof Symbol && Symbol.for, p = n ? Symbol.for(\\"react.element\\") : 60103, q = n ? Symbol.for(\\"react.portal\\") : 60106, r = n ? Symbol.for(\\"react.fragment\\") : 60107, t = n ? Symbol.for(\\"react.strict_mode\\") : 60108, u = n ? Symbol.for(\\"react.profiler\\") : 60114, v = n ? Symbol.for(\\"react.provider\\") : 60109, w = n ? Symbol.for(\\"react.context\\") : 60110, x = n ? Symbol.for(\\"react.forward_ref\\") : 60112, y = n ? Symbol.for(\\"react.suspense\\") : 60113, z = n ? Symbol.for(\\"react.memo\\") : 60115, A = n ? Symbol.for(\\"react.lazy\\") : 60116, B = \\"function\\" === typeof Symbol && Symbol.iterator;
+    var _typeof = __webpack_require__(13);
+    var l = __webpack_require__(24), n = \\"function\\" === typeof Symbol && Symbol.for, p = n ? Symbol.for(\\"react.element\\") : 60103, q = n ? Symbol.for(\\"react.portal\\") : 60106, r = n ? Symbol.for(\\"react.fragment\\") : 60107, t = n ? Symbol.for(\\"react.strict_mode\\") : 60108, u = n ? Symbol.for(\\"react.profiler\\") : 60114, v = n ? Symbol.for(\\"react.provider\\") : 60109, w = n ? Symbol.for(\\"react.context\\") : 60110, x = n ? Symbol.for(\\"react.forward_ref\\") : 60112, y = n ? Symbol.for(\\"react.suspense\\") : 60113, z = n ? Symbol.for(\\"react.memo\\") : 60115, A = n ? Symbol.for(\\"react.lazy\\") : 60116, B = \\"function\\" === typeof Symbol && Symbol.iterator;
     function C(a) {
         for (var b = \\"https://reactjs.org/docs/error-decoder.html?invariant=\\" + a, c = 1; c < arguments.length; c++) {
             b += \\"&args[]=\\" + encodeURIComponent(arguments[c]);

--- a/packages/taro-mini-runner/__tests__/fixtures/react/src/pages/index/index.jsx
+++ b/packages/taro-mini-runner/__tests__/fixtures/react/src/pages/index/index.jsx
@@ -4,7 +4,9 @@ import './index.css'
 
 export default class Index extends Component {
 
-  componentWillMount () { }
+  async componentWillMount () {
+    await Promise.resolve(1)
+  }
 
   componentDidMount () { }
 

--- a/packages/taro-mini-runner/package.json
+++ b/packages/taro-mini-runner/package.json
@@ -65,6 +65,7 @@
     "postcss-loader": "^3.0.0",
     "postcss-pxtransform": "^1.3.2",
     "postcss-url": "8.0.0",
+    "regenerator-runtime": "0.11",
     "request": "^2.88.0",
     "resolve": "^1.11.1",
     "sass-loader": "^8.0.2",

--- a/packages/taro-mini-runner/src/webpack/base.conf.ts
+++ b/packages/taro-mini-runner/src/webpack/base.conf.ts
@@ -11,7 +11,11 @@ export default (appPath: string) => {
       modules: [
         'node_modules',
         path.join(appPath, 'node_modules')
-      ]
+      ],
+      alias: {
+        // 小程序使用 regenerator-runtime@0.11
+        'regenerator-runtime': require.resolve('regenerator-runtime')
+      }
     },
     resolveLoader: {
       modules: [

--- a/packages/taro-mini-runner/yarn.lock
+++ b/packages/taro-mini-runner/yarn.lock
@@ -3994,7 +3994,7 @@ regenerate@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
 
-regenerator-runtime@^0.11.0:
+regenerator-runtime@0.11, regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 


### PR DESCRIPTION
**这个 PR 做了什么?**

* mini-runner 内置 **regenerator-runtime@0.11**，并让 webpack alias 到它。避免其它包使用到 regenerator-runtime@0.13 而令小程序报错。
* 更新测试用例

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #6278 

**这个 PR 满足以下需求:**

- [x] 提交到 next 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
