### PR TITLE
fix(taro-mini-runner): 修复babel.transform 未传递 config.filename问题

### DIFF
--- a/packages/taro-mini-runner/src/loaders/wxTransformerLoader.ts
+++ b/packages/taro-mini-runner/src/loaders/wxTransformerLoader.ts
@@ -107,6 +107,7 @@ export default function wxTransformerLoader (source) {
         isUseComponentBuildPage
       })
       const code = generate(result).code
+      babelConfig.filename = filePath;
       const res = transform(code, babelConfig)
       if (NODE_MODULES_REG.test(filePath) && res.code) {
         res.code = npmCodeHack(filePath, res.code)


### PR DESCRIPTION
修复babel.transform 未传递 config.filename 导致插件中无法访问 state.file.opts.filename问题, 同issue #2168

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
正常 babel 插件中应可以通过 state.file.opts.filename 访问到当前编译文件的绝对路径，但是 taro 中调用的 babel 插件中获取的 filename 始终是 unknown, 这个问题在1.x的版本解决了, 但是目前发现在2.x的版本上还是存在该问题。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #2168
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
