### PR TITLE
fix(rn): RN Image 组件 widthFix 时,部分图片不显示问题

### DIFF
--- a/packages/taro-components-rn/src/components/Image/index.tsx
+++ b/packages/taro-components-rn/src/components/Image/index.tsx
@@ -87,7 +87,9 @@ class _Image extends React.Component<ImageProps, ImageState> {
         layoutWidth
       })
     }
-    this.hasLayout = true
+    if (!!this.state.ratio) {
+      this.hasLayout = true
+    }
   }
 
   loadImg = (props: ImageProps) => {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

> Image 组件在ReactNative端使用时，若 mode 设为 widthFix 则可能导致图片不能显示，其原因是图片高度计算为0。

原因：widthFix 模式下，其高度根据容器宽度`this.state.layoutWidth` 和图片宽高比 `this.state.ratio` 计算所得，而 `onLayout` 函数执行一次后，即标志已渲染完成，此时忽略了 `setState` 是异步执行的，故而导致此时 `ratio` 依然为初始值 0。



**这个 PR 是什么类型?** (至少选择一个)

- [X] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [X] 提交到 master 分支
- [X] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [X] 所有测试用例已经通过
- [X] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [X] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
