### PR TITLE
fix(type): 修复组件 ref 类型以支持 useRef 用法

### DIFF
--- a/packages/taro-components/types/common.d.ts
+++ b/packages/taro-components/types/common.d.ts
@@ -1,4 +1,4 @@
-import {CSSProperties} from 'react';
+import {CSSProperties, LegacyRef} from 'react';
 
 export type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never })[keyof T]>;
 
@@ -18,7 +18,7 @@ export interface StandardProps extends EventProps {
   /** 动画属性 */
   animation?: { actions: object[] }
   /** 引用 */
-  ref?: string | ((node: any) => any)
+  ref?: LegacyRef<any>
 }
 
 export interface FormItemProps {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

目前组件的 ref 属性传入 useRef 值时类型不匹配.

```tsx
const r = useRef<typeof View>()
const c = <View ref={r} />
```

由于 StandardProps 类型没有传递泛型, 暂时只能用 any.

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [x] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
