### PR TITLE
fix(shared): 给 Map 组件的 setting 添加默认值, fix #6949

### DIFF
--- a/packages/shared/src/components.ts
+++ b/packages/shared/src/components.ts
@@ -71,7 +71,7 @@ const Map = {
   'enable-rotate': 'false',
   'enable-satellite': 'false',
   'enable-traffic': 'false',
-  setting: '',
+  setting: '[]',
   bindMarkerTap: '',
   bindLabelTap: '',
   bindControlTap: '',


### PR DESCRIPTION
**这个 PR 做了什么?**

修复微信小程序使用 Map 组件时报错的问题

**这个 PR 是什么类型?**

- [x] 错误修复(Bugfix) issue id #6949 

**这个 PR 满足以下需求:**

- [x] 提交到 next 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
