### PR TITLE
fix: 修复微信小程序canvas部分属性类型缺失, 定义Path2D接口

### DIFF
--- a/docs/apis/canvas/Canvas.md
+++ b/docs/apis/canvas/Canvas.md
@@ -9,6 +9,94 @@ Canvas 实例，可通过 SelectorQuery 获取。
 
 ## 方法
 
+<table>
+  <thead>
+    <tr>
+      <th>参数</th>
+      <th>类型</th>
+      <th>说明</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>width</td>
+      <td><code>number</code></td>
+      <td>画布宽度<br />API 支持度: weapp<br /><a href="https://developers.weixin.qq.com/miniprogram/dev/api/canvas/Canvas.html">参考地址</a></td>
+    </tr>
+    <tr>
+      <td>height</td>
+      <td><code>number</code></td>
+      <td>画布高度<br />API 支持度: weapp<br /><a href="https://developers.weixin.qq.com/miniprogram/dev/api/canvas/Canvas.html">参考地址</a></td>
+    </tr>
+  </tbody>
+</table>
+
+### toDataURL
+
+返回一个包含图片展示的 data URI 。可以使用 type 参数其类型，默认为 PNG 格式。
+
+> [参考文档](https://developers.weixin.qq.com/miniprogram/dev/api/canvas/Canvas.toDataURL.html)
+
+```tsx
+(type: string, encoderOptions: number) => string
+```
+
+<table>
+  <thead>
+    <tr>
+      <th>参数</th>
+      <th>类型</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>type</td>
+      <td><code>string</code></td>
+    </tr>
+    <tr>
+      <td>encoderOptions</td>
+      <td><code>number</code></td>
+    </tr>
+  </tbody>
+</table>
+
+#### API 支持度
+
+| API | 微信小程序 | H5 | React Native |
+| :---: | :---: | :---: | :---: |
+| Canvas.toDataURL | ✔️ |  |  |
+
+### createPath2D
+
+创建 Path2D 对象
+
+> [参考文档](https://developers.weixin.qq.com/miniprogram/dev/api/canvas/Canvas.createPath2D.html)
+
+```tsx
+(path: Path2D) => Path2D
+```
+
+<table>
+  <thead>
+    <tr>
+      <th>参数</th>
+      <th>类型</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>path</td>
+      <td><code>Path2D</code></td>
+    </tr>
+  </tbody>
+</table>
+
+#### API 支持度
+
+| API | 微信小程序 | H5 | React Native |
+| :---: | :---: | :---: | :---: |
+| Canvas.createPath2D | ✔️ |  |  |
+
 ### cancelAnimationFrame
 
 取消由 requestAnimationFrame 添加到计划中的动画帧请求。支持在 2D Canvas 和 WebGL Canvas 下使用, 但不支持混用 2D 和 WebGL 的方法。
@@ -140,6 +228,10 @@ Canvas 实例，可通过 SelectorQuery 获取。
 
 | API | 微信小程序 | H5 | React Native |
 | :---: | :---: | :---: | :---: |
+| Canvas.width | ✔️ |  |  |
+| Canvas.height | ✔️ |  |  |
+| Canvas.toDataURL | ✔️ |  |  |
+| Canvas.createPath2D | ✔️ |  |  |
 | Canvas.cancelAnimationFrame | ✔️ |  |  |
 | Canvas.createImageData | ✔️ |  |  |
 | Canvas.createImage | ✔️ |  |  |

--- a/packages/taro/types/api/canvas/Path2D.d.ts
+++ b/packages/taro/types/api/canvas/Path2D.d.ts
@@ -1,0 +1,30 @@
+// https://stackoverflow.com/questions/34109921/using-path2d-in-a-typescript-project-is-not-resolved
+// Class
+interface Path2D {
+	addPath(path: Path2D, transform?: SVGMatrix);
+	closePath(): void;
+	moveTo(x: number, y: number): void;
+	lineTo(x: number, y: number): void;
+	bezierCurveTo(cp1x: number, cp1y: number, cp2x: number, cp2y: number, x: number, y: number): void;
+	quadraticCurveTo(cpx: number, cpy: number, x: number, y: number): void;
+	arc(x: number, y: number, radius: number, startAngle: number, endAngle: number, anticlockwise?: boolean): void;
+	arcTo(x1: number, y1: number, x2: number, y2: number, radius: number): void;
+	/*ellipse(x: number, y: number, radiusX: number, radiusY: number, rotation: number, startAngle: number, endAngle: number, anticlockwise?: boolean): void;*/
+	rect(x: number, y: number, w: number, h: number): void;
+}
+
+// Constructor
+interface Path2DConstructor {
+	new (): Path2D;
+	new (d: string): Path2D;
+	new (path: Path2D, fillRule?: string): Path2D;
+	prototype: Path2D;
+}
+declare var Path2D: Path2DConstructor;
+
+// Extend CanvasRenderingContext2D
+interface CanvasRenderingContext2D {
+	fill(path: Path2D): void;
+	stroke(path: Path2D): void;
+	clip(path: Path2D, fillRule?: string): void;
+}

--- a/packages/taro/types/api/canvas/index.d.ts
+++ b/packages/taro/types/api/canvas/index.d.ts
@@ -223,6 +223,32 @@ declare namespace Taro {
    * @see https://developers.weixin.qq.com/miniprogram/dev/api/canvas/Canvas.html
    */
   interface Canvas {
+		/**
+		 * 画布宽度
+		 * @supported weapp
+		 * @see https://developers.weixin.qq.com/miniprogram/dev/api/canvas/Canvas.html
+		 */
+		width: number
+
+		/**
+		 * 画布高度
+		 * @supported weapp
+		 * @see https://developers.weixin.qq.com/miniprogram/dev/api/canvas/Canvas.html
+		 */
+		height: number
+
+		/** 返回一个包含图片展示的 data URI 。可以使用 type 参数其类型，默认为 PNG 格式。
+		 * @supported weapp
+		 * @see https://developers.weixin.qq.com/miniprogram/dev/api/canvas/Canvas.toDataURL.html
+		 */
+		toDataURL(type: string, encoderOptions: number): string
+
+		/** 创建 Path2D 对象
+		 * @supported weapp
+		 * @see https://developers.weixin.qq.com/miniprogram/dev/api/canvas/Canvas.createPath2D.html
+		 */
+		createPath2D(path: Path2D): Path2D
+
     /** 取消由 requestAnimationFrame 添加到计划中的动画帧请求。支持在 2D Canvas 和 WebGL Canvas 下使用, 但不支持混用 2D 和 WebGL 的方法。
      * @supported weapp
      * @see https://developers.weixin.qq.com/miniprogram/dev/api/canvas/Canvas.cancelAnimationFrame.html


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

修复微信小程序canvas部分属性类型缺失，并且定义Path2D接口

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #6320 
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [x] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [ ] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
