### PR TITLE
refactor(webpack-runner): 同步 2.x 的 sourceMapType 配置项

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
     "type": "node",
     "request": "launch",
     "name": "CLI debug",
-    "program": "${workspaceFolder}/packages/taro-cli/bin/taro-build",
+    "program": "${workspaceFolder}/packages/taro-cli/bin/taro",
     // "cwd": "${project absolute path}",
     // "args": [
     //   "build",

--- a/packages/taro-webpack-runner/src/config/dev.conf.ts
+++ b/packages/taro-webpack-runner/src/config/dev.conf.ts
@@ -37,6 +37,7 @@ export default function (appPath: string, config: Partial<BuildConfig>): any {
     designWidth = 750,
     deviceRatio,
     enableSourceMap = true,
+    sourceMapType,
     enableExtract = false,
 
     defineConstants = emptyObj,
@@ -113,7 +114,7 @@ export default function (appPath: string, config: Partial<BuildConfig>): any {
 
   chain.merge({
     mode,
-    devtool: getDevtool([enableSourceMap]),
+    devtool: getDevtool({ enableSourceMap, sourceMapType }),
     entry,
     output: getOutput(appPath, [{
       outputRoot,

--- a/packages/taro-webpack-runner/src/config/prod.conf.ts
+++ b/packages/taro-webpack-runner/src/config/prod.conf.ts
@@ -36,6 +36,7 @@ export default function (appPath: string, config: Partial<BuildConfig>): any {
     designWidth = 750,
     deviceRatio,
     enableSourceMap = false,
+    sourceMapType,
     enableExtract = true,
 
     defineConstants = emptyObj,
@@ -132,7 +133,7 @@ export default function (appPath: string, config: Partial<BuildConfig>): any {
 
   chain.merge({
     mode,
-    devtool: getDevtool(enableSourceMap),
+    devtool: getDevtool({ enableSourceMap, sourceMapType }),
     entry,
     output: getOutput(appPath, [{
       outputRoot,

--- a/packages/taro-webpack-runner/src/util/chain.ts
+++ b/packages/taro-webpack-runner/src/util/chain.ts
@@ -559,6 +559,6 @@ export const getOutput = (appPath: string, [{ outputRoot, publicPath, chunkDirec
   }
 }
 
-export const getDevtool = enableSourceMap => {
-  return enableSourceMap ? 'cheap-module-eval-source-map' : 'none'
+export const getDevtool = ({ enableSourceMap, sourceMapType = 'cheap-module-eval-source-map' }) => {
+  return enableSourceMap ? sourceMapType : 'none'
 }


### PR DESCRIPTION
**这个 PR 做了什么?**

同步 2.x 的 h5.sourceMapType 配置项

**这个 PR 是什么类型?** (至少选择一个)

- [x] 新功能(Feature)

**这个 PR 满足以下需求:**

- [x] 提交到 next 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
