### PR TITLE
feat(h5): uploadFile可配置withCredentials

### DIFF
--- a/docs/apis/network/upload/uploadFile.md
+++ b/docs/apis/network/upload/uploadFile.md
@@ -87,6 +87,12 @@ sidebar_label: uploadFile
       <td style="text-align:center">否</td>
       <td>接口调用成功的回调函数</td>
     </tr>
+    <tr>
+      <td>withCredentials</td>
+      <td><code>boolean</code></td>
+      <td style="text-align:center">否</td>
+      <td>（仅H5）表示跨域请求时是否需要使用凭证</td>
+    </tr>
   </tbody>
 </table>
 

--- a/packages/taro-h5/src/api/fileTransfer/uploadFile.js
+++ b/packages/taro-h5/src/api/fileTransfer/uploadFile.js
@@ -1,7 +1,7 @@
 import { createCallbackManager } from '../utils'
 import { convertObjectUrlToBlob, NETWORK_TIMEOUT, setHeader, XHR_STATS } from './utils'
 
-const createUploadTask = ({ url, filePath, fileName, formData, name, header, success, error }) => {
+const createUploadTask = ({ url, filePath, fileName, formData, name, header, success, error, withCredentials }) => {
   let timeout
   let formKey
   const apiName = 'uploadFile'
@@ -12,7 +12,7 @@ const createUploadTask = ({ url, filePath, fileName, formData, name, header, suc
     progressUpdate: createCallbackManager()
   }
 
-  xhr.withCredentials = true
+  xhr.withCredentials = withCredentials
 
   xhr.open('POST', url)
   setHeader(xhr, header)
@@ -140,9 +140,10 @@ const createUploadTask = ({ url, filePath, fileName, formData, name, header, suc
  * @param {function} [object.success] 接口调用成功的回调函数
  * @param {function} [object.fail] 接口调用失败的回调函数
  * @param {function} [object.complete] 接口调用结束的回调函数（调用成功、失败都会执行）
+ * @param {Boolean} [object.withCredentials] （仅H5）表示跨域请求时是否需要使用凭证
  * @returns {UploadTask}
  */
-const uploadFile = ({ url, filePath, fileName, name, header, formData, success, fail, complete }) => {
+const uploadFile = ({ url, filePath, fileName, name, header, formData, success, fail, complete, withCredentials }) => {
   let task
   const promise = new Promise((resolve, reject) => {
     task = createUploadTask({

--- a/packages/taro-h5/src/api/fileTransfer/uploadFile.js
+++ b/packages/taro-h5/src/api/fileTransfer/uploadFile.js
@@ -143,7 +143,7 @@ const createUploadTask = ({ url, filePath, fileName, formData, name, header, suc
  * @param {Boolean} [object.withCredentials] （仅H5）表示跨域请求时是否需要使用凭证
  * @returns {UploadTask}
  */
-const uploadFile = ({ url, filePath, fileName, name, header, formData, success, fail, complete, withCredentials }) => {
+const uploadFile = ({ url, filePath, fileName, name, header, formData, success, fail, complete, withCredentials = true }) => {
   let task
   const promise = new Promise((resolve, reject) => {
     task = createUploadTask({
@@ -162,7 +162,8 @@ const uploadFile = ({ url, filePath, fileName, name, header, formData, success, 
         fail && fail(res)
         complete && complete(res)
         reject(res)
-      }
+      },
+      withCredentials
     })
   })
 

--- a/packages/taro/types/api/network/upload.d.ts
+++ b/packages/taro/types/api/network/upload.d.ts
@@ -25,6 +25,8 @@ declare namespace Taro {
       success?: (
         result: SuccessCallbackResult,
       ) => void
+      /** （仅H5）表示跨域请求时是否需要使用凭证 */
+      withCredentials?: boolean
     }
     interface SuccessCallbackResult extends General.CallbackResult {
       /** 开发者服务器返回的数据 */


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
uploadFile可配置withCredentials（仅H5）

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [x] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
当Access-Control-Allow-Origin为*并且withCredentials为true时，会跨域。而上传未能进行配置。因此为uploadFile可配置项withCredentials（仅H5）