### PR TITLE
fix(router): navigateBack API支持配置 delta，close #6740

### DIFF
--- a/packages/taro-router/src/api.ts
+++ b/packages/taro-router/src/api.ts
@@ -24,9 +24,7 @@ function navigate (option: Option | NavigateBackOption, method: 'navigateTo' | '
     } else if (method === 'redirectTo') {
       history.replace((option as Option).url)
     } else if (method === 'navigateBack') {
-      for (let i = 0; i < (option as NavigateBackOption).delta; i++) {
-        history.goBack()
-      }
+      history.go(-(option as NavigateBackOption).delta)
     }
   } catch (error) {
     failReason = error

--- a/packages/taro-router/src/api.ts
+++ b/packages/taro-router/src/api.ts
@@ -1,23 +1,32 @@
 import { stacks } from './stack'
 import { history } from './history'
 
-interface Option {
-  url: string
+interface Base {
   success?: Function
   fail?: Function
   complete?: Function
 }
 
-function navigate (option: Option, method: 'navigateTo' | 'redirectTo' | 'navigateBack') {
-  const { url, success, complete, fail } = option
+interface Option extends Base {
+  url: string
+}
+
+interface NavigateBackOption extends Base {
+  delta: number
+}
+
+function navigate (option: Option | NavigateBackOption, method: 'navigateTo' | 'redirectTo' | 'navigateBack') {
+  const { success, complete, fail } = option
   let failReason
   try {
     if (method === 'navigateTo') {
-      history.push(url)
+      history.push((option as Option).url)
     } else if (method === 'redirectTo') {
-      history.replace(url)
+      history.replace((option as Option).url)
     } else if (method === 'navigateBack') {
-      history.goBack()
+      for (let i = 0; i < (option as NavigateBackOption).delta; i++) {
+        history.goBack()
+      }
     }
   } catch (error) {
     failReason = error
@@ -43,7 +52,10 @@ export function redirectTo (option: Option) {
   return navigate(option, 'redirectTo')
 }
 
-export function navigateBack (options: Option) {
+export function navigateBack (options: NavigateBackOption = { delta: 1 }) {
+  if (!options.delta || options.delta < 1) {
+    options.delta = 1
+  }
   return navigate(options, 'navigateBack')
 }
 


### PR DESCRIPTION
**这个 PR 做了什么?**

navigateBack API支持配置 delta

**这个 PR 是什么类型?**

- [x] 错误修复(Bugfix) issue id #6740 

**这个 PR 满足以下需求:**

- [x] 提交到 next 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
