### PR TITLE
fix(runtime): html 解析 className 不正确

### DIFF
--- a/packages/taro-cli/yarn.lock
+++ b/packages/taro-cli/yarn.lock
@@ -393,12 +393,16 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.1.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.2.1"
   resolved "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
   dependencies:
     "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
+
+any-promise@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
 
 append-buffer@^1.0.2:
   version "1.0.2"
@@ -1211,6 +1215,17 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
+cli-highlight@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/cli-highlight/-/cli-highlight-2.1.4.tgz#098cb642cf17f42adc1c1145e07f960ec4d7522b"
+  dependencies:
+    chalk "^3.0.0"
+    highlight.js "^9.6.0"
+    mz "^2.4.0"
+    parse5 "^5.1.1"
+    parse5-htmlparser2-tree-adapter "^5.1.1"
+    yargs "^15.0.0"
+
 cli-spinners@^0.1.2:
   version "0.1.2"
   resolved "https://registry.npm.taobao.org/cli-spinners/download/cli-spinners-0.1.2.tgz?cache=0&sync_timestamp=1586157490774&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcli-spinners%2Fdownload%2Fcli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
@@ -1230,6 +1245,14 @@ cliui@^5.0.0:
     string-width "^3.1.0"
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
+
+cliui@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^6.2.0"
 
 clone-buffer@^1.0.0:
   version "1.0.0"
@@ -2425,6 +2448,13 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
+find-up@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
+  dependencies:
+    locate-path "^5.0.0"
+    path-exists "^4.0.0"
+
 find-yarn-workspace-root@1.2.1:
   version "1.2.1"
   resolved "https://registry.npm.taobao.org/find-yarn-workspace-root/download/find-yarn-workspace-root-1.2.1.tgz#40eb8e6e7c2502ddfaa2577c176f221422f860db"
@@ -2882,6 +2912,10 @@ highlight-es@^1.0.0:
     chalk "^2.4.0"
     is-es2016-keyword "^1.0.0"
     js-tokens "^3.0.0"
+
+highlight.js@^9.6.0:
+  version "9.18.1"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.1.tgz#ed21aa001fe6252bb10a3d76d47573c6539fe13c"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -3687,6 +3721,12 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+locate-path@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
+  dependencies:
+    p-locate "^4.1.0"
+
 lodash.toarray@^4.4.0:
   version "4.4.0"
   resolved "https://registry.npm.taobao.org/lodash.toarray/download/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
@@ -3956,6 +3996,14 @@ mute-stream@0.0.7:
 mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.npm.taobao.org/mute-stream/download/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
+
+mz@^2.4.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
+  dependencies:
+    any-promise "^1.0.0"
+    object-assign "^4.0.1"
+    thenify-all "^1.0.0"
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -4265,9 +4313,9 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.0.0:
+p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
-  resolved "https://registry.npm.taobao.org/p-limit/download/p-limit-2.3.0.tgz?cache=0&sync_timestamp=1586101408834&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fp-limit%2Fdownload%2Fp-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   dependencies:
     p-try "^2.0.0"
 
@@ -4282,6 +4330,12 @@ p-locate@^3.0.0:
   resolved "https://registry.npm.taobao.org/p-locate/download/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
   dependencies:
     p-limit "^2.0.0"
+
+p-locate@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
+  dependencies:
+    p-limit "^2.2.0"
 
 p-timeout@^2.0.1:
   version "2.0.1"
@@ -4373,6 +4427,16 @@ parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npm.taobao.org/parse-passwd/download/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
 
+parse5-htmlparser2-tree-adapter@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-5.1.1.tgz#e8c743d4e92194d5293ecde2b08be31e67461cbc"
+  dependencies:
+    parse5 "^5.1.1"
+
+parse5@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
+
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.npm.taobao.org/pascalcase/download/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
@@ -4394,6 +4458,10 @@ path-exists@^2.0.0, path-exists@^2.1.0:
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npm.taobao.org/path-exists/download/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
+
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
 
 path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
@@ -5445,9 +5513,9 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string-width@^4.1.0:
+string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.0"
-  resolved "https://registry.npm.taobao.org/string-width/download/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
   dependencies:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
@@ -5739,6 +5807,18 @@ term-size@^1.2.0:
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npm.taobao.org/text-table/download/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
+thenify-all@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
+  dependencies:
+    thenify ">= 3.1.0 < 4"
+
+"thenify@>= 3.1.0 < 4":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.0.tgz#e69e38a1babe969b0108207978b9f62b88604839"
+  dependencies:
+    any-promise "^1.0.0"
 
 throat@^2.0.2:
   version "2.0.2"
