### PR TITLE
chore(release): publish v3.0.0-rc.4 [auto review]

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -34,6 +34,6 @@
       "license": "MIT"
     }
   },
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "npmClient": "yarn"
 }

--- a/packages/babel-plugin-transform-taroapi/package.json
+++ b/packages/babel-plugin-transform-taroapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-transform-taroapi",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc"

--- a/packages/babel-preset-taro/package.json
+++ b/packages/babel-preset-taro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-taro",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "> TODO: description",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/babel-preset-taro#readme",
@@ -32,8 +32,8 @@
     "@babel/preset-react": "^7.7.4",
     "@babel/preset-typescript": "^7.8.0",
     "@babel/runtime": "^7.7.4",
-    "@tarojs/taro-h5": "3.0.0-rc.3",
-    "babel-plugin-transform-taroapi": "3.0.0-rc.3",
+    "@tarojs/taro-h5": "3.0.0-rc.4",
+    "babel-plugin-transform-taroapi": "3.0.0-rc.4",
     "core-js": "^3.6.3"
   }
 }

--- a/packages/eslint-config-taro/package.json
+++ b/packages/eslint-config-taro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-taro",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "Taro specific linting rules for ESLint",
   "main": "index.js",
   "files": [

--- a/packages/eslint-plugin-taro/package.json
+++ b/packages/eslint-plugin-taro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-taro",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "Taro specific linting plugin for ESLint",
   "main": "index.js",
   "files": [

--- a/packages/postcss-plugin-constparse/package.json
+++ b/packages/postcss-plugin-constparse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-plugin-constparse",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "parse constants defined in config",
   "main": "index.js",
   "author": "Simba",

--- a/packages/postcss-pxtransform/package.json
+++ b/packages/postcss-pxtransform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-pxtransform",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "PostCSS plugin px 转小程序 rpx及h5 rem 单位",
   "keywords": [
     "postcss",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/shared",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "> TODO: description",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/shared#readme",

--- a/packages/taro-api/package.json
+++ b/packages/taro-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/api",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "Taro common API",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/api#readme",
@@ -29,6 +29,6 @@
     "url": "https://github.com/NervJS/taro/issues"
   },
   "dependencies": {
-    "@tarojs/runtime": "3.0.0-rc.3"
+    "@tarojs/runtime": "3.0.0-rc.4"
   }
 }

--- a/packages/taro-cli/package.json
+++ b/packages/taro-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/cli",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "cli tool for taro",
   "main": "index.js",
   "scripts": {
@@ -43,10 +43,10 @@
   "license": "MIT",
   "dependencies": {
     "@hapi/joi": "17.1.1",
-    "@tarojs/helper": "3.0.0-rc.3",
-    "@tarojs/service": "3.0.0-rc.3",
-    "@tarojs/taro": "3.0.0-rc.3",
-    "@tarojs/taroize": "3.0.0-rc.3",
+    "@tarojs/helper": "3.0.0-rc.4",
+    "@tarojs/service": "3.0.0-rc.4",
+    "@tarojs/taro": "3.0.0-rc.4",
+    "@tarojs/taroize": "3.0.0-rc.4",
     "@tarojs/transformer-wx": "^2.0.4",
     "@types/request": "^2.48.1",
     "@typescript-eslint/parser": "^2.0.0",
@@ -74,11 +74,11 @@
     "ejs": "^2.6.1",
     "envinfo": "^6.0.1",
     "eslint": "^6.1.0",
-    "eslint-config-taro": "3.0.0-rc.3",
+    "eslint-config-taro": "3.0.0-rc.4",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-react": "^7.4.0",
     "eslint-plugin-react-hooks": "^1.6.1",
-    "eslint-plugin-taro": "3.0.0-rc.3",
+    "eslint-plugin-taro": "3.0.0-rc.4",
     "eslint-plugin-vue": "^6.2.2",
     "fbjs": "^1.0.0",
     "find-yarn-workspace-root": "1.2.1",
@@ -101,7 +101,7 @@
     "postcss-modules-resolve-imports": "^1.3.0",
     "postcss-modules-scope": "^1.1.0",
     "postcss-modules-values": "^1.3.0",
-    "postcss-pxtransform": "3.0.0-rc.3",
+    "postcss-pxtransform": "3.0.0-rc.4",
     "postcss-reporter": "^6.0.1",
     "postcss-taro-unit-transform": "1.2.15",
     "postcss-url": "^7.3.2",
@@ -122,7 +122,7 @@
     "xxhashjs": "^0.2.2"
   },
   "devDependencies": {
-    "@tarojs/mini-runner": "3.0.0-rc.3",
-    "@tarojs/webpack-runner": "3.0.0-rc.3"
+    "@tarojs/mini-runner": "3.0.0-rc.4",
+    "@tarojs/webpack-runner": "3.0.0-rc.4"
   }
 }

--- a/packages/taro-components/package.json
+++ b/packages/taro-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/components",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "",
   "main:h5": "src/index.js",
   "main": "dist/index.js",
@@ -36,7 +36,7 @@
   "license": "MIT",
   "dependencies": {
     "@stencil/core": "^1.8.1",
-    "@tarojs/taro": "3.0.0-rc.3",
+    "@tarojs/taro": "3.0.0-rc.4",
     "better-scroll": "^1.14.1",
     "classnames": "^2.2.5",
     "intersection-observer": "^0.7.0",

--- a/packages/taro-h5/package.json
+++ b/packages/taro-h5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taro-h5",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "Taro h5 framework",
   "main:h5": "src/index.js",
   "main": "dist/index.cjs.js",
@@ -33,9 +33,9 @@
   "author": "O2Team",
   "license": "MIT",
   "dependencies": {
-    "@tarojs/api": "3.0.0-rc.3",
-    "@tarojs/router": "3.0.0-rc.3",
-    "@tarojs/runtime": "3.0.0-rc.3",
+    "@tarojs/api": "3.0.0-rc.4",
+    "@tarojs/router": "3.0.0-rc.4",
+    "@tarojs/runtime": "3.0.0-rc.4",
     "base64-js": "^1.3.0",
     "jsonp-retry": "^1.0.3",
     "mobile-detect": "^1.4.2",

--- a/packages/taro-helper/package.json
+++ b/packages/taro-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/helper",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "Taro Helper",
   "main": "index.js",
   "types": "types/index.d.ts",
@@ -41,7 +41,7 @@
     "@babel/preset-typescript": "7.9.0",
     "@babel/register": "7.9.0",
     "@babel/runtime": "7.9.2",
-    "@tarojs/taro": "3.0.0-rc.3",
+    "@tarojs/taro": "3.0.0-rc.4",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "chalk": "3.0.0",
     "chokidar": "3.3.1",

--- a/packages/taro-loader/package.json
+++ b/packages/taro-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taro-loader",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "> TODO: description",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-loader#readme",
@@ -32,6 +32,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@tarojs/taro": "3.0.0-rc.3"
+    "@tarojs/taro": "3.0.0-rc.4"
   }
 }

--- a/packages/taro-mini-runner/package.json
+++ b/packages/taro-mini-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/mini-runner",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "Mini app runner for taro",
   "main": "index.js",
   "scripts": {
@@ -36,12 +36,12 @@
     "@babel/core": "7.6.4",
     "@babel/plugin-proposal-class-properties": "7.5.5",
     "@babel/preset-env": "7.6.3",
-    "@tarojs/helper": "3.0.0-rc.3",
-    "@tarojs/runner-utils": "3.0.0-rc.3",
-    "@tarojs/runtime": "3.0.0-rc.3",
-    "@tarojs/shared": "3.0.0-rc.3",
-    "@tarojs/taro": "3.0.0-rc.3",
-    "@tarojs/taro-loader": "3.0.0-rc.3",
+    "@tarojs/helper": "3.0.0-rc.4",
+    "@tarojs/runner-utils": "3.0.0-rc.4",
+    "@tarojs/runtime": "3.0.0-rc.4",
+    "@tarojs/shared": "3.0.0-rc.4",
+    "@tarojs/taro": "3.0.0-rc.4",
+    "@tarojs/taro-loader": "3.0.0-rc.4",
     "babel-loader": "8.0.6",
     "babel-types": "^6.26.0",
     "copy-webpack-plugin": "^5.0.3",
@@ -84,8 +84,8 @@
     "yauzl": "2.10.0"
   },
   "devDependencies": {
-    "@tarojs/components": "3.0.0-rc.3",
-    "@tarojs/react": "3.0.0-rc.3",
-    "babel-preset-taro": "3.0.0-rc.3"
+    "@tarojs/components": "3.0.0-rc.4",
+    "@tarojs/react": "3.0.0-rc.4",
+    "babel-preset-taro": "3.0.0-rc.4"
   }
 }

