### PR TITLE
fix(runtime/share): swiperitem不设置style属性，fix #7147

### DIFF
--- a/packages/shared/src/components.ts
+++ b/packages/shared/src/components.ts
@@ -683,6 +683,10 @@ export function createMiniComponents (components: Components, buildType: string)
         Object.assign(newComp, styles, isAlipay ? alipayEvents : events)
       }
 
+      if (compName === 'swiper-item') {
+        delete newComp.style
+      }
+
       if (compName === 'slot' || compName === 'slot-view') {
         result[compName] = {
           slot: 'i.name'

--- a/packages/taro-runtime/src/hydrate.ts
+++ b/packages/taro-runtime/src/hydrate.ts
@@ -69,7 +69,7 @@ export function hydrate (node: TaroElement | TaroText): MiniData {
     data[Shortcuts.Class] = node.className
   }
 
-  if (node.cssText !== '') {
+  if (node.cssText !== '' && node.nodeName !== 'swiper-item') {
     data[Shortcuts.Style] = node.cssText
   }
 


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

为 `SwiperItem` 设置 style 属性会覆盖小程序自动添加的 `transform` 等 style，因此直接不许设置 style。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #7147 

**这个 PR 满足以下需求:**

- [x] 提交到 next 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）