@@ -6253,6 +6333,14 @@ wrap-ansi@^5.1.0:
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
 
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.npm.taobao.org/wrappy/download/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -6339,6 +6427,13 @@ yargs-parser@^13.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^18.1.1:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs@^13.2.2:
   version "13.3.2"
   resolved "https://registry.npm.taobao.org/yargs/download/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
@@ -6353,6 +6448,22 @@ yargs@^13.2.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
+
+yargs@^15.0.0:
+  version "15.3.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.1"
 
 yauzl@^2.4.2:
   version "2.10.0"

--- a/packages/taro-mini-runner/__tests__/__snapshots__/alipay.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/alipay.spec.ts.snap
@@ -8080,7 +8080,7 @@ object-assign
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/babel.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/babel.spec.ts.snap
@@ -7110,7 +7110,7 @@ object-assign
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/bytedance.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/bytedance.spec.ts.snap
@@ -8080,7 +8080,7 @@ object-assign
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/common-style.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/common-style.spec.ts.snap
@@ -7136,7 +7136,7 @@ object-assign
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/config.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/config.spec.ts.snap
@@ -7276,7 +7276,7 @@ object-assign
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {
@@ -16780,7 +16780,7 @@ object-assign
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {
@@ -26288,7 +26288,7 @@ I m irrelevant.
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/css-modules.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/css-modules.spec.ts.snap
@@ -7134,7 +7134,7 @@ object-assign
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {
@@ -16652,7 +16652,7 @@ object-assign
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/custom-tabbar.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/custom-tabbar.spec.ts.snap
@@ -8016,7 +8016,7 @@ h�hځ� �r������Nb2��х��K~��>;;ːL�1�
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/jd.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/jd.spec.ts.snap
@@ -8080,7 +8080,7 @@ object-assign
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/nerv.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/nerv.spec.ts.snap
@@ -2375,7 +2375,7 @@ require(\\"./taro\\");
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/parse-html.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/parse-html.spec.ts.snap
@@ -6979,7 +6979,7 @@ object-assign
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/prerender.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/prerender.spec.ts.snap
@@ -8574,7 +8574,7 @@ object-assign
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {
@@ -19655,7 +19655,7 @@ object-assign
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {
@@ -30688,7 +30688,7 @@ object-assign
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/qq.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/qq.spec.ts.snap
@@ -7700,7 +7700,7 @@ object-assign
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {
@@ -18172,7 +18172,7 @@ object-assign
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/react.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/react.spec.ts.snap
@@ -8080,7 +8080,7 @@ object-assign
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/sass.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/sass.spec.ts.snap
@@ -7117,7 +7117,7 @@ object-assign
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {
@@ -16622,7 +16622,7 @@ object-assign
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {
@@ -26127,7 +26127,7 @@ object-assign
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {
@@ -35632,7 +35632,7 @@ object-assign
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/subpackages.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/subpackages.spec.ts.snap
@@ -7739,7 +7739,7 @@ require(\\"../../sub-utils\\");
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/swan.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/swan.spec.ts.snap
@@ -8080,7 +8080,7 @@ object-assign
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/tabbar.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/tabbar.spec.ts.snap
@@ -7136,7 +7136,7 @@ h�hځ� �r������Nb2��х��K~��>;;ːL�1�
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {
@@ -16717,7 +16717,7 @@ h�hځ� �r������Nb2��х��K~��>;;ːL�1�
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/ts.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/ts.spec.ts.snap
@@ -7120,7 +7120,7 @@ object-assign
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/vue.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/vue.spec.ts.snap
@@ -8052,7 +8052,7 @@ require(\\"./taro\\");
                         var attr = child.attributes[i];
                         var _splitEqual = splitEqual(attr), _splitEqual2 = Object(_babel_runtime_helpers_esm_slicedToArray__WEBPACK_IMPORTED_MODULE_6__[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {

--- a/packages/taro-mini-runner/__tests__/__snapshots__/wx-hybrid.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/wx-hybrid.spec.ts.snap
@@ -7745,7 +7745,7 @@ object-assign
                         const attr = child.attributes[i];
                         const [key, value] = splitEqual(attr);
                         if (key === \\"class\\") {
-                            el.className += el.className;
+                            el.className += \\" \\" + unquote(value);
                         } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                             continue;
                         } else {

--- a/packages/taro-runtime/src/dom/html/parser.ts
+++ b/packages/taro-runtime/src/dom/html/parser.ts
@@ -116,7 +116,7 @@ function format (children: ChildNode[]) {
       const attr = child.attributes[i]
       const [key, value] = splitEqual(attr)
       if (key === 'class') {
-        el.className += el.className
+        el.className += ' ' + unquote(value)
       } else if (key[0] === 'o' && key[1] === 'n') {
         continue
       } else {

--- a/packages/taro-webpack-runner/__tests__/__snapshots__/babel.spec.ts.snap
+++ b/packages/taro-webpack-runner/__tests__/__snapshots__/babel.spec.ts.snap
@@ -19948,7 +19948,7 @@ Element.remove()
                 var attr = child.attributes[i];
                 var _splitEqual = splitEqual(attr), _splitEqual2 = Object(slicedToArray[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                 if (key === \\"class\\") {
-                    el.className += el.className;
+                    el.className += \\" \\" + unquote(value);
                 } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                     continue;
                 } else {

--- a/packages/taro-webpack-runner/__tests__/__snapshots__/css-modules.spec.ts.snap
+++ b/packages/taro-webpack-runner/__tests__/__snapshots__/css-modules.spec.ts.snap
@@ -19972,7 +19972,7 @@ Element.remove()
                 var attr = child.attributes[i];
                 var _splitEqual = splitEqual(attr), _splitEqual2 = Object(slicedToArray[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                 if (key === \\"class\\") {
-                    el.className += el.className;
+                    el.className += \\" \\" + unquote(value);
                 } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                     continue;
                 } else {
@@ -62467,7 +62467,7 @@ Element.remove()
                 var attr = child.attributes[i];
                 var _splitEqual = splitEqual(attr), _splitEqual2 = Object(slicedToArray[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                 if (key === \\"class\\") {
-                    el.className += el.className;
+                    el.className += \\" \\" + unquote(value);
                 } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                     continue;
                 } else {

--- a/packages/taro-webpack-runner/__tests__/__snapshots__/nerv.spec.ts.snap
+++ b/packages/taro-webpack-runner/__tests__/__snapshots__/nerv.spec.ts.snap
@@ -19956,7 +19956,7 @@ Element.remove()
                 var attr = child.attributes[i];
                 var _splitEqual = splitEqual(attr), _splitEqual2 = Object(slicedToArray[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                 if (key === \\"class\\") {
-                    el.className += el.className;
+                    el.className += \\" \\" + unquote(value);
                 } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                     continue;
                 } else {

--- a/packages/taro-webpack-runner/__tests__/__snapshots__/react.spec.ts.snap
+++ b/packages/taro-webpack-runner/__tests__/__snapshots__/react.spec.ts.snap
@@ -19955,7 +19955,7 @@ Element.remove()
                 var attr = child.attributes[i];
                 var _splitEqual = splitEqual(attr), _splitEqual2 = Object(slicedToArray[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                 if (key === \\"class\\") {
-                    el.className += el.className;
+                    el.className += \\" \\" + unquote(value);
                 } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                     continue;
                 } else {

--- a/packages/taro-webpack-runner/__tests__/__snapshots__/subpackages.spec.ts.snap
+++ b/packages/taro-webpack-runner/__tests__/__snapshots__/subpackages.spec.ts.snap
@@ -20225,7 +20225,7 @@ Element.remove()
                 var attr = child.attributes[i];
                 var _splitEqual = splitEqual(attr), _splitEqual2 = Object(slicedToArray[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                 if (key === \\"class\\") {
-                    el.className += el.className;
+                    el.className += \\" \\" + unquote(value);
                 } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                     continue;
                 } else {

--- a/packages/taro-webpack-runner/__tests__/__snapshots__/ts.spec.ts.snap
+++ b/packages/taro-webpack-runner/__tests__/__snapshots__/ts.spec.ts.snap
@@ -19958,7 +19958,7 @@ Element.remove()
                 var attr = child.attributes[i];
                 var _splitEqual = splitEqual(attr), _splitEqual2 = Object(slicedToArray[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                 if (key === \\"class\\") {
-                    el.className += el.className;
+                    el.className += \\" \\" + unquote(value);
                 } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                     continue;
                 } else {

--- a/packages/taro-webpack-runner/__tests__/__snapshots__/vue.spec.ts.snap
+++ b/packages/taro-webpack-runner/__tests__/__snapshots__/vue.spec.ts.snap
@@ -19810,7 +19810,7 @@ Element.remove()
                 var attr = child.attributes[i];
                 var _splitEqual = splitEqual(attr), _splitEqual2 = Object(slicedToArray[\\"a\\"])(_splitEqual, 2), key = _splitEqual2[0], value = _splitEqual2[1];
                 if (key === \\"class\\") {
-                    el.className += el.className;
+                    el.className += \\" \\" + unquote(value);
                 } else if (key[0] === \\"o\\" && key[1] === \\"n\\") {
                     continue;
                 } else {


### PR DESCRIPTION
目前的实现会把 HTML 的 className 设置为 tagName 两次，而忽略了传入的原有 className。
修复之后的 className = tagName + 原有 className