### PR TITLE
fix(react): 修复使用第三方组件不能触发 onClick 事件的问题，fix #7182

### DIFF
--- a/packages/taro-react/__tests__/props.spec.js
+++ b/packages/taro-react/__tests__/props.spec.js
@@ -64,7 +64,7 @@ describe('Context', () => {
     it('onClick should work like onTap', () => {
       const container = document.createElement('div')
       const spy = jest.fn()
-      render(<div type="button" onClick={spy} />, container)
+      render(<view type="button" onClick={spy} />, container)
       expect('tap' in container.firstChild.__handlers).toBe(true)
     })
 
@@ -72,7 +72,7 @@ describe('Context', () => {
       const createEvent = runtime.createEvent
       const container = document.createElement('div')
       const spy = jest.fn()
-      render(<div type="button" onClick={spy} id='fork' />, container)
+      render(<view type="button" onClick={spy} id='fork' />, container)
       const event = createEvent({ type: 'tap', currentTarget: { id: container.firstChild.uid }, target: { id: container.firstChild.uid } })
       container.firstChild.dispatchEvent(event)
       expect(spy).toBeCalled()

--- a/packages/taro-react/src/props.ts
+++ b/packages/taro-react/src/props.ts
@@ -1,5 +1,5 @@
 import { TaroElement, Style, document, FormElement } from '@tarojs/runtime'
-import { isFunction, isString, isObject, isNumber } from '@tarojs/shared'
+import { isFunction, isString, isObject, isNumber, internalComponents, capitalize, toCamelCase } from '@tarojs/shared'
 import { CommonEvent } from '@tarojs/components'
 
 export type Props = Record<string, unknown>
@@ -39,7 +39,11 @@ function setEvent (dom: TaroElement, name: string, value: unknown, oldValue?: un
     eventName = eventName.slice(0, -7)
   }
 
-  if (eventName === 'click') {
+  const compName = capitalize(toCamelCase(dom.tagName.toLowerCase()))
+
+  console.log('compName: ', compName, compName in internalComponents)
+
+  if (eventName === 'click' && compName in internalComponents) {
     eventName = 'tap'
   }
 

--- a/packages/taro-react/src/props.ts
+++ b/packages/taro-react/src/props.ts
@@ -41,8 +41,6 @@ function setEvent (dom: TaroElement, name: string, value: unknown, oldValue?: un
 
   const compName = capitalize(toCamelCase(dom.tagName.toLowerCase()))
 
-  console.log('compName: ', compName, compName in internalComponents)
-
   if (eventName === 'click' && compName in internalComponents) {
     eventName = 'tap'
   }


### PR DESCRIPTION
**这个 PR 做了什么?**

修复使用原生组件不能触发 `onClick` 事件的问题

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #7182

**这个 PR 满足以下需求:**

- [x] 提交到 next 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）