### PR TITLE
修复头条、Vue3 等问题

### DIFF
--- a/packages/taro-mini-runner/src/webpack/vue3.ts
+++ b/packages/taro-mini-runner/src/webpack/vue3.ts
@@ -1,4 +1,5 @@
 import { REG_VUE, chalk } from '@tarojs/helper'
+import * as webpack from 'webpack'
 import { toCamelCase, internalComponents, capitalize } from '@tarojs/shared'
 import { componentConfig } from '../template/component'
 import type { RootNode, TemplateChildNode, ElementNode, AttributeNode, DirectiveNode, SimpleExpressionNode } from '@vue/compiler-core'
@@ -22,6 +23,13 @@ export function customVue3Chain (chain) {
   chain
     .plugin('vueLoaderPlugin')
     .use(VueLoaderPlugin)
+
+  chain
+    .plugin('defined')
+    .use(webpack.DefinePlugin, [{
+      __VUE_OPTIONS_API__: JSON.stringify(true),
+      __VUE_PROD_DEVTOOLS__: JSON.stringify(false)
+    }])
 
   chain.module
     .rule('vue')

--- a/packages/taro-runtime/src/dsl/react.ts
+++ b/packages/taro-runtime/src/dsl/react.ts
@@ -191,54 +191,68 @@ export function createReactApp (App: React.ComponentClass, react: typeof React, 
     }
   }
 
-  class AppConfig implements AppInstance {
-    config = config
-
-    onLaunch (options) {
-      // eslint-disable-next-line react/no-render-return-value
-      wrapper = ReactDOM.render(R.createElement(AppWrapper), document.getElementById('app'))
-      const app = ref.current
-      Current.router = {
-        params: options?.query,
-        ...options
-      }
-      if (app != null && isFunction(app.onLaunch)) {
-        app.onLaunch(options)
-      }
-    }
-
-    onShow (options) {
-      const app = ref.current
-      Current.router = {
-        params: options?.query,
-        ...options
-      }
-      if (app != null && isFunction(app.componentDidShow)) {
-        app.componentDidShow(options)
-      }
-    }
-
-    onHide (options: unknown) {
-      const app = ref.current
-      if (app != null && isFunction(app.componentDidHide)) {
-        app.componentDidHide(options)
-      }
-    }
-
+  const app: AppInstance = Object.create({
     render (cb: () => void) {
       wrapper.forceUpdate(cb)
-    }
+    },
 
     mount (component: ReactPageComponent, id: string, cb: () => void) {
       const page = connectReactPage(R, id)(component)
       wrapper.mount(page, id, cb)
-    }
+    },
 
     unmount (id: string, cb: () => void) {
       wrapper.unmount(id, cb)
     }
-  }
+  }, {
+    config: {
+      writable: true,
+      enumerable: true,
+      configurable: true,
+      value: config
+    },
 
-  Current.app = new AppConfig()
+    onLaunch: {
+      enumerable: true,
+      value (options) {
+        // eslint-disable-next-line react/no-render-return-value
+        wrapper = ReactDOM.render(R.createElement(AppWrapper), document.getElementById('app'))
+        const app = ref.current
+        Current.router = {
+          params: options?.query,
+          ...options
+        }
+        if (app != null && isFunction(app.onLaunch)) {
+          app.onLaunch(options)
+        }
+      }
+    },
+
+    onShow: {
+      enumerable: true,
+      value (options) {
+        const app = ref.current
+        Current.router = {
+          params: options?.query,
+          ...options
+        }
+        if (app != null && isFunction(app.componentDidShow)) {
+          app.componentDidShow(options)
+        }
+      }
+    },
+
+    onHide: {
+      enumerable: true,
+      value (options: unknown) {
+        const app = ref.current
+        if (app != null && isFunction(app.componentDidHide)) {
+          app.componentDidHide(options)
+        }
+      }
+    }
+  })
+
+  Current.app = app
   return Current.app
 }

--- a/packages/taro-runtime/src/dsl/vue.ts
+++ b/packages/taro-runtime/src/dsl/vue.ts
@@ -146,48 +146,62 @@ export function createVueApp (App: VueInstance, vue: V, config: AppConfig) {
     }
   })
 
