### PR TITLE
feat(mini-runner): 为小程序端新增若干编译配置项

### DIFF
--- a/packages/taro-cli/src/doctor/configSchema.ts
+++ b/packages/taro-cli/src/doctor/configSchema.ts
@@ -51,6 +51,12 @@ const schema = Joi.object().keys({
     commonChunks: Joi.alternatives(Joi.func(), Joi.array().items(Joi.string())),
     addChunkPages: Joi.func(),
     output: Joi.object(),
+    enableSourceMap: Joi.bool(),
+    sourceMapType: Joi.string(),
+    debugReact: Joi.bool(),
+    minifyXML: Joi.object().keys({
+      collapseWhitespace: Joi.bool()
+    }),
     postcss: Joi.object().pattern(
       Joi.string(),
       Joi.object().keys({
@@ -114,6 +120,7 @@ const schema = Joi.object().keys({
       Joi.func()
     ),
     enableSourceMap: Joi.bool(),
+    sourceMapType: Joi.string(),
     enableExtract: Joi.bool(),
     cssLoaderOption: Joi.object(), // 第三方配置
     styleLoaderOption: Joi.object(), // 第三方配置

--- a/packages/taro-mini-runner/package.json
+++ b/packages/taro-mini-runner/package.json
@@ -52,6 +52,7 @@
     "csso-webpack-plugin": "^1.0.0-beta.12",
     "file-loader": "^6.0.0",
     "fs-extra": "^8.0.1",
+    "html-minifier": "^4.0.0",
     "jsdom": "^15.2.1",
     "less": "^3.10.3",
     "less-loader": "^5.0.0",

--- a/packages/taro-mini-runner/src/webpack/build.conf.ts
+++ b/packages/taro-mini-runner/src/webpack/build.conf.ts
@@ -45,9 +45,12 @@ export default (appPath: string, mode, config: Partial<IBuildConfig>): any => {
     designWidth = 750,
     deviceRatio,
     enableSourceMap = process.env.NODE_ENV !== 'production',
+    sourceMapType,
+    debugReact = false,
     baseLevel = 16,
     framework = 'nerv',
     prerender,
+    minifyXML = {},
 
     defineConstants = {},
     env = {},
@@ -100,6 +103,13 @@ export default (appPath: string, mode, config: Partial<IBuildConfig>): any => {
   alias[taroJsComponents + '$'] = `${taroJsComponents}/mini`
   if (framework === 'react') {
     alias['react-dom'] = '@tarojs/react'
+    if (process.env.NODE_ENV !== 'production' && !debugReact) {
+      alias['react-reconciler'] = 'react-reconciler/cjs/react-reconciler.production.min.js'
+      // eslint-disable-next-line dot-notation
+      alias['react'] = 'react/cjs/react.production.min.js'
+      // eslint-disable-next-line dot-notation
+      alias['scheduler'] = 'scheduler/cjs/scheduler.production.min.js'
+    }
   }
   if (framework === 'nerv') {
     alias['react-dom'] = 'nervjs'
@@ -145,7 +155,8 @@ export default (appPath: string, mode, config: Partial<IBuildConfig>): any => {
     prerender,
     addChunkPages,
     modifyMiniConfigs,
-    modifyBuildAssets
+    modifyBuildAssets,
+    minifyXML
   })
 
   plugin.miniCssExtractPlugin = getMiniCssExtractPlugin([{
@@ -181,7 +192,7 @@ export default (appPath: string, mode, config: Partial<IBuildConfig>): any => {
 
   chain.merge({
     mode,
-    devtool: getDevtool(enableSourceMap),
+    devtool: getDevtool(enableSourceMap, sourceMapType),
     entry: entryRes!.entry,
     output: getOutput(appPath, [{
       outputRoot,

--- a/packages/taro-mini-runner/src/webpack/chain.ts
+++ b/packages/taro-mini-runner/src/webpack/chain.ts
@@ -472,6 +472,6 @@ export function getOutput (appPath: string, [{ outputRoot, publicPath, globalObj
   }
 }
 
-export function getDevtool (enableSourceMap) {
-  return enableSourceMap ? 'source-map' : 'none'
+export function getDevtool (enableSourceMap, sourceMapType = 'cheap-module-source-map') {
+  return enableSourceMap ? sourceMapType : 'none'
 }

--- a/packages/taro/types/compile.d.ts
+++ b/packages/taro/types/compile.d.ts
@@ -115,6 +115,11 @@ export interface ICompileOption {
 export interface IMiniAppConfig {
   appOutput?: boolean,
   enableSourceMap?: boolean,
+  sourceMapType?: string,
+  debugReact?: boolean,
+  minifyXML?: {
+    collapseWhitespace?: boolean
+  },
 
   webpackChain?: (chain: any, webpack: any, PARSE_AST_TYPE: any) => void,
   entry?: webpack.Entry,


### PR DESCRIPTION
**这个 PR 做了什么?**

* 同步 H5 端的 sourceMapType 配置
* 新增 debugReact 配置，可配置是否使用 development 版本的 React，默认使用 production 版本
* 新增 minifyXML 配置，可配置是否去除 xml 文件中的空格，默认不去除

**这个 PR 是什么类型?**

- [x] 新功能(Feature)

**这个 PR 满足以下需求:**

- [x] 提交到 next 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）