### PR TITLE
fix(mini-runner): 修复支付宝 picker 报错，fix #6804

### DIFF
--- a/packages/taro-mini-runner/src/template/index.ts
+++ b/packages/taro-mini-runner/src/template/index.ts
@@ -74,9 +74,9 @@ function buildStandardComponentTemplate (comp: Component, level: number, support
   const children = voidElements.has(comp.nodeName)
     ? ''
     : `
-    <${Adapter.type === PLATFORMS.ALIPAY && comp.nodeName === 'picker' ? 'view' : 'block'} ${Adapter.for}="{{i.${Shortcuts.Childnodes}}}" ${Adapter.key}="id">
+    ${Adapter.type === PLATFORMS.ALIPAY && comp.nodeName === 'picker' ? '<view>\n' : ''}<block ${Adapter.for}="{{i.${Shortcuts.Childnodes}}}" ${Adapter.key}="id">
       ${child}
-    </${Adapter.type === PLATFORMS.ALIPAY && comp.nodeName === 'picker' ? 'view' : 'block'}>
+    </block>${Adapter.type === PLATFORMS.ALIPAY && comp.nodeName === 'picker' ? '\n</view>' : ''}
   `
   return `
 <template name="tmpl_${level}_${comp.nodeName}">


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

修复支付宝 picker 报错，支付宝 picker 的 children 只能为一个节点，现在先套一个 view 。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #6804

**这个 PR 满足以下需求:**

- [x] 提交到 next 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [x] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
