### PR TITLE
fix(taro-h5): 修复 previewImage bug，fix #6656

### DIFF
--- a/packages/taro-components/src/components/swiper/swiper.tsx
+++ b/packages/taro-components/src/components/swiper/swiper.tsx
@@ -191,13 +191,15 @@ export class Swiper implements ComponentInterface {
       }
     )
 
+    const hostStyle: Record<string, string> = {}
     const style: Record<string, string> = {}
     if (this.full) {
+      hostStyle.height = '100%'
       style.height = '100%'
     }
 
     return (
-      <Host>
+      <Host style={hostStyle}>
         <div class={cls} style={style}>
           <style type='text/css'>
             {`

--- a/packages/taro-h5/src/api/image/preview_image.js
+++ b/packages/taro-h5/src/api/image/preview_image.js
@@ -27,9 +27,6 @@ export async function previewImage (options) {
   })
 
   const swiper = document.createElement('taro-swiper-core')
-  swiper.indicatorDots = true
-  swiper.indicatorActiveColor = '#777'
-  swiper.indicatorColor = 'rgba(255, 255, 0, .1)'
   swiper.full = true
 
   const { urls = [], current = '' } = options


### PR DESCRIPTION
**这个 PR 做了什么?**

* 修复图片没有居中的问题
* 去掉 indicator

**这个 PR 是什么类型?**

- [x] 错误修复(Bugfix) issue id #6656 

**这个 PR 满足以下需求:**

- [x] 提交到 next 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
