### PR TITLE
feat(runtime): 普通组件可以访问 onShow 和 onHide 生命周期

### DIFF
--- a/packages/taro-components/package.json
+++ b/packages/taro-components/package.json
@@ -5,7 +5,7 @@
   "main:h5": "src/index.js",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
-  "typings": "types/index.d.ts",
+  "types": "types/index.d.ts",
   "sideEffects": [
     "*.scss",
     "*.css"

--- a/packages/taro-mini-runner/__tests__/__snapshots__/alipay.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/alipay.spec.ts.snap
@@ -9154,6 +9154,12 @@ object-assign
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -9165,7 +9171,9 @@ object-assign
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -9180,7 +9188,7 @@ object-assign
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -9198,14 +9206,22 @@ object-assign
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/babel.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/babel.spec.ts.snap
@@ -8181,6 +8181,12 @@ object-assign
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -8192,7 +8198,9 @@ object-assign
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -8207,7 +8215,7 @@ object-assign
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -8225,14 +8233,22 @@ object-assign
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/bytedance.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/bytedance.spec.ts.snap
@@ -9156,6 +9156,12 @@ object-assign
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -9167,7 +9173,9 @@ object-assign
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -9182,7 +9190,7 @@ object-assign
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -9200,14 +9208,22 @@ object-assign
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/common-style.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/common-style.spec.ts.snap
@@ -8207,6 +8207,12 @@ object-assign
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -8218,7 +8224,9 @@ object-assign
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -8233,7 +8241,7 @@ object-assign
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -8251,14 +8259,22 @@ object-assign
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/config.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/config.spec.ts.snap
@@ -8347,6 +8347,12 @@ object-assign
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -8358,7 +8364,9 @@ object-assign
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -8373,7 +8381,7 @@ object-assign
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -8391,14 +8399,22 @@ object-assign
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {
@@ -17798,6 +17814,12 @@ object-assign
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -17809,7 +17831,9 @@ object-assign
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -17824,7 +17848,7 @@ object-assign
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -17842,14 +17866,22 @@ object-assign
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {
@@ -27253,6 +27285,12 @@ I m irrelevant.
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -27264,7 +27302,9 @@ I m irrelevant.
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -27279,7 +27319,7 @@ I m irrelevant.
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -27297,14 +27337,22 @@ I m irrelevant.
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/css-modules.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/css-modules.spec.ts.snap
@@ -8205,6 +8205,12 @@ object-assign
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -8216,7 +8222,9 @@ object-assign
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -8231,7 +8239,7 @@ object-assign
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -8249,14 +8257,22 @@ object-assign
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {
@@ -17670,6 +17686,12 @@ object-assign
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -17681,7 +17703,9 @@ object-assign
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -17696,7 +17720,7 @@ object-assign
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -17714,14 +17738,22 @@ object-assign
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/custom-tabbar.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/custom-tabbar.spec.ts.snap
@@ -9078,6 +9078,12 @@ h�hځ� �r������Nb2��х��K~��>;;ːL�1�
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -9089,7 +9095,9 @@ h�hځ� �r������Nb2��х��K~��>;;ːL�1�
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -9104,7 +9112,7 @@ h�hځ� �r������Nb2��х��K~��>;;ːL�1�
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -9122,14 +9130,22 @@ h�hځ� �r������Nb2��х��K~��>;;ːL�1�
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/jd.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/jd.spec.ts.snap
@@ -9156,6 +9156,12 @@ object-assign
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -9167,7 +9173,9 @@ object-assign
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -9182,7 +9190,7 @@ object-assign
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -9200,14 +9208,22 @@ object-assign
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/nerv.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/nerv.spec.ts.snap
@@ -3455,6 +3455,12 @@ require(\\"./taro\\");
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -3466,7 +3472,9 @@ require(\\"./taro\\");
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -3481,7 +3489,7 @@ require(\\"./taro\\");
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -3499,14 +3507,22 @@ require(\\"./taro\\");
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/parse-html.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/parse-html.spec.ts.snap
@@ -8050,6 +8050,12 @@ object-assign
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -8061,7 +8067,9 @@ object-assign
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -8076,7 +8084,7 @@ object-assign
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -8094,14 +8102,22 @@ object-assign
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/prerender.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/prerender.spec.ts.snap
@@ -9645,6 +9645,12 @@ object-assign
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -9656,7 +9662,9 @@ object-assign
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -9671,7 +9679,7 @@ object-assign
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -9689,14 +9697,22 @@ object-assign
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {
@@ -20673,6 +20689,12 @@ object-assign
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -20684,7 +20706,9 @@ object-assign
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -20699,7 +20723,7 @@ object-assign
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -20717,14 +20741,22 @@ object-assign
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {
@@ -31653,6 +31685,12 @@ object-assign
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -31664,7 +31702,9 @@ object-assign
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -31679,7 +31719,7 @@ object-assign
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -31697,14 +31737,22 @@ object-assign
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/qq.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/qq.spec.ts.snap
@@ -8771,6 +8771,12 @@ object-assign
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -8782,7 +8788,9 @@ object-assign
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -8797,7 +8805,7 @@ object-assign
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -8815,14 +8823,22 @@ object-assign
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {
@@ -19190,6 +19206,12 @@ object-assign
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -19201,7 +19223,9 @@ object-assign
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -19216,7 +19240,7 @@ object-assign
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -19234,14 +19258,22 @@ object-assign
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/react.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/react.spec.ts.snap
@@ -9151,6 +9151,12 @@ object-assign
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -9162,7 +9168,9 @@ object-assign
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -9177,7 +9185,7 @@ object-assign
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -9195,14 +9203,22 @@ object-assign
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/sass.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/sass.spec.ts.snap
@@ -8188,6 +8188,12 @@ object-assign
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -8199,7 +8205,9 @@ object-assign
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -8214,7 +8222,7 @@ object-assign
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -8232,14 +8240,22 @@ object-assign
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {
@@ -17640,6 +17656,12 @@ object-assign
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -17651,7 +17673,9 @@ object-assign
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -17666,7 +17690,7 @@ object-assign
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -17684,14 +17708,22 @@ object-assign
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {
@@ -27092,6 +27124,12 @@ object-assign
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -27103,7 +27141,9 @@ object-assign
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -27118,7 +27158,7 @@ object-assign
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -27136,14 +27176,22 @@ object-assign
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {
@@ -36544,6 +36592,12 @@ object-assign
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -36555,7 +36609,9 @@ object-assign
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -36570,7 +36626,7 @@ object-assign
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -36588,14 +36644,22 @@ object-assign
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/subpackages.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/subpackages.spec.ts.snap
@@ -8815,6 +8815,12 @@ require(\\"../../sub-utils\\");
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -8826,7 +8832,9 @@ require(\\"../../sub-utils\\");
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -8841,7 +8849,7 @@ require(\\"../../sub-utils\\");
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -8859,14 +8867,22 @@ require(\\"../../sub-utils\\");
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/swan.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/swan.spec.ts.snap
@@ -9156,6 +9156,12 @@ object-assign
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -9167,7 +9173,9 @@ object-assign
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -9182,7 +9190,7 @@ object-assign
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -9200,14 +9208,22 @@ object-assign
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/tabbar.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/tabbar.spec.ts.snap
@@ -8195,6 +8195,12 @@ h�hځ� �r������Nb2��х��K~��>;;ːL�1�
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -8206,7 +8212,9 @@ h�hځ� �r������Nb2��х��K~��>;;ːL�1�
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -8221,7 +8229,7 @@ h�hځ� �r������Nb2��х��K~��>;;ːL�1�
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -8239,14 +8247,22 @@ h�hځ� �r������Nb2��х��K~��>;;ːL�1�
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {
@@ -17705,6 +17721,12 @@ h�hځ� �r������Nb2��х��K~��>;;ːL�1�
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -17716,7 +17738,9 @@ h�hځ� �r������Nb2��х��K~��>;;ːL�1�
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -17731,7 +17755,7 @@ h�hځ� �r������Nb2��х��K~��>;;ːL�1�
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -17749,14 +17773,22 @@ h�hځ� �r������Nb2��х��K~��>;;ːL�1�
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/ts.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/ts.spec.ts.snap
@@ -8191,6 +8191,12 @@ object-assign
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -8202,7 +8208,9 @@ object-assign
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -8217,7 +8225,7 @@ object-assign
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -8235,14 +8243,22 @@ object-assign
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/vue.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/vue.spec.ts.snap
@@ -9135,6 +9135,12 @@ require(\\"./taro\\");
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
                 var pageElement = null;
@@ -9146,7 +9152,9 @@ require(\\"./taro\\");
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, (function() {
                             pageElement = document$1.getElementById(path);
@@ -9161,7 +9169,7 @@ require(\\"./taro\\");
                     onReady: function onReady() {
                         var path = getPath(id, this.options);
                         raf((function() {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         }));
                         safeExecute(path, \\"onReady\\");
                     },
@@ -9179,14 +9187,22 @@ require(\\"./taro\\");
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf((function() {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        }));
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide: function onHide() {
                         Current.page = null;
                         Current.router = null;
                         var path = getPath(id, this.options);
+                        raf((function() {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        }));
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh: function onPullDownRefresh() {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/wx-hybrid.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/wx-hybrid.spec.ts.snap
@@ -8627,6 +8627,12 @@ object-assign
             function getOnReadyEventKey(path) {
                 return path + \\".\\" + \\"onReady\\";
             }
+            function getOnShowEventKey(path) {
+                return path + \\".\\" + \\"onShow\\";
+            }
+            function getOnHideEventKey(path) {
+                return path + \\".\\" + \\"onHide\\";
+            }
             function createPageConfig(component, pageName, data) {
                 const id = pageName !== null && pageName !== void 0 ? pageName : \`taro_page_\${pageId()}\`;
                 let pageElement = null;
@@ -8637,7 +8643,9 @@ object-assign
                         Current.router = {
                             params: options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
                         Current.app.mount(component, path, () => {
                             pageElement = document$1.getElementById(path);
@@ -8652,7 +8660,7 @@ object-assign
                     onReady() {
                         const path = getPath(id, this.options);
                         raf(() => {
-                            eventCenter.trigger(getOnReadyEventKey(path));
+                            eventCenter.trigger(getOnReadyEventKey(id));
                         });
                         safeExecute(path, \\"onReady\\");
                     },
@@ -8670,14 +8678,22 @@ object-assign
                         Current.router = {
                             params: this.options,
                             path: addLeadingSlash(this.route || this.__route__),
-                            onReady: getOnReadyEventKey(path)
+                            onReady: getOnReadyEventKey(id),
+                            onShow: getOnShowEventKey(id),
+                            onHide: getOnHideEventKey(id)
                         };
+                        raf(() => {
+                            eventCenter.trigger(getOnShowEventKey(id));
+                        });
                         safeExecute(path, \\"onShow\\");
                     },
                     onHide() {
                         Current.page = null;
                         Current.router = null;
                         const path = getPath(id, this.options);
+                        raf(() => {
+                            eventCenter.trigger(getOnHideEventKey(id));
+                        });
                         safeExecute(path, \\"onHide\\");
                     },
                     onPullDownRefresh() {

--- a/packages/taro-runtime/src/current.ts
+++ b/packages/taro-runtime/src/current.ts
@@ -1,9 +1,11 @@
 import { AppInstance, PageInstance } from './dsl/instance'
 
 interface Router {
-  params: Record<string, unknown>
+  params: Record<string, unknown>,
   path: string,
-  onReady: string
+  onReady: string,
+  onHide: string,
+  onShow: string
 }
 
 interface Current {

--- a/packages/taro-runtime/src/dsl/common.ts
+++ b/packages/taro-runtime/src/dsl/common.ts
@@ -86,6 +86,14 @@ export function getOnReadyEventKey (path: string) {
   return path + '.' + 'onReady'
 }
 
+export function getOnShowEventKey (path: string) {
+  return path + '.' + 'onShow'
+}
+
+export function getOnHideEventKey (path: string) {
+  return path + '.' + 'onHide'
+}
+
 export function createPageConfig (component: React.ComponentClass, pageName?: string, data?: Record<string, unknown>) {
   const id = pageName ?? `taro_page_${pageId()}`
   // 小程序 Page 构造器是一个傲娇小公主，不能把复杂的对象挂载到参数上
@@ -100,7 +108,9 @@ export function createPageConfig (component: React.ComponentClass, pageName?: st
       Current.router = {
         params: options,
         path: addLeadingSlash(this.route || this.__route__),
-        onReady: getOnReadyEventKey(path)
+        onReady: getOnReadyEventKey(id),
+        onShow: getOnShowEventKey(id),
+        onHide: getOnHideEventKey(id),
       }
 
       Current.app!.mount!(component, path, () => {
@@ -118,7 +128,7 @@ export function createPageConfig (component: React.ComponentClass, pageName?: st
       const path = getPath(id, this.options)
 
       raf(() => {
-        eventCenter.trigger(getOnReadyEventKey(path))
+        eventCenter.trigger(getOnReadyEventKey(id))
       })
 
       safeExecute(path, 'onReady')
@@ -138,8 +148,14 @@ export function createPageConfig (component: React.ComponentClass, pageName?: st
       Current.router = {
         params: this.options,
         path: addLeadingSlash(this.route || this.__route__),
-        onReady: getOnReadyEventKey(path)
+        onReady: getOnReadyEventKey(id),
+        onShow: getOnShowEventKey(id),
+        onHide: getOnHideEventKey(id),
       }
+
+      raf(() => {
+        eventCenter.trigger(getOnShowEventKey(id))
+      })
 
       safeExecute(path, 'onShow')
     },
@@ -147,6 +163,11 @@ export function createPageConfig (component: React.ComponentClass, pageName?: st
       Current.page = null
       Current.router = null
       const path = getPath(id, this.options)
+      
+      raf(() => {
+        eventCenter.trigger(getOnHideEventKey(id))
+      })
+
       safeExecute(path, 'onHide')
     },
     onPullDownRefresh () {

--- a/packages/taro-runtime/src/dsl/common.ts
+++ b/packages/taro-runtime/src/dsl/common.ts
@@ -110,7 +110,7 @@ export function createPageConfig (component: React.ComponentClass, pageName?: st
         path: addLeadingSlash(this.route || this.__route__),
         onReady: getOnReadyEventKey(id),
         onShow: getOnShowEventKey(id),
-        onHide: getOnHideEventKey(id),
+        onHide: getOnHideEventKey(id)
       }
 
       Current.app!.mount!(component, path, () => {
@@ -150,7 +150,7 @@ export function createPageConfig (component: React.ComponentClass, pageName?: st
         path: addLeadingSlash(this.route || this.__route__),
         onReady: getOnReadyEventKey(id),
         onShow: getOnShowEventKey(id),
-        onHide: getOnHideEventKey(id),
+        onHide: getOnHideEventKey(id)
       }
 
       raf(() => {
@@ -163,7 +163,7 @@ export function createPageConfig (component: React.ComponentClass, pageName?: st
       Current.page = null
       Current.router = null
       const path = getPath(id, this.options)
-      
+
       raf(() => {
         eventCenter.trigger(getOnHideEventKey(id))
       })

--- a/packages/taro-webpack-runner/__tests__/__snapshots__/babel.spec.ts.snap
+++ b/packages/taro-webpack-runner/__tests__/__snapshots__/babel.spec.ts.snap
@@ -21058,6 +21058,12 @@ Element.remove()
     function getOnReadyEventKey(path) {
         return path + \\".\\" + \\"onReady\\";
     }
+    function getOnShowEventKey(path) {
+        return path + \\".\\" + \\"onShow\\";
+    }
+    function getOnHideEventKey(path) {
+        return path + \\".\\" + \\"onHide\\";
+    }
     function createPageConfig(component, pageName, data) {
         var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
         var pageElement = null;
@@ -21069,7 +21075,9 @@ Element.remove()
                 Current.router = {
                     \\"params\\": options,
                     \\"path\\": addLeadingSlash(this.route || this.__route__),
-                    \\"onReady\\": getOnReadyEventKey(path)
+                    \\"onReady\\": getOnReadyEventKey(id),
+                    \\"onShow\\": getOnShowEventKey(id),
+                    \\"onHide\\": getOnHideEventKey(id)
                 };
                 Current.app.mount(component, path, (function() {
                     pageElement = document$1.getElementById(path);
@@ -21084,7 +21092,7 @@ Element.remove()
             \\"onReady\\": function onReady() {
                 var path = getPath(id, this.options);
                 raf((function() {
-                    eventCenter.trigger(getOnReadyEventKey(path));
+                    eventCenter.trigger(getOnReadyEventKey(id));
                 }));
                 safeExecute(path, \\"onReady\\");
             },
@@ -21102,14 +21110,22 @@ Element.remove()
                 Current.router = {
                     \\"params\\": this.options,
                     \\"path\\": addLeadingSlash(this.route || this.__route__),
-                    \\"onReady\\": getOnReadyEventKey(path)
+                    \\"onReady\\": getOnReadyEventKey(id),
+                    \\"onShow\\": getOnShowEventKey(id),
+                    \\"onHide\\": getOnHideEventKey(id)
                 };
+                raf((function() {
+                    eventCenter.trigger(getOnShowEventKey(id));
+                }));
                 safeExecute(path, \\"onShow\\");
             },
             \\"onHide\\": function onHide() {
                 Current.page = null;
                 Current.router = null;
                 var path = getPath(id, this.options);
+                raf((function() {
+                    eventCenter.trigger(getOnHideEventKey(id));
+                }));
                 safeExecute(path, \\"onHide\\");
             },
             \\"onPullDownRefresh\\": function onPullDownRefresh() {

--- a/packages/taro-webpack-runner/__tests__/__snapshots__/css-modules.spec.ts.snap
+++ b/packages/taro-webpack-runner/__tests__/__snapshots__/css-modules.spec.ts.snap
@@ -21082,6 +21082,12 @@ Element.remove()
     function getOnReadyEventKey(path) {
         return path + \\".\\" + \\"onReady\\";
     }
+    function getOnShowEventKey(path) {
+        return path + \\".\\" + \\"onShow\\";
+    }
+    function getOnHideEventKey(path) {
+        return path + \\".\\" + \\"onHide\\";
+    }
     function createPageConfig(component, pageName, data) {
         var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
         var pageElement = null;
@@ -21093,7 +21099,9 @@ Element.remove()
                 Current.router = {
                     \\"params\\": options,
                     \\"path\\": addLeadingSlash(this.route || this.__route__),
-                    \\"onReady\\": getOnReadyEventKey(path)
+                    \\"onReady\\": getOnReadyEventKey(id),
+                    \\"onShow\\": getOnShowEventKey(id),
+                    \\"onHide\\": getOnHideEventKey(id)
                 };
                 Current.app.mount(component, path, (function() {
                     pageElement = document$1.getElementById(path);
@@ -21108,7 +21116,7 @@ Element.remove()
             \\"onReady\\": function onReady() {
                 var path = getPath(id, this.options);
                 raf((function() {
-                    eventCenter.trigger(getOnReadyEventKey(path));
+                    eventCenter.trigger(getOnReadyEventKey(id));
                 }));
                 safeExecute(path, \\"onReady\\");
             },
@@ -21126,14 +21134,22 @@ Element.remove()
                 Current.router = {
                     \\"params\\": this.options,
                     \\"path\\": addLeadingSlash(this.route || this.__route__),
-                    \\"onReady\\": getOnReadyEventKey(path)
+                    \\"onReady\\": getOnReadyEventKey(id),
+                    \\"onShow\\": getOnShowEventKey(id),
+                    \\"onHide\\": getOnHideEventKey(id)
                 };
+                raf((function() {
+                    eventCenter.trigger(getOnShowEventKey(id));
+                }));
                 safeExecute(path, \\"onShow\\");
             },
             \\"onHide\\": function onHide() {
                 Current.page = null;
                 Current.router = null;
                 var path = getPath(id, this.options);
+                raf((function() {
+                    eventCenter.trigger(getOnHideEventKey(id));
+                }));
                 safeExecute(path, \\"onHide\\");
             },
             \\"onPullDownRefresh\\": function onPullDownRefresh() {
@@ -63543,6 +63559,12 @@ Element.remove()
     function getOnReadyEventKey(path) {
         return path + \\".\\" + \\"onReady\\";
     }
+    function getOnShowEventKey(path) {
+        return path + \\".\\" + \\"onShow\\";
+    }
+    function getOnHideEventKey(path) {
+        return path + \\".\\" + \\"onHide\\";
+    }
     function createPageConfig(component, pageName, data) {
         var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
         var pageElement = null;
@@ -63554,7 +63576,9 @@ Element.remove()
                 Current.router = {
                     \\"params\\": options,
                     \\"path\\": addLeadingSlash(this.route || this.__route__),
-                    \\"onReady\\": getOnReadyEventKey(path)
+                    \\"onReady\\": getOnReadyEventKey(id),
+                    \\"onShow\\": getOnShowEventKey(id),
+                    \\"onHide\\": getOnHideEventKey(id)
                 };
                 Current.app.mount(component, path, (function() {
                     pageElement = document$1.getElementById(path);
@@ -63569,7 +63593,7 @@ Element.remove()
             \\"onReady\\": function onReady() {
                 var path = getPath(id, this.options);
                 raf((function() {
-                    eventCenter.trigger(getOnReadyEventKey(path));
+                    eventCenter.trigger(getOnReadyEventKey(id));
                 }));
                 safeExecute(path, \\"onReady\\");
             },
@@ -63587,14 +63611,22 @@ Element.remove()
                 Current.router = {
                     \\"params\\": this.options,
                     \\"path\\": addLeadingSlash(this.route || this.__route__),
-                    \\"onReady\\": getOnReadyEventKey(path)
+                    \\"onReady\\": getOnReadyEventKey(id),
+                    \\"onShow\\": getOnShowEventKey(id),
+                    \\"onHide\\": getOnHideEventKey(id)
                 };
+                raf((function() {
+                    eventCenter.trigger(getOnShowEventKey(id));
+                }));
                 safeExecute(path, \\"onShow\\");
             },
             \\"onHide\\": function onHide() {
                 Current.page = null;
                 Current.router = null;
                 var path = getPath(id, this.options);
+                raf((function() {
+                    eventCenter.trigger(getOnHideEventKey(id));
+                }));
                 safeExecute(path, \\"onHide\\");
             },
             \\"onPullDownRefresh\\": function onPullDownRefresh() {

--- a/packages/taro-webpack-runner/__tests__/__snapshots__/nerv.spec.ts.snap
+++ b/packages/taro-webpack-runner/__tests__/__snapshots__/nerv.spec.ts.snap
@@ -21066,6 +21066,12 @@ Element.remove()
     function getOnReadyEventKey(path) {
         return path + \\".\\" + \\"onReady\\";
     }
+    function getOnShowEventKey(path) {
+        return path + \\".\\" + \\"onShow\\";
+    }
+    function getOnHideEventKey(path) {
+        return path + \\".\\" + \\"onHide\\";
+    }
     function createPageConfig(component, pageName, data) {
         var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
         var pageElement = null;
@@ -21077,7 +21083,9 @@ Element.remove()
                 Current.router = {
                     \\"params\\": options,
                     \\"path\\": addLeadingSlash(this.route || this.__route__),
-                    \\"onReady\\": getOnReadyEventKey(path)
+                    \\"onReady\\": getOnReadyEventKey(id),
+                    \\"onShow\\": getOnShowEventKey(id),
+                    \\"onHide\\": getOnHideEventKey(id)
                 };
                 Current.app.mount(component, path, (function() {
                     pageElement = document$1.getElementById(path);
@@ -21092,7 +21100,7 @@ Element.remove()
             \\"onReady\\": function onReady() {
                 var path = getPath(id, this.options);
                 raf((function() {
-                    eventCenter.trigger(getOnReadyEventKey(path));
+                    eventCenter.trigger(getOnReadyEventKey(id));
                 }));
                 safeExecute(path, \\"onReady\\");
             },
@@ -21110,14 +21118,22 @@ Element.remove()
                 Current.router = {
                     \\"params\\": this.options,
                     \\"path\\": addLeadingSlash(this.route || this.__route__),
-                    \\"onReady\\": getOnReadyEventKey(path)
+                    \\"onReady\\": getOnReadyEventKey(id),
+                    \\"onShow\\": getOnShowEventKey(id),
+                    \\"onHide\\": getOnHideEventKey(id)
                 };
+                raf((function() {
+                    eventCenter.trigger(getOnShowEventKey(id));
+                }));
                 safeExecute(path, \\"onShow\\");
             },
             \\"onHide\\": function onHide() {
                 Current.page = null;
                 Current.router = null;
                 var path = getPath(id, this.options);
+                raf((function() {
+                    eventCenter.trigger(getOnHideEventKey(id));
+                }));
                 safeExecute(path, \\"onHide\\");
             },
             \\"onPullDownRefresh\\": function onPullDownRefresh() {

--- a/packages/taro-webpack-runner/__tests__/__snapshots__/react.spec.ts.snap
+++ b/packages/taro-webpack-runner/__tests__/__snapshots__/react.spec.ts.snap
@@ -21065,6 +21065,12 @@ Element.remove()
     function getOnReadyEventKey(path) {
         return path + \\".\\" + \\"onReady\\";
     }
+    function getOnShowEventKey(path) {
+        return path + \\".\\" + \\"onShow\\";
+    }
+    function getOnHideEventKey(path) {
+        return path + \\".\\" + \\"onHide\\";
+    }
     function createPageConfig(component, pageName, data) {
         var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
         var pageElement = null;
@@ -21076,7 +21082,9 @@ Element.remove()
                 Current.router = {
                     \\"params\\": options,
                     \\"path\\": addLeadingSlash(this.route || this.__route__),
-                    \\"onReady\\": getOnReadyEventKey(path)
+                    \\"onReady\\": getOnReadyEventKey(id),
+                    \\"onShow\\": getOnShowEventKey(id),
+                    \\"onHide\\": getOnHideEventKey(id)
                 };
                 Current.app.mount(component, path, (function() {
                     pageElement = document$1.getElementById(path);
@@ -21091,7 +21099,7 @@ Element.remove()
             \\"onReady\\": function onReady() {
                 var path = getPath(id, this.options);
                 raf((function() {
-                    eventCenter.trigger(getOnReadyEventKey(path));
+                    eventCenter.trigger(getOnReadyEventKey(id));
                 }));
                 safeExecute(path, \\"onReady\\");
             },
@@ -21109,14 +21117,22 @@ Element.remove()
                 Current.router = {
                     \\"params\\": this.options,
                     \\"path\\": addLeadingSlash(this.route || this.__route__),
-                    \\"onReady\\": getOnReadyEventKey(path)
+                    \\"onReady\\": getOnReadyEventKey(id),
+                    \\"onShow\\": getOnShowEventKey(id),
+                    \\"onHide\\": getOnHideEventKey(id)
                 };
+                raf((function() {
+                    eventCenter.trigger(getOnShowEventKey(id));
+                }));
                 safeExecute(path, \\"onShow\\");
             },
             \\"onHide\\": function onHide() {
                 Current.page = null;
                 Current.router = null;
                 var path = getPath(id, this.options);
+                raf((function() {
+                    eventCenter.trigger(getOnHideEventKey(id));
+                }));
                 safeExecute(path, \\"onHide\\");
             },
             \\"onPullDownRefresh\\": function onPullDownRefresh() {

--- a/packages/taro-webpack-runner/__tests__/__snapshots__/subpackages.spec.ts.snap
+++ b/packages/taro-webpack-runner/__tests__/__snapshots__/subpackages.spec.ts.snap
@@ -21335,6 +21335,12 @@ Element.remove()
     function getOnReadyEventKey(path) {
         return path + \\".\\" + \\"onReady\\";
     }
+    function getOnShowEventKey(path) {
+        return path + \\".\\" + \\"onShow\\";
+    }
+    function getOnHideEventKey(path) {
+        return path + \\".\\" + \\"onHide\\";
+    }
     function createPageConfig(component, pageName, data) {
         var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
         var pageElement = null;
@@ -21346,7 +21352,9 @@ Element.remove()
                 Current.router = {
                     \\"params\\": options,
                     \\"path\\": addLeadingSlash(this.route || this.__route__),
-                    \\"onReady\\": getOnReadyEventKey(path)
+                    \\"onReady\\": getOnReadyEventKey(id),
+                    \\"onShow\\": getOnShowEventKey(id),
+                    \\"onHide\\": getOnHideEventKey(id)
                 };
                 Current.app.mount(component, path, (function() {
                     pageElement = document$1.getElementById(path);
@@ -21361,7 +21369,7 @@ Element.remove()
             \\"onReady\\": function onReady() {
                 var path = getPath(id, this.options);
                 raf((function() {
-                    eventCenter.trigger(getOnReadyEventKey(path));
+                    eventCenter.trigger(getOnReadyEventKey(id));
                 }));
                 safeExecute(path, \\"onReady\\");
             },
@@ -21379,14 +21387,22 @@ Element.remove()
                 Current.router = {
                     \\"params\\": this.options,
                     \\"path\\": addLeadingSlash(this.route || this.__route__),
-                    \\"onReady\\": getOnReadyEventKey(path)
+                    \\"onReady\\": getOnReadyEventKey(id),
+                    \\"onShow\\": getOnShowEventKey(id),
+                    \\"onHide\\": getOnHideEventKey(id)
                 };
+                raf((function() {
+                    eventCenter.trigger(getOnShowEventKey(id));
+                }));
                 safeExecute(path, \\"onShow\\");
             },
             \\"onHide\\": function onHide() {
                 Current.page = null;
                 Current.router = null;
                 var path = getPath(id, this.options);
+                raf((function() {
+                    eventCenter.trigger(getOnHideEventKey(id));
+                }));
                 safeExecute(path, \\"onHide\\");
             },
             \\"onPullDownRefresh\\": function onPullDownRefresh() {

--- a/packages/taro-webpack-runner/__tests__/__snapshots__/ts.spec.ts.snap
+++ b/packages/taro-webpack-runner/__tests__/__snapshots__/ts.spec.ts.snap
@@ -21068,6 +21068,12 @@ Element.remove()
     function getOnReadyEventKey(path) {
         return path + \\".\\" + \\"onReady\\";
     }
+    function getOnShowEventKey(path) {
+        return path + \\".\\" + \\"onShow\\";
+    }
+    function getOnHideEventKey(path) {
+        return path + \\".\\" + \\"onHide\\";
+    }
     function createPageConfig(component, pageName, data) {
         var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
         var pageElement = null;
@@ -21079,7 +21085,9 @@ Element.remove()
                 Current.router = {
                     \\"params\\": options,
                     \\"path\\": addLeadingSlash(this.route || this.__route__),
-                    \\"onReady\\": getOnReadyEventKey(path)
+                    \\"onReady\\": getOnReadyEventKey(id),
+                    \\"onShow\\": getOnShowEventKey(id),
+                    \\"onHide\\": getOnHideEventKey(id)
                 };
                 Current.app.mount(component, path, (function() {
                     pageElement = document$1.getElementById(path);
@@ -21094,7 +21102,7 @@ Element.remove()
             \\"onReady\\": function onReady() {
                 var path = getPath(id, this.options);
                 raf((function() {
-                    eventCenter.trigger(getOnReadyEventKey(path));
+                    eventCenter.trigger(getOnReadyEventKey(id));
                 }));
                 safeExecute(path, \\"onReady\\");
             },
@@ -21112,14 +21120,22 @@ Element.remove()
                 Current.router = {
                     \\"params\\": this.options,
                     \\"path\\": addLeadingSlash(this.route || this.__route__),
-                    \\"onReady\\": getOnReadyEventKey(path)
+                    \\"onReady\\": getOnReadyEventKey(id),
+                    \\"onShow\\": getOnShowEventKey(id),
+                    \\"onHide\\": getOnHideEventKey(id)
                 };
+                raf((function() {
+                    eventCenter.trigger(getOnShowEventKey(id));
+                }));
                 safeExecute(path, \\"onShow\\");
             },
             \\"onHide\\": function onHide() {
                 Current.page = null;
                 Current.router = null;
                 var path = getPath(id, this.options);
+                raf((function() {
+                    eventCenter.trigger(getOnHideEventKey(id));
+                }));
                 safeExecute(path, \\"onHide\\");
             },
             \\"onPullDownRefresh\\": function onPullDownRefresh() {

--- a/packages/taro-webpack-runner/__tests__/__snapshots__/vue.spec.ts.snap
+++ b/packages/taro-webpack-runner/__tests__/__snapshots__/vue.spec.ts.snap
@@ -20949,6 +20949,12 @@ Element.remove()
     function getOnReadyEventKey(path) {
         return path + \\".\\" + \\"onReady\\";
     }
+    function getOnShowEventKey(path) {
+        return path + \\".\\" + \\"onShow\\";
+    }
+    function getOnHideEventKey(path) {
+        return path + \\".\\" + \\"onHide\\";
+    }
     function createPageConfig(component, pageName, data) {
         var id = pageName !== null && pageName !== void 0 ? pageName : \\"taro_page_\\".concat(pageId());
         var pageElement = null;
@@ -20960,7 +20966,9 @@ Element.remove()
                 Current.router = {
                     \\"params\\": options,
                     \\"path\\": addLeadingSlash(this.route || this.__route__),
-                    \\"onReady\\": getOnReadyEventKey(path)
+                    \\"onReady\\": getOnReadyEventKey(id),
+                    \\"onShow\\": getOnShowEventKey(id),
+                    \\"onHide\\": getOnHideEventKey(id)
                 };
                 Current.app.mount(component, path, (function() {
                     pageElement = document$1.getElementById(path);
@@ -20975,7 +20983,7 @@ Element.remove()
             \\"onReady\\": function onReady() {
                 var path = getPath(id, this.options);
                 raf((function() {
-                    eventCenter.trigger(getOnReadyEventKey(path));
+                    eventCenter.trigger(getOnReadyEventKey(id));
                 }));
                 safeExecute(path, \\"onReady\\");
             },
@@ -20993,14 +21001,22 @@ Element.remove()
                 Current.router = {
                     \\"params\\": this.options,
                     \\"path\\": addLeadingSlash(this.route || this.__route__),
-                    \\"onReady\\": getOnReadyEventKey(path)
+                    \\"onReady\\": getOnReadyEventKey(id),
+                    \\"onShow\\": getOnShowEventKey(id),
+                    \\"onHide\\": getOnHideEventKey(id)
                 };
+                raf((function() {
+                    eventCenter.trigger(getOnShowEventKey(id));
+                }));
                 safeExecute(path, \\"onShow\\");
             },
             \\"onHide\\": function onHide() {
                 Current.page = null;
                 Current.router = null;
                 var path = getPath(id, this.options);
+                raf((function() {
+                    eventCenter.trigger(getOnHideEventKey(id));
+                }));
                 safeExecute(path, \\"onHide\\");
             },
             \\"onPullDownRefresh\\": function onPullDownRefresh() {

--- a/packages/taro/types/taro.extend.d.ts
+++ b/packages/taro/types/taro.extend.d.ts
@@ -110,6 +110,8 @@ declare namespace Taro {
     app: AppInstance | null,
     router: RouterInfo | null,
     page: PageInstance | null,
-    onReady: string
+    onReady: string,
+    onHide: string,
+    onShow: string
   }
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

增加了onShow onHide 事件
事件的key 使用了页面的path没有带参数

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [x] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [ ] 百度小程序
- [x] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
