### PR TITLE
fix(cli): 修复 inspect 命令对 config 的整理

### DIFF
--- a/packages/taro-cli/__tests__/inspect.spec.ts
+++ b/packages/taro-cli/__tests__/inspect.spec.ts
@@ -98,17 +98,21 @@ describe('inspect', () => {
     const logSpy = jest.spyOn(console, 'log')
     const errorSpy = jest.spyOn(console, 'error')
 
-    exitSpy.mockImplementation(() => {})
+    exitSpy.mockImplementation(() => {
+      throw new Error()
+    })
     logSpy.mockImplementation(() => {})
     errorSpy.mockImplementation(() => {})
 
-    const appPath = path.resolve(__dirname, 'fixtures/default')
-    await runInspect(appPath, {
-      options: {
-        type: 'h5'
-      },
-      args: ['resolve.mainFields.0']
-    })
+    try {
+      const appPath = path.resolve(__dirname, 'fixtures/default')
+      await runInspect(appPath, {
+        options: {
+          type: 'h5'
+        },
+        args: ['resolve.mainFields.0']
+      })
+    } catch (error) {}
 
     expect(exitSpy).toBeCalledWith(0)
     expect(logSpy).toBeCalledTimes(1)

--- a/packages/taro-cli/src/presets/commands/inspect.ts
+++ b/packages/taro-cli/src/presets/commands/inspect.ts
@@ -30,18 +30,25 @@ export default (ctx: IPluginContext) => {
 
       process.env.TARO_ENV = platform
 
-      const config = getConfig(ctx, platform)
+      let config = getConfig(ctx, platform)
       const isProduction = process.env.NODE_ENV === 'production'
       const outputPath = options.output || options.o
       const mode = outputPath ? 'output' : 'console'
       const extractPath = _[1]
+
+      config = {
+        ...config,
+        ...config[ctx.platforms.get(platform)?.useConfigName || '']
+      }
+      delete config.mini
+      delete config.h5
 
       await ctx.applyPlugins({
         name: platform,
         opts: {
           config: {
             ...config,
-            isWatch: false,
+            isWatch: !isProduction,
             mode: isProduction ? 'production' : 'development',
             async modifyWebpackChain (chain, webpack) {
               await ctx.applyPlugins({

--- a/packages/taro-service/src/Kernel.ts
+++ b/packages/taro-service/src/Kernel.ts
@@ -189,6 +189,7 @@ export default class Kernel extends EventEmitter {
     const kernelApis = [
       'appPath',
       'plugins',
+      'platforms',
       'paths',
       'helper',
       'runOpts',

--- a/packages/taro-service/types/index.d.ts
+++ b/packages/taro-service/types/index.d.ts
@@ -12,6 +12,10 @@ export declare interface IPluginContext {
    */
   plugins: Map<string, IPlugin>
   /**
+   * 获取当前所有挂载的平台
+   */
+  platforms: Map<string, IPlatform>
+  /**
    * 包含当前执行命令的相关路径集合
    */
   paths: IPaths


### PR DESCRIPTION
**这个 PR 做了什么?**

* 目前 inspect 命令对 Taro 项目配置的解析不正确，应该把 mini、h5 里的配置项扁平化。
* isWatch 根据 process.env.NODE_ENV 确定

**这个 PR 是什么类型?**

- [x] 错误修复(Bugfix)

**这个 PR 满足以下需求:**

- [x] 提交到 next 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能
