### PR TITLE
feat(runner): 支持解析多端文件，close #6231

### DIFF
--- a/packages/taro-mini-runner/src/webpack/base.conf.ts
+++ b/packages/taro-mini-runner/src/webpack/base.conf.ts
@@ -1,5 +1,6 @@
 import * as path from 'path'
 import * as Chain from 'webpack-chain'
+import { MultiPlatformPlugin } from '@tarojs/runner-utils'
 
 export default (appPath: string) => {
   const chain = new Chain()
@@ -23,6 +24,10 @@ export default (appPath: string) => {
       ]
     }
   })
+
+  chain.resolve
+    .plugin('MultiPlatformPlugin')
+    .use(MultiPlatformPlugin, ['described-resolve', 'resolve'])
 
   return chain
 }

--- a/packages/taro-runner-utils/src/index.ts
+++ b/packages/taro-runner-utils/src/index.ts
@@ -1,7 +1,9 @@
 import { getBundleResult, getBundleContent, getSassLoaderOption } from './scss'
+import { MultiPlatformPlugin } from './resolve/MultiPlatformPlugin'
 
 export {
   getBundleResult,
   getBundleContent,
-  getSassLoaderOption
+  getSassLoaderOption,
+  MultiPlatformPlugin
 }

--- a/packages/taro-runner-utils/src/resolve/MultiPlatformPlugin.ts
+++ b/packages/taro-runner-utils/src/resolve/MultiPlatformPlugin.ts
@@ -1,0 +1,83 @@
+import * as path from 'path'
+import helper from '@tarojs/helper'
+
+interface IOptions {
+  include?: string[]
+}
+
+/**
+ * @description 此 enhance-resolve 插件用于根据当前编译的平台，解析多端文件的后缀
+ *
+ * @property {string} source resolver hook 类别
+ * @property {string} target 解析完成后需要触发的钩子
+ * @property {IOptions} options 插件配置项
+ *
+ * @example
+ *   there's filepath 'src/index'
+ *   when platform is weapp, we get 'src/index.weapp.[js|ts|jsx|tsx]'
+ *   when platform is h5, we get 'src/index.h5.[js|ts|jsx|tsx]'
+ *   by default, we get 'src/index.[js|ts|jsx|tsx]'
+ *
+ * @class MultiPlatformPlugin
+ */
+export class MultiPlatformPlugin {
+  private source: string
+  private target: string
+  private options: IOptions
+
+  constructor (source: string, target: string, options?: IOptions) {
+    this.source = source
+    this.target = target
+    this.options = options || {}
+  }
+
+  public apply (resolver) {
+    const target = resolver.ensureHook(this.target)
+    resolver
+      .getHook(this.source)
+      .tapAsync('MultiPlatformPlugin', (request, resolveContext, callback) => {
+        const innerRequest: string = request.request || request.path
+        if (!innerRequest) return callback()
+
+        if (!path.extname(innerRequest)) {
+          let srcRequest: string
+          if (path.isAbsolute(innerRequest)) {
+            // absolute path
+            srcRequest = innerRequest
+          } else if (!path.isAbsolute(innerRequest) && /^\./.test(innerRequest)) {
+            // relative path
+            srcRequest = path.resolve(request.path, request.request)
+          } else {
+            return callback()
+          }
+
+          if (/node_modules/.test(srcRequest) && !this.includes(srcRequest)) {
+            return callback()
+          }
+
+          const newRequestStr = helper.resolveMainFilePath(srcRequest)
+          if (newRequestStr === innerRequest) return callback()
+          const obj = Object.assign({}, request, {
+            request: newRequestStr
+          })
+          return resolver.doResolve(target, obj, 'resolve multi platform file path', resolveContext, (err, result) => {
+            if (err) return callback(err)
+
+            if (result === undefined) return callback(null, null)
+            return callback(null, result)
+          })
+        }
+
+        callback()
+      })
+  }
+
+  private includes (filePath: string): boolean {
+    if (!this.options.include || !this.options.include.length) return false
+
+    filePath = filePath.replace(path.sep, '/')
+
+    const res = this.options.include.find(item => filePath.includes(item))
+    return Boolean(res)
+  }
+}