-  class AppConfig implements AppInstance {
-    config = config
-
-    onLaunch (options) {
-      wrapper.$mount(document.getElementById('app') as any)
-      appInstance = wrapper.$refs.app as VueAppInstance
-      Current.router = {
-        params: options?.query,
-        ...options
-      }
-      if (appInstance != null && isFunction(appInstance.$options.onLaunch)) {
-        appInstance.$options.onLaunch.call(appInstance, options)
-      }
-    }
-
-    onShow (options) {
-      Current.router = {
-        params: options?.query,
-        ...options
-      }
-      if (appInstance != null && isFunction(appInstance.$options.onShow)) {
-        appInstance.$options.onShow.call(appInstance, options)
-      }
-    }
-
-    onHide (options: unknown) {
-      if (appInstance != null && isFunction(appInstance.$options.onHide)) {
-        appInstance.$options.onHide.call(appInstance, options)
-      }
-    }
-
+  const app: AppInstance = Object.create({
     mount (component: ComponentOptions<VueCtor>, id: string, cb: () => void) {
       const page = connectVuePage(Vue, id)(component)
       wrapper.mount(page, id, cb)
-    }
+    },
 
     unmount (id: string, cb: () => void) {
       wrapper.unmount(id, cb)
     }
-  }
+  }, {
+    config: {
+      writable: true,
+      enumerable: true,
+      configurable: true,
+      value: config
+    },
 
-  Current.app = new AppConfig()
+    onLaunch: {
+      enumerable: true,
+      value (options) {
+        wrapper.$mount(document.getElementById('app') as any)
+        appInstance = wrapper.$refs.app as VueAppInstance
+        Current.router = {
+          params: options?.query,
+          ...options
+        }
+        if (appInstance != null && isFunction(appInstance.$options.onLaunch)) {
+          appInstance.$options.onLaunch.call(appInstance, options)
+        }
+      }
+    },
+
+    onShow: {
+      enumerable: true,
+      value (options) {
+        Current.router = {
+          params: options?.query,
+          ...options
+        }
+        if (appInstance != null && isFunction(appInstance.$options.onShow)) {
+          appInstance.$options.onShow.call(appInstance, options)
+        }
+      }
+    },
+
+    onHide: {
+      enumerable: true,
+      value (options) {
+        if (appInstance != null && isFunction(appInstance.$options.onHide)) {
+          appInstance.$options.onHide.call(appInstance, options)
+        }
+      }
+    }
+  })
+
+  Current.app = app
 
   return Current.app
 }

--- a/packages/taro-runtime/src/dsl/vue3.ts
+++ b/packages/taro-runtime/src/dsl/vue3.ts
@@ -1,5 +1,5 @@
 import { isFunction, isArray, ensure, capitalize, toCamelCase, internalComponents, hasOwn, isBooleanStringLiteral } from '@tarojs/shared'
-import { AppInstance } from './instance'
+import { AppInstance, Instance, PageProps } from './instance'
 import { Current } from '../current'
 import { injectPageInstance } from './common'
 import { isBrowser } from '../env'
@@ -18,6 +18,8 @@ import type { Reconciler } from '../reconciler'
 
 function createVue3Page (h: typeof createElement, id: string) {
   return function (component): VNode {
+    // vue3 组件 created 时机比小程序页面 onShow 慢，这里先插入一个实例以响应初始化时的小程序生命周期调用
+    injectPageInstance(({ $options: component } as Instance<PageProps>), id)
     const inject = {
       props: {
         tid: String
@@ -114,51 +116,65 @@ export function createVue3App (app: App<TaroElement>, h: typeof createElement, c
     return pages.slice()
   }
 
-  class AppConfig implements AppInstance {
-    config = config
-
-    onLaunch (options) {
-      Current.router = {
-        params: options?.query,
-        ...options
-      }
-      appInstance = app.mount('#app')
-      const onLaunch = appInstance?.$options?.onLaunch
-      isFunction(onLaunch) && onLaunch.call(appInstance, options)
-    }
-
-    onShow (options) {
-      Current.router = {
-        params: options?.query,
-        ...options
-      }
-      const onShow = appInstance?.$options?.onShow
-      isFunction(onShow) && onShow.call(appInstance, options)
-    }
-
-    onHide (options: unknown) {
-      const onHide = appInstance?.$options?.onHide
-      isFunction(onHide) && onHide.call(appInstance, options)
-    }
-
-    mount = (component: Component, id: string, cb: () => void) => {
+  const appConfig: AppInstance = Object.create({
+    mount (component: Component, id: string, cb: () => void) {
       const page = createVue3Page(h, id)(component)
       pages.push(page)
       this.updateAppInstance(cb)
-    }
+    },
 
-    unmount = (id: string, cb: () => void) => {
+    unmount (id: string, cb: () => void) {
       pages = pages.filter(page => page.key !== id)
       this.updateAppInstance(cb)
-    }
+    },
 
     updateAppInstance (cb?: (() => void | undefined)) {
       appInstance.$forceUpdate()
       appInstance.$nextTick(cb)
     }
-  }
+  }, {
+    config: {
+      writable: true,
+      enumerable: true,
+      configurable: true,
+      value: config
+    },
 
-  Current.app = new AppConfig()
+    onLaunch: {
+      enumerable: true,
+      value (options) {
+        Current.router = {
+          params: options?.query,
+          ...options
+        }
+        appInstance = app.mount('#app')
+        const onLaunch = appInstance?.$options?.onLaunch
+        isFunction(onLaunch) && onLaunch.call(appInstance, options)
+      }
+    },
+
+    onShow: {
+      enumerable: true,
+      value (options) {
+        Current.router = {
+          params: options?.query,
+          ...options
+        }
+        const onShow = appInstance?.$options?.onShow
+        isFunction(onShow) && onShow.call(appInstance, options)
+      }
+    },
+
+    onHide: {
+      enumerable: true,
+      value (options) {
+        const onHide = appInstance?.$options?.onHide
+        isFunction(onHide) && onHide.call(appInstance, options)
+      }
+    }
+  })
+
+  Current.app = appConfig
 
   return Current.app
 }


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

* 字节基础库 1.70+ `App` 构造器不支持传入类实例，这里改为传入使用 Object.create 创建的对象。
* 修复在进入页面时 Vue3 不触发 `onShow` 的问题。
* 兼容 Vue3 3.0.0-rc.3 新增的两个编译配置：`__VUE_OPTIONS_API__` 和 ` __VUE_PROD_DEVTOOLS__`

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #6929 #7143 

**这个 PR 满足以下需求:**

- [x] 提交到 next 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）