### PR TITLE
fix(h5): 修复不支持fetch的浏览器调用request无法返回结果

### DIFF
--- a/packages/taro-h5/src/api/request/index.js
+++ b/packages/taro-h5/src/api/request/index.js
@@ -77,9 +77,9 @@ function _request (options) {
     .then(response => {
       res.statusCode = response.status
       res.header = {}
-      response.headers.forEach((val, key) => {
-        res.header[key] = val
-      })
+      for (const key of response.headers.keys()) {
+        res.header[key] = response.headers.get(key)
+      }
       if (!response.ok) {
         throw response
       }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

在 taro-h5/src/api/request/index.js (80行) 的 response.headers —— 在支持fetch的浏览器其为Map对象，在不支持fetch的浏览器上，通过unfetch/polyfill兼容，其值为普通对象（如下图），不可使用 forEach 进行遍历。
![1](https://user-images.githubusercontent.com/9846146/88454376-ce096480-cea1-11ea-8070-0c183175b63f.png)

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue #7161 
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
