### PR TITLE
fix(mini-runner): 修复支付宝小程序预渲染报错, fix #7111

### DIFF
--- a/packages/taro-mini-runner/__tests__/__snapshots__/prerender.spec.ts.snap
+++ b/packages/taro-mini-runner/__tests__/__snapshots__/prerender.spec.ts.snap
@@ -80,7 +80,7 @@ require(\\"./taro\\");
 }, [ [ 21, 0, 1, 3, 2 ] ] ]);
 
 
-      if (typeof PRERENDER !== 'undefiend') {
+      if (typeof PRERENDER !== 'undefined') {
         module.exports = global._prerender
       }
 
@@ -2176,7 +2176,7 @@ require(\\"./taro\\");
         __webpack_exports__[\\"a\\"] = region;
     }
 }, [ [ 27, 0, 1, 3, 2 ] ] ]);
-      if (typeof PRERENDER !== 'undefiend') {
+      if (typeof PRERENDER !== 'undefined') {
         module.exports = global._prerender
       }
 
@@ -2299,7 +2299,7 @@ require(\\"./taro\\");
     },
     26: function(module, exports, __webpack_require__) {}
 }, [ [ 25, 0, 1, 3, 2 ] ] ]);
-      if (typeof PRERENDER !== 'undefiend') {
+      if (typeof PRERENDER !== 'undefined') {
         module.exports = global._prerender
       }
 
@@ -2708,7 +2708,7 @@ require(\\"./taro\\");
 }, [ [ 17, 0, 1, 3, 2 ] ] ]);
 
 
-      if (typeof PRERENDER !== 'undefiend') {
+      if (typeof PRERENDER !== 'undefined') {
         module.exports = global._prerender
       }
 
@@ -4800,7 +4800,7 @@ require(\\"./taro\\");
         }).call(this, __webpack_require__(10));
     }
 }, [ [ 23, 0, 1, 3, 2 ] ] ]);
-      if (typeof PRERENDER !== 'undefiend') {
+      if (typeof PRERENDER !== 'undefined') {
         module.exports = global._prerender
       }
 
@@ -4916,7 +4916,7 @@ require(\\"./taro\\");
     },
     22: function(module, exports, __webpack_require__) {}
 }, [ [ 21, 0, 1, 3, 2 ] ] ]);
-      if (typeof PRERENDER !== 'undefiend') {
+      if (typeof PRERENDER !== 'undefined') {
         module.exports = global._prerender
       }
 
@@ -5313,7 +5313,7 @@ require(\\"./taro\\");
 }, [ [ 17, 0, 1, 3, 2 ] ] ]);
 
 
-      if (typeof PRERENDER !== 'undefiend') {
+      if (typeof PRERENDER !== 'undefined') {
         module.exports = global._prerender
       }
 
@@ -7405,7 +7405,7 @@ require(\\"./taro\\");
         }).call(this, __webpack_require__(10));
     }
 }, [ [ 23, 0, 1, 3, 2 ] ] ]);
-      if (typeof PRERENDER !== 'undefiend') {
+      if (typeof PRERENDER !== 'undefined') {
         module.exports = global._prerender
       }
 
@@ -7521,7 +7521,7 @@ require(\\"./taro\\");
     },
     22: function(module, exports, __webpack_require__) {}
 }, [ [ 21, 0, 1, 3, 2 ] ] ]);
-      if (typeof PRERENDER !== 'undefiend') {
+      if (typeof PRERENDER !== 'undefined') {
         module.exports = global._prerender
       }
 

--- a/packages/taro-mini-runner/src/prerender/prerender.ts
+++ b/packages/taro-mini-runner/src/prerender/prerender.ts
@@ -249,7 +249,7 @@ export class Prerender {
     path = this.getRealPath(path)
     return new Promise((resolve) => {
       const s = `
-      if (typeof PRERENDER !== 'undefiend') {
+      if (typeof PRERENDER !== 'undefined') {
         module.exports = global._prerender
       }`
       fs.appendFile(path, s, 'utf8', () => {


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

修复支付宝小程序预渲染报错

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #7111 

**这个 PR 满足以下需求:**

- [x] 提交到 next 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [x] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