--- a/packages/taro-react/package.json
+++ b/packages/taro-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/react",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "like react-dom, but for mini apps.",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-react#readme",
@@ -23,7 +23,7 @@
     "url": "https://github.com/NervJS/taro/issues"
   },
   "dependencies": {
-    "@tarojs/runtime": "3.0.0-rc.3",
+    "@tarojs/runtime": "3.0.0-rc.4",
     "react-reconciler": "^0.23.0",
     "scheduler": "^0.17.0"
   },

--- a/packages/taro-router/package.json
+++ b/packages/taro-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/router",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "Taro-router",
   "main:h5": "dist/router.esm.js",
   "main": "dist/index.js",
@@ -27,7 +27,7 @@
   "author": "O2Team",
   "license": "MIT",
   "dependencies": {
-    "@tarojs/runtime": "3.0.0-rc.3",
+    "@tarojs/runtime": "3.0.0-rc.4",
     "history": "^4.10.1",
     "universal-router": "^8.3.0",
     "url-parse": "^1.4.7"

--- a/packages/taro-runner-utils/package.json
+++ b/packages/taro-runner-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/runner-utils",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "Taro runner utilities.",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/core": "^7.8.4",
-    "@tarojs/helper": "3.0.0-rc.3",
+    "@tarojs/helper": "3.0.0-rc.4",
     "chalk": "^3.0.0",
     "fs-extra": "^8.1.0",
     "lodash": "^4.17.15",

--- a/packages/taro-runtime/package.json
+++ b/packages/taro-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/runtime",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "taro runtime for mini apps.",
   "main": "dist/index.js",
   "module": "dist/runtime.esm.js",

--- a/packages/taro-service/package.json
+++ b/packages/taro-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/service",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "Taro Service",
   "main": "index.js",
   "types": "types/index.d.ts",
@@ -33,8 +33,8 @@
   "homepage": "https://github.com/NervJS/taro#readme",
   "dependencies": {
     "@hapi/joi": "17.1.1",
-    "@tarojs/helper": "3.0.0-rc.3",
-    "@tarojs/taro": "3.0.0-rc.3",
+    "@tarojs/helper": "3.0.0-rc.4",
+    "@tarojs/taro": "3.0.0-rc.4",
     "fs-extra": "8.1.0",
     "lodash": "4.17.15",
     "resolve": "1.15.1",

--- a/packages/taro-webpack-runner/package.json
+++ b/packages/taro-webpack-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/webpack-runner",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "webpack runner for taro",
   "main": "index.js",
   "scripts": {
@@ -30,11 +30,11 @@
   "homepage": "https://github.com/NervJS/taro#readme",
   "dependencies": {
     "@babel/core": "7.6.4",
-    "@tarojs/helper": "3.0.0-rc.3",
-    "@tarojs/runner-utils": "3.0.0-rc.3",
-    "@tarojs/runtime": "3.0.0-rc.3",
-    "@tarojs/shared": "3.0.0-rc.3",
-    "@tarojs/taro-loader": "3.0.0-rc.3",
+    "@tarojs/helper": "3.0.0-rc.4",
+    "@tarojs/runner-utils": "3.0.0-rc.4",
+    "@tarojs/runtime": "3.0.0-rc.4",
+    "@tarojs/shared": "3.0.0-rc.4",
+    "@tarojs/taro-loader": "3.0.0-rc.4",
     "autoprefixer": "9.7.4",
     "babel-loader": "8.0.6",
     "copy-webpack-plugin": "5.1.1",
@@ -52,8 +52,8 @@
     "open": "7.0.2",
     "ora": "4.0.3",
     "postcss-loader": "3.0.0",
-    "postcss-plugin-constparse": "3.0.0-rc.3",
-    "postcss-pxtransform": "3.0.0-rc.3",
+    "postcss-plugin-constparse": "3.0.0-rc.4",
+    "postcss-pxtransform": "3.0.0-rc.4",
     "resolve": "1.15.1",
     "resolve-url-loader": "3.1.1",
     "sass": "^1.25.0",
@@ -71,8 +71,8 @@
     "webpack-format-messages": "2.0.3"
   },
   "devDependencies": {
-    "@tarojs/components": "3.0.0-rc.3",
-    "@tarojs/taro": "3.0.0-rc.3",
+    "@tarojs/components": "3.0.0-rc.4",
+    "@tarojs/taro": "3.0.0-rc.4",
     "@types/autoprefixer": "9.7.0",
     "@types/detect-port": "1.1.0",
     "@types/lodash": "4.14.149",
@@ -80,7 +80,7 @@
     "@types/resolve": "1.14.0",
     "@types/webpack": "4.41.6",
     "@types/webpack-dev-server": "3.10.0",
-    "babel-plugin-transform-taroapi": "3.0.0-rc.3",
-    "babel-preset-taro": "3.0.0-rc.3"
+    "babel-plugin-transform-taroapi": "3.0.0-rc.4",
+    "babel-preset-taro": "3.0.0-rc.4"
   }
 }

--- a/packages/taro-with-weapp/package.json
+++ b/packages/taro-with-weapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/with-weapp",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "taroize 之后的运行时",
   "main": "index.js",
   "scripts": {

--- a/packages/taro/package.json
+++ b/packages/taro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taro",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "Taro framework",
   "main": "index.js",
   "main:h5": "h5.js",
@@ -31,10 +31,10 @@
   "author": "O2Team",
   "license": "MIT",
   "dependencies": {
-    "@tarojs/api": "3.0.0-rc.3",
-    "@tarojs/taro-h5": "3.0.0-rc.3"
+    "@tarojs/api": "3.0.0-rc.4",
+    "@tarojs/taro-h5": "3.0.0-rc.4"
   },
   "devDependencies": {
-    "@tarojs/runtime": "3.0.0-rc.3"
+    "@tarojs/runtime": "3.0.0-rc.4"
   }
 }

--- a/packages/taroize/package.json
+++ b/packages/taroize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taroize",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "转换原生微信小程序代码为 Taro 代码",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## 特性

- 新增组件 `slot` 和 `slot-view`，用于原生小程序组件， [文档](https://nervjs.github.io/taro/docs/next/mini-third-party#%E4%BD%BF%E7%94%A8-slot)

## 修复

### H5

- 路由配置支持 `basename`，close #6577
- 路由模式支持 `hash`，close #6228
- 路由配置支持 `customRoutes`
- loader 生成的代码无法在非 ES6 环境下运行，close #6547

### React

- 使用函数式组件作为入口组件不会报错，close #6517

### Vue

- 第三方组件的属性无法使用短横线风格，close #6509

### CLI

- view 模板没有 bindTransitionEnd 事件，close #6558 by @ziruozimi

### Typings

- `Taro.getAccountInfoSync` by @cncolder

## 重构

### Vue

- 默认 import 支持 resolve `.vue` 文件

### H5

- navigate 相关 API 支持 promise 调用