### PR TITLE
fix(taro): 修复 @tarojs/taro 未导出 getCurrentInstance 的问题

### DIFF
--- a/packages/taro-api/src/index.js
+++ b/packages/taro-api/src/index.js
@@ -12,6 +12,7 @@ import {
 } from './native-apis'
 import {
   Current,
+  getCurrentInstance,
   useDidShow,
   useDidHide,
   usePullDownRefresh,
@@ -43,6 +44,7 @@ const Taro = {
   Link,
   interceptors,
   Current,
+  getCurrentInstance,
   useDidShow,
   useDidHide,
   usePullDownRefresh,


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
taro3.0.0-rc.5新增了 `getCurrentInstance` api，但这个api无法从 `@tarojs/taro` 中导出，此PR即修复此问题 


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [ ] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
