### PR TITLE
perf(runtime): 页面组件卸载时组件引用

### DIFF
--- a/packages/taro-helper/yarn.lock
+++ b/packages/taro-helper/yarn.lock
@@ -745,16 +745,6 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@tarojs/taro@2.2.1":
-  version "2.2.1"
-  resolved "https://registry.npm.taobao.org/@tarojs/taro/download/@tarojs/taro-2.2.1.tgz?cache=0&sync_timestamp=1588213070796&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40tarojs%2Ftaro%2Fdownload%2F%40tarojs%2Ftaro-2.2.1.tgz#32974e49ec55a9af6f916bcba7f713cf2089b68e"
-  dependencies:
-    "@tarojs/utils" "2.2.1"
-
-"@tarojs/utils@2.2.1":
-  version "2.2.1"
-  resolved "https://registry.npm.taobao.org/@tarojs/utils/download/@tarojs/utils-2.2.1.tgz?cache=0&sync_timestamp=1588213058625&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40tarojs%2Futils%2Fdownload%2F%40tarojs%2Futils-2.2.1.tgz#d80e72272d8e50addccdef2408e45874ea0d55ab"
-
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.npm.taobao.org/@types/color-name/download/@types/color-name-1.1.1.tgz?cache=0&sync_timestamp=1588200011932&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fcolor-name%2Fdownload%2F%40types%2Fcolor-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"

--- a/packages/taro-mini-runner/__tests__/__snapshots__/alipay.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/alipay.spec.ts.snap
@@ -9187,6 +9187,7 @@ object-assign
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }

--- a/packages/taro-mini-runner/__tests__/__snapshots__/babel.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/babel.spec.ts.snap
@@ -8214,6 +8214,7 @@ object-assign
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }

--- a/packages/taro-mini-runner/__tests__/__snapshots__/bytedance.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/bytedance.spec.ts.snap
@@ -9189,6 +9189,7 @@ object-assign
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }

--- a/packages/taro-mini-runner/__tests__/__snapshots__/common-style.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/common-style.spec.ts.snap
@@ -8240,6 +8240,7 @@ object-assign
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }

--- a/packages/taro-mini-runner/__tests__/__snapshots__/config.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/config.spec.ts.snap
@@ -8380,6 +8380,7 @@ object-assign
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }
@@ -17831,6 +17832,7 @@ object-assign
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }
@@ -27286,6 +27288,7 @@ I m irrelevant.
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }

--- a/packages/taro-mini-runner/__tests__/__snapshots__/css-modules.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/css-modules.spec.ts.snap
@@ -8238,6 +8238,7 @@ object-assign
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }
@@ -17703,6 +17704,7 @@ object-assign
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }

--- a/packages/taro-mini-runner/__tests__/__snapshots__/custom-tabbar.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/custom-tabbar.spec.ts.snap
@@ -9111,6 +9111,7 @@ h�hځ� �r������Nb2��х��K~��>;;ːL�1�
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }

--- a/packages/taro-mini-runner/__tests__/__snapshots__/jd.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/jd.spec.ts.snap
@@ -9189,6 +9189,7 @@ object-assign
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }

--- a/packages/taro-mini-runner/__tests__/__snapshots__/nerv.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/nerv.spec.ts.snap
@@ -3488,6 +3488,7 @@ require(\\"./taro\\");
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }

--- a/packages/taro-mini-runner/__tests__/__snapshots__/parse-html.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/parse-html.spec.ts.snap
@@ -8083,6 +8083,7 @@ object-assign
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }

--- a/packages/taro-mini-runner/__tests__/__snapshots__/prerender.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/prerender.spec.ts.snap
@@ -9678,6 +9678,7 @@ object-assign
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }
@@ -20706,6 +20707,7 @@ object-assign
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }
@@ -31686,6 +31688,7 @@ object-assign
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }

--- a/packages/taro-mini-runner/__tests__/__snapshots__/qq.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/qq.spec.ts.snap
@@ -8804,6 +8804,7 @@ object-assign
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }
@@ -19223,6 +19224,7 @@ object-assign
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }

--- a/packages/taro-mini-runner/__tests__/__snapshots__/react.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/react.spec.ts.snap
@@ -9184,6 +9184,7 @@ object-assign
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }

--- a/packages/taro-mini-runner/__tests__/__snapshots__/sass.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/sass.spec.ts.snap
@@ -8221,6 +8221,7 @@ object-assign
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }
@@ -17673,6 +17674,7 @@ object-assign
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }
@@ -27125,6 +27127,7 @@ object-assign
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }
@@ -36577,6 +36580,7 @@ object-assign
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }

--- a/packages/taro-mini-runner/__tests__/__snapshots__/subpackages.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/subpackages.spec.ts.snap
@@ -8848,6 +8848,7 @@ require(\\"../../sub-utils\\");
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }

--- a/packages/taro-mini-runner/__tests__/__snapshots__/swan.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/swan.spec.ts.snap
@@ -9189,6 +9189,7 @@ object-assign
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }

--- a/packages/taro-mini-runner/__tests__/__snapshots__/tabbar.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/tabbar.spec.ts.snap
@@ -8228,6 +8228,7 @@ h�hځ� �r������Nb2��х��K~��>;;ːL�1�
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }
@@ -17738,6 +17739,7 @@ h�hځ� �r������Nb2��х��K~��>;;ːL�1�
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }

--- a/packages/taro-mini-runner/__tests__/__snapshots__/ts.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/ts.spec.ts.snap
@@ -8224,6 +8224,7 @@ object-assign
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }

