### PR TITLE
fix(transformer-wx): 非实例方法 bind 应该转换为匿名回调

### DIFF
--- a/packages/taro-transformer-wx/__tests__/event.spec.ts
+++ b/packages/taro-transformer-wx/__tests__/event.spec.ts
@@ -120,6 +120,29 @@ describe('event', () => {
     // expect(template).toMatch(`data-e-handleClick-a-b="{{777}}`)
   })
 
+  test('非 this bind 绑定转换为匿名函数', () => {
+    const { template, ast, code } = transform({
+      ...baseOptions,
+      code: buildComponent(
+        `
+      const callback = function(params) {}
+      return (
+        <View onClick={callback.bind(null, 1)} />
+      )
+      `,
+        '',
+        `import { Custom } from './utils'`
+      )
+    })
+
+    const instance = evalClass(ast)
+    removeShadowData(instance.state)
+    expect(instance.$$events).toEqual(['anonymousFunc0'])
+    expect(template).toMatch(
+      `bindtap="anonymousFunc0"`
+    )
+  })
+
   describe('this.props.func', () => {
     test('简单情况', () => {
       const { template, ast, code } = transform({

--- a/packages/taro-transformer-wx/src/class.ts
+++ b/packages/taro-transformer-wx/src/class.ts
@@ -974,6 +974,9 @@ class Transformer {
     } else if (t.isMemberExpression(expr) && !t.isThisExpression(expr.object)) {
       // @TODO: 新旧 props 系统在事件处理上耦合太深，快应用应用新 props 把旧 props 系统逻辑全部清楚
       this.buildAnonyMousFunc(path, attr, expr)
+    } else if (t.isCallExpression(expr) && !code.startsWith('this')) {
+      // 非类实例方法 bind 应该转换为 anonymous func
+      this.buildAnonyMousFunc(path, attr, expr)
     }
   }
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

类组件的 事件Props 如果包含 bind 绑定就会被转换为 `data-e-tap-so="this"` 形式，例如：

```jsx
const callback = () => {};

export default class Example extends Taro.Component {
  render() {
    return <View onClick={callback.bind(this, 1)}>Example</View>;
  }
}
```

转译为：

```xml
<block wx:if="{{$taroCompReady}}">
    <view bindtap="callback" data-e-tap-so="this" data-e-tap-a-a="{{1}}">Example</view>
</block>
```

运行时 callback 找不到。

预期的行为是：只有`类实例方法`进行 bind 时，才启用 `data-e-tap-so`


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [x] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
