### PR TITLE
fix(runtime):  修复 html 解析器分析属性时对空格的错误处理，fix #6911

### DIFF
--- a/packages/taro-runtime/src/dom/html/parser.ts
+++ b/packages/taro-runtime/src/dom/html/parser.ts
@@ -94,7 +94,9 @@ function splitEqual (str: string) {
   const sep = '='
   const idx = str.indexOf(sep)
   if (idx === -1) return [str]
-  return [str.slice(0, idx), str.slice(idx + sep.length)]
+  const key = str.slice(0, idx).trim()
+  const value = str.slice(idx + sep.length).trim()
+  return [key, value]
 }
 
 function format (children: ChildNode[]) {

--- a/packages/taro-runtime/src/dom/html/scaner.ts
+++ b/packages/taro-runtime/src/dom/html/scaner.ts
@@ -62,6 +62,11 @@ function isWhitespaceChar (char: string) {
   return whitespace.test(char)
 }
 
+const equalSign = /=/
+function isEqualSignChar (char: string) {
+  return equalSign.test(char)
+}
+
 function shouldBeIgnore (tagName: string) {
   const name = tagName.toLowerCase()
   if (options.html.skipElements.has(name)) {
@@ -83,6 +88,30 @@ function findTextEnd (str: string, index: number) {
       return textEnd
     }
     index = textEnd + 1
+  }
+}
+
+function isWordEnd (cursor: number, wordBegin: number, html: string) {
+  if (!isWhitespaceChar(html.charAt(cursor))) return false
+
+  const len = html.length
+
+  // backwrad
+  for (let i = cursor - 1; i > wordBegin; i--) {
+    const char = html.charAt(i)
+    if (!isWhitespaceChar(char)) {
+      if (isEqualSignChar(char)) return false
+      break
+    }
+  }
+
+  // forward
+  for (let i = cursor + 1; i < len; i++) {
+    const char = html.charAt(i)
+    if (!isWhitespaceChar(char)) {
+      if (isEqualSignChar(char)) return false
+      return true
+    }
   }
 }
 
@@ -248,8 +277,7 @@ export class Scaner {
         break
       }
 
-      const isWordEnd = isWhitespaceChar(char)
-      if (isWordEnd) {
+      if (isWordEnd(cursor, wordBegin, html)) {
         if (cursor !== wordBegin) {
           words.push(html.slice(wordBegin, cursor))
         }


### PR DESCRIPTION
**这个 PR 做了什么?**

修复以下这种情况，属性名后的 `=` 旁多出空格会解析错误的问题

```js
<p style = "font-size:35px;color:grey">
```

**这个 PR 是什么类型?**

- [x] 错误修复(Bugfix) issue id #6911

**这个 PR 满足以下需求:**

- [x] 提交到 next 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