--- a/packages/taro-mini-runner/__tests__/__snapshots__/vue.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/vue.spec.ts.snap
@@ -9168,6 +9168,7 @@ require(\\"./taro\\");
                     onUnload: function onUnload() {
                         var path = getPath(id, this.options);
                         Current.app.unmount(path, (function() {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }

--- a/packages/taro-mini-runner/__tests__/__snapshots__/wx-hybrid.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/wx-hybrid.spec.ts.snap
@@ -8659,6 +8659,7 @@ object-assign
                     onUnload() {
                         const path = getPath(id, this.options);
                         Current.app.unmount(path, () => {
+                            instances.delete(path);
                             if (pageElement) {
                                 pageElement.ctx = null;
                             }

--- a/packages/taro-runtime/src/dsl/common.ts
+++ b/packages/taro-runtime/src/dsl/common.ts
@@ -126,6 +126,7 @@ export function createPageConfig (component: React.ComponentClass, pageName?: st
     onUnload () {
       const path = getPath(id, this.options)
       Current.app!.unmount!(path, () => {
+        instances.delete(path);
         if (pageElement) {
           pageElement.ctx = null
         }

--- a/packages/taro-runtime/src/dsl/common.ts
+++ b/packages/taro-runtime/src/dsl/common.ts
@@ -126,7 +126,7 @@ export function createPageConfig (component: React.ComponentClass, pageName?: st
     onUnload () {
       const path = getPath(id, this.options)
       Current.app!.unmount!(path, () => {
-        instances.delete(path);
+        instances.delete(path)
         if (pageElement) {
           pageElement.ctx = null
         }

--- a/packages/taro-webpack-runner/__tests__/__snapshots__/babel.spec.ts.snap
+++ b/packages/taro-webpack-runner/__tests__/__snapshots__/babel.spec.ts.snap
@@ -21091,6 +21091,7 @@ Element.remove()
             \\"onUnload\\": function onUnload() {
                 var path = getPath(id, this.options);
                 Current.app.unmount(path, (function() {
+                    instances.delete(path);
                     if (pageElement) {
                         pageElement.ctx = null;
                     }

--- a/packages/taro-webpack-runner/__tests__/__snapshots__/css-modules.spec.ts.snap
+++ b/packages/taro-webpack-runner/__tests__/__snapshots__/css-modules.spec.ts.snap
@@ -21115,6 +21115,7 @@ Element.remove()
             \\"onUnload\\": function onUnload() {
                 var path = getPath(id, this.options);
                 Current.app.unmount(path, (function() {
+                    instances.delete(path);
                     if (pageElement) {
                         pageElement.ctx = null;
                     }
@@ -63576,6 +63577,7 @@ Element.remove()
             \\"onUnload\\": function onUnload() {
                 var path = getPath(id, this.options);
                 Current.app.unmount(path, (function() {
+                    instances.delete(path);
                     if (pageElement) {
                         pageElement.ctx = null;
                     }

--- a/packages/taro-webpack-runner/__tests__/__snapshots__/nerv.spec.ts.snap
+++ b/packages/taro-webpack-runner/__tests__/__snapshots__/nerv.spec.ts.snap
@@ -21099,6 +21099,7 @@ Element.remove()
             \\"onUnload\\": function onUnload() {
                 var path = getPath(id, this.options);
                 Current.app.unmount(path, (function() {
+                    instances.delete(path);
                     if (pageElement) {
                         pageElement.ctx = null;
                     }

--- a/packages/taro-webpack-runner/__tests__/__snapshots__/react.spec.ts.snap
+++ b/packages/taro-webpack-runner/__tests__/__snapshots__/react.spec.ts.snap
@@ -21098,6 +21098,7 @@ Element.remove()
             \\"onUnload\\": function onUnload() {
                 var path = getPath(id, this.options);
                 Current.app.unmount(path, (function() {
+                    instances.delete(path);
                     if (pageElement) {
                         pageElement.ctx = null;
                     }

--- a/packages/taro-webpack-runner/__tests__/__snapshots__/subpackages.spec.ts.snap
+++ b/packages/taro-webpack-runner/__tests__/__snapshots__/subpackages.spec.ts.snap
@@ -21368,6 +21368,7 @@ Element.remove()
             \\"onUnload\\": function onUnload() {
                 var path = getPath(id, this.options);
                 Current.app.unmount(path, (function() {
+                    instances.delete(path);
                     if (pageElement) {
                         pageElement.ctx = null;
                     }

--- a/packages/taro-webpack-runner/__tests__/__snapshots__/ts.spec.ts.snap
+++ b/packages/taro-webpack-runner/__tests__/__snapshots__/ts.spec.ts.snap
@@ -21101,6 +21101,7 @@ Element.remove()
             \\"onUnload\\": function onUnload() {
                 var path = getPath(id, this.options);
                 Current.app.unmount(path, (function() {
+                    instances.delete(path);
                     if (pageElement) {
                         pageElement.ctx = null;
                     }

--- a/packages/taro-webpack-runner/__tests__/__snapshots__/vue.spec.ts.snap
+++ b/packages/taro-webpack-runner/__tests__/__snapshots__/vue.spec.ts.snap
@@ -20982,6 +20982,7 @@ Element.remove()
             \\"onUnload\\": function onUnload() {
                 var path = getPath(id, this.options);
                 Current.app.unmount(path, (function() {
+                    instances.delete(path);
                     if (pageElement) {
                         pageElement.ctx = null;
                     }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

runtime 内保存的组件实例，页面关闭没有被清除。
重复进出多几次页面，导致内存占用过高


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [ ] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [ ] 百度小程序
- [x] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