--- a/packages/taro-runner-utils/types/index.d.ts
+++ b/packages/taro-runner-utils/types/index.d.ts
@@ -1,2 +1,3 @@
 import { getBundleResult, getBundleContent, getSassLoaderOption } from './scss';
-export { getBundleResult, getBundleContent, getSassLoaderOption };
+import { MultiPlatformPlugin } from './resolve/MultiPlatformPlugin';
+export { getBundleResult, getBundleContent, getSassLoaderOption, MultiPlatformPlugin };

--- a/packages/taro-runner-utils/types/resolve/MultiPlatformPlugin.d.ts
+++ b/packages/taro-runner-utils/types/resolve/MultiPlatformPlugin.d.ts
@@ -1,0 +1,27 @@
+interface IOptions {
+    include?: string[];
+}
+/**
+ * @description 此 enhance-resolve 插件用于根据当前编译的平台，解析多端文件的后缀
+ *
+ * @property {string} source resolver hook 类别
+ * @property {string} target 解析完成后需要触发的钩子
+ * @property {IOptions} options 插件配置项
+ *
+ * @example
+ *   there's filepath 'src/index'
+ *   when platform is weapp, we get 'src/index.weapp.[js|ts|jsx|tsx]'
+ *   when platform is h5, we get 'src/index.h5.[js|ts|jsx|tsx]'
+ *   by default, we get 'src/index.[js|ts|jsx|tsx]'
+ *
+ * @class MultiPlatformPlugin
+ */
+export declare class MultiPlatformPlugin {
+    private source;
+    private target;
+    private options;
+    constructor(source: string, target: string, options?: IOptions);
+    apply(resolver: any): void;
+    private includes;
+}
+export {};

--- a/packages/taro-webpack-runner/src/config/base.conf.ts
+++ b/packages/taro-webpack-runner/src/config/base.conf.ts
@@ -1,5 +1,6 @@
 import * as path from 'path'
 import * as Chain from 'webpack-chain'
+import { MultiPlatformPlugin } from '@tarojs/runner-utils'
 
 import { getRootPath } from '../util'
 import { BuildConfig } from '../util/types'
@@ -27,6 +28,10 @@ export default (appPath: string, config: Partial<BuildConfig>) => {
       modules: [path.join(getRootPath(), 'node_modules'), 'node_modules']
     }
   })
+
+  chain.resolve
+    .plugin('MultiPlatformPlugin')
+    .use(MultiPlatformPlugin, ['described-resolve', 'resolve'])
 
   return chain
 }

--- a/packages/taro-webpack-runner/src/index.ts
+++ b/packages/taro-webpack-runner/src/index.ts
@@ -72,7 +72,6 @@ const buildDev = async (appPath: string, config: BuildConfig): Promise<any> => {
   const customDevServerOption = config.devServer || {}
   const webpackChain = devConf(appPath, config)
   const onBuildFinish = config.onBuildFinish
-  console.log(config)
   await customizeChain(webpackChain, config.modifyWebpackChain, config.webpackChain)
 
   const devServerOptions = recursiveMerge<WebpackDevServer.Configuration>(


### PR DESCRIPTION
**这个 PR 做了什么?**

增加了一个 [enhance-resolve](https://github.com/webpack/enhanced-resolve) 插件。用于根据当前编译的平台，解析多端文件的后缀。
 
 >    @example
 >    there's filepath 'src/index'
 >    when platform is weapp, we get "src/index.weapp.[js|ts|jsx|tsx]"
 >    when platform is h5, we get "src/index.h5.[js|ts|jsx|tsx]"
 >    by default, we get "src/index.[js|ts|jsx|tsx]"

**这个 PR 是什么类型?**

- [x] 新功能(Feature) issue id #6231

**这个 PR 满足以下需求:**

- [x] 提交到 next 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）