### PR TITLE
refactor(runtime): 使用引用代替 Taro hooks 依赖

### DIFF
--- a/packages/taro-runtime/src/dsl/hooks.ts
+++ b/packages/taro-runtime/src/dsl/hooks.ts
@@ -1,12 +1,16 @@
-import type { DependencyList } from 'react'
 import { PageContext, R as React } from './react'
 import { getPageInstance, injectPageInstance } from './common'
 import { PageLifeCycle } from './instance'
 import { Current } from '../current'
 
 const taroHooks = (lifecycle: keyof PageLifeCycle) => {
-  return (fn: Function, deps: DependencyList = []) => {
+  return (fn: Function) => {
     const id = React.useContext(PageContext)
+
+    // hold fn ref and keep up to date
+    const fnRef = React.useRef(fn)
+    if (fnRef.current !== fn) fnRef.current = fn
+
     React.useLayoutEffect(() => {
       let inst = getPageInstance(id)
       let first = false
@@ -17,7 +21,8 @@ const taroHooks = (lifecycle: keyof PageLifeCycle) => {
       if (lifecycle !== 'onShareAppMessage') {
         (inst![lifecycle] as any) = [
           ...((inst![lifecycle] as any) || []),
-          fn.bind(null)
+          // callback is immutable but inner function is up to date
+          (...args: any) => fnRef.current(...args)
         ]
       } else {
         inst![lifecycle] = fn.bind(null)
@@ -25,7 +30,7 @@ const taroHooks = (lifecycle: keyof PageLifeCycle) => {
       if (first) {
         injectPageInstance(inst!, id)
       }
-    }, deps)
+    }, [])
   }
 }
 

--- a/packages/taro-runtime/src/dsl/hooks.ts
+++ b/packages/taro-runtime/src/dsl/hooks.ts
@@ -18,14 +18,16 @@ const taroHooks = (lifecycle: keyof PageLifeCycle) => {
         first = true
         inst = Object.create(null)
       }
+
+      // callback is immutable but inner function is up to date
+      const callback = (...args: any) => fnRef.current(...args)
       if (lifecycle !== 'onShareAppMessage') {
         (inst![lifecycle] as any) = [
           ...((inst![lifecycle] as any) || []),
-          // callback is immutable but inner function is up to date
-          (...args: any) => fnRef.current(...args)
+          callback
         ]
       } else {
-        inst![lifecycle] = fn.bind(null)
+        inst![lifecycle] = callback
       }
       if (first) {
         injectPageInstance(inst!, id)

--- a/packages/taro/types/taro.hooks.d.ts
+++ b/packages/taro/types/taro.hooks.d.ts
@@ -234,35 +234,35 @@ declare namespace Taro {
   /**
    * 页面展示时的回调
    */
-  function useDidShow (callback: () => any, deps?: DependencyList)
+  function useDidShow (callback: () => any): void
   /**
    * 页面隐藏时的回调
    */
-  function useDidHide (callback: () => any, deps?: DependencyList)
+  function useDidHide (callback: () => any): void
   /**
    * 监听用户下拉刷新事件
    */
-  function usePullDownRefresh (callback: () => any, deps?: DependencyList)
+  function usePullDownRefresh (callback: () => any): void
   /**
    * 监听用户上拉触底事件
    */
-  function useReachBottom (callback: () => any, deps?: DependencyList)
+  function useReachBottom (callback: () => any): void
   /**
    * 监听用户滑动页面事件
    */
-  function usePageScroll (callback: (obj: PageScrollObject) => any, deps?: DependencyList)
+  function usePageScroll (callback: (obj: PageScrollObject) => any): void
   /**
    * 小程序屏幕旋转时触发
    */
-  function useResize (callback: (obj: any) => any, deps?: DependencyList)
+  function useResize (callback: (obj: any) => any): void
   /**
    * 监听用户点击页面内转发按钮（button 组件 open-type="share"）或右上角菜单“转发”按钮的行为，并自定义转发内容
    */
-  function useShareAppMessage (callback: (obj: ShareAppMessageObject) => any, deps?: DependencyList)
+  function useShareAppMessage (callback: (obj: ShareAppMessageObject) => any): void
   /**
    * 点击 tab 时触发
    */
-  function useTabItemTap (callback: (obj: TabItemTapObject) => any, deps?: DependencyList)
+  function useTabItemTap (callback: (obj: TabItemTapObject) => any): void
   /**
    * 获取页面传入路由相关参数
    */


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

taro-runtime 中特有的 hooks 一直以来需要传递两个参数, 第一个参数 callback 不会更新, 而第二个参数 deps 会造成 callback 重复执行. 一直以来都是不建议传递第二个参数的.

这个 PR 移除了第二个参数, 使用 `React.useRef` 包装第一个 callback 参数, 从而实现小程序生命周期调用的函数不变, 但内部实际执行的永远是最新的 callback 参数. 这符合 class 组件中的使用方式.

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #6419 
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [x] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [ ] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [x] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [x] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
