### PR TITLE
fix(runtime): 修复百度小程序 input 跳焦问题, fix #6943

### DIFF
--- a/packages/taro-runtime/src/dom/form.ts
+++ b/packages/taro-runtime/src/dom/form.ts
@@ -17,12 +17,14 @@ export class FormElement extends TaroElement {
   }
 
   public dispatchEvent (event: TaroEvent) {
-    if (
-      (event.type === 'input' || event.type === 'change') &&
-      event.mpEvent &&
-      (isString(event.mpEvent.detail.value) || isBoolean(event.mpEvent.detail.value) || isNumber(event.mpEvent.detail.value) || isArray(event.mpEvent.detail.value))
-    ) {
-      this.value = event.mpEvent.detail.value
+    if ((event.type === 'input' || event.type === 'change') && event.mpEvent) {
+      let val = event.mpEvent.detail.value
+      if (isNumber(val) || isArray(val)) {
+        val = JSON.stringify(val)
+      }
+      if (isString(val) || isBoolean(val)) {
+        this.props.value = val as string
+      }
     }
     return super.dispatchEvent(event)
   }


### PR DESCRIPTION
**这个 PR 做了什么?**

修复百度小程序 input 跳焦问题。

表单内容改变时，需要同步 Taro FromElement 的 value 值，但之前是会触发 setData，导致百度表单跳焦点。因此现在改为不触发 setData。

**这个 PR 是什么类型?**

- [x] 错误修复(Bugfix) issue id #6943 

**这个 PR 满足以下需求:**

- [x] 提交到 next 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [x] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
