### PR TITLE
修正虚拟列表Vue示例中的数据引用错误

### DIFF
--- a/versioned_docs/version-3.0.5/guide.mdx
+++ b/versioned_docs/version-3.0.5/guide.mdx
@@ -1316,13 +1316,13 @@ Vue.use(VirtualList)
 ```html title="src/components/row.vue"
 <template>
   <thread
-    :key="data.id"
-    :node="data.node"
-    :title="data.title"
-    :last_modified="data.last_modified"
-    :replies="data.replies"
-    :tid="data.id"
-    :member="data.member"
+    :key="thread.id"
+    :node="thread.node"
+    :title="thread.title"
+    :last_modified="thread.last_modified"
+    :replies="thread.replies"
+    :tid="thread.id"
+    :member="thread.member"
   />
 </template>
 
@@ -1332,7 +1332,12 @@ export default {
   components: {
     'thread': Thread
   },
-  props: ['index', 'data', 'css']
+  props: ['index', 'data', 'css'],
+  computed:{
+    thread(){
+      return this.data[this.index]
+    }
+  }
 }
 </script>
 ```


### PR DESCRIPTION

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复了一个文档中的示例代码错误
在虚拟列表中，`itemData` 传入给`item`组件的是一整个数组。而不是数组中的单项。因此在这个示例的Row中，如果直接用传入的`data` 将会引发错误，因为data是一个数组。
因此需要在子组件中对data进一步处理，使用`data[index]` 来获得当前子组件Row应该渲染的单项数据。



**这个 PR 是什么类型?** (至少选择一个)


- [X] 文档修改(Docs)

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [x] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [x] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
