### PR TITLE
修复 Canvas、Map、Ad 组件

### DIFF
--- a/packages/shared/src/components.ts
+++ b/packages/shared/src/components.ts
@@ -50,12 +50,12 @@ const Map = {
   longitude: '',
   latitude: '',
   scale: '16',
-  markers: '',
+  markers: '[]',
   covers: '',
-  polyline: '',
-  circles: '',
+  polyline: '[]',
+  circles: '[]',
   controls: '',
-  'include-point': 'false',
+  'include-point': '[]',
   'show-location': '',
   polygons: '',
   subkey: '',
@@ -569,7 +569,7 @@ const Video = {
 }
 
 const Canvas = {
-  type: '',
+  type: singleQuote('2d'),
   'canvas-id': '',
   'disable-scroll': 'false',
   bindTouchStart: '',

--- a/packages/shared/src/components.ts
+++ b/packages/shared/src/components.ts
@@ -583,6 +583,8 @@ const Canvas = {
 const Ad = {
   'unit-id': '',
   'ad-intervals': '',
+  'ad-type': singleQuote('banner'),
+  'ad-theme': singleQuote('white'),
   bindLoad: '',
   bindError: '',
   bindClose: ''

--- a/packages/shared/src/components.ts
+++ b/packages/shared/src/components.ts
@@ -55,7 +55,7 @@ const Map = {
   polyline: '[]',
   circles: '[]',
   controls: '',
-  'include-point': '[]',
+  'include-points': '[]',
   'show-location': '',
   polygons: '',
   subkey: '',

--- a/packages/taro-components/src/components/canvas/canvas.tsx
+++ b/packages/taro-components/src/components/canvas/canvas.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { Component, h, ComponentInterface, Prop, State, Element, Event } from '@stencil/core'
+import { Component, h, ComponentInterface, Prop, Element, Event } from '@stencil/core'
 
 const LONG_TAP_DELAY = 500
 
@@ -9,13 +9,8 @@ const LONG_TAP_DELAY = 500
 })
 export class Canvas implements ComponentInterface {
   private timer: NodeJS.Timeout
-  // @Prop() type: '2d' | 'webgl'
-  @Prop() canvasId: string
 
-  @State() width = 300
-  @State() height = 150
-  @State() klass: string
-  @State() css: string
+  @Prop() canvasId: string
 
   @Element() el: HTMLElement
 
@@ -24,26 +19,6 @@ export class Canvas implements ComponentInterface {
   })
 
   onLongTap
-
-  private canvas?: HTMLCanvasElement
-
-  componentDidLoad () {
-    const { width, height } = this.el.getBoundingClientRect()
-    this.width = width
-    this.height = height
-    this.klass = this.el.className
-    this.css = this.el.style.cssText
-  }
-
-  componentDidUpdate () {
-    const { width, height } = this.el.getBoundingClientRect()
-    if (this.width !== width) this.width = width
-    if (this.height !== height) this.height = height
-    if (this.canvas) {
-      this.canvas.className = this.el.className
-      this.canvas.style.cssText = this.el.style.cssText
-    }
-  }
 
   onTouchStart = () => {
     this.timer = setTimeout(() => {
@@ -60,18 +35,15 @@ export class Canvas implements ComponentInterface {
   }
 
   render () {
-    const {
-      canvasId,
-      width,
-      height
-    } = this
+    const { canvasId } = this
 
     return (
       <canvas
         canvas-id={canvasId}
-        ref={node => (this.canvas = node!)}
-        width={width}
-        height={height}
+        style={{
+          width: '100%',
+          height: '100%'
+        }}
         onTouchStart={this.onTouchStart}
         onTouchMove={this.onTouchMove}
         onTouchEnd={this.onTouchEnd}


### PR DESCRIPTION
**这个 PR 做了什么?**

* 修复 H5 Canvas 组件样式问题, fix #6990
* Canvas 的 type 需要默认值 '2d'
* Map 的数组类型需要默认值，否则头条下会报错，fix #7207
* 修复地图组件属性，fix #7178
* 补充 `Ad` 组件确实的属性，fix #7237

**这个 PR 是什么类型?**

- [x] 错误修复(Bugfix) issue id #6990 #7207 #7178 #7237 

**这个 PR 满足以下需求:**

- [x] 提交到 next 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [x] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）