### PR TITLE
fix(runtime): 给每个页面的 key 增加一个独立 id，避免 key 重复而报错

### DIFF
--- a/packages/taro-runtime/src/dsl/react.ts
+++ b/packages/taro-runtime/src/dsl/react.ts
@@ -134,7 +134,7 @@ function setReconciler () {
   options.reconciler(hostConfig)
 }
 
-const tabbarId = incrementId()
+const pageKeyId = incrementId()
 
 export function createReactApp (App: React.ComponentClass, react: typeof React, reactdom, config: AppConfig) {
   R = react
@@ -154,10 +154,7 @@ export function createReactApp (App: React.ComponentClass, react: typeof React, 
     private elements: Array<PageComponent> = []
 
     public mount (component: React.ComponentClass<PageProps>, id: string, cb: () => void) {
-      let key = id
-      if (id.startsWith('custom-tab-bar')) {
-        key += tabbarId()
-      }
+      const key = id + pageKeyId()
       const page = () => R.createElement(component, { key, tid: id })
       this.pages.push(page)
       this.forceUpdate(cb)


### PR DESCRIPTION
**这个 PR 做了什么?**

给每个页面的 key 增加一个独立 id，避免 key 重复而报错

两种情况下以 path + options 组成的 key 可能重复：

1. custom-tab-bar
2. Taro 页面 A 使用原生 API 跳转新页面 A'，且不带参，这时 A 与 A' 路径一样，所以会重复。（Taro 跳转API 添加了随机参数，所以不会重复）

**这个 PR 是什么类型?**

- [x] 错误修复(Bugfix)

**这个 PR 满足以下需求:**

- [x] 提交到 next 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）