### PR TITLE
fix(mini-runner): qq小程序已不存在bindLongTab事件

### DIFF
--- a/packages/shared/src/components.ts
+++ b/packages/shared/src/components.ts
@@ -662,7 +662,7 @@ export function createMiniComponents (components: Components, buildType: string)
           let propValue = component[prop]
           if (prop.startsWith('bind') || specialEvents.has(prop)) {
             prop = isAlipay ? prop.replace('bind', 'on') : prop.toLowerCase()
-            if (buildType === 'weapp' && prop === 'bindlongtap') {
+            if ((buildType === 'weapp' || buildType === 'qq') && prop === 'bindlongtap') {
               prop = 'bindlongpress'
             }
             propValue = 'eh'


### PR DESCRIPTION
[解决QQ小程序bindLongTab不存在的bug，参考这个issues](https://github.com/NervJS/taro/issues/5706#issue-581518178)