### PR TITLE
picker组件为多列选择器时range的长度变化不能正确工作的bug修复

### DIFF
--- a/packages/taro-components/src/components/picker/index.js
+++ b/packages/taro-components/src/components/picker/index.js
@@ -48,11 +48,25 @@ export default class Picker extends Nerv.Component {
         range = []
         this.props.range = []
       }
-      if (range.length === this.index.length) this.index = []
-      range.forEach((r, i) => {
-        const v = value && value.length ? value[i] : undefined
-        this.index.push(this.verifyValue(v, r) ? Math.floor(value[i]) : 0)
-      })
+      if (range === this.props.range && this.props.value !== value) {
+        this.index = []
+        range.forEach((r, i) => {
+          const v = value && value.length ? value[i] : undefined
+          this.index.push(this.verifyValue(v, r) ? Math.floor(value[i]) : 0)
+        })
+        this.setState({
+          height: this.index.map(i => TOP - i * LINE_HEIGHT)
+        })
+      } else if (range.length !== this.index.length) {
+        range.forEach((r, i) => {
+          if (i >= this.index.length) {
+            this.index.push(0)
+          }
+        })
+        this.setState({
+          height: this.index.map(i => TOP - i * LINE_HEIGHT)
+        })
+      }
     } else if (mode === 'time') {
       // check value...
       if (!this.verifyTime(value)) {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
当用户使用多列picker时, 想要动态增减列(即改变range属性的长度), 改动之后再操作picker会报错, 这个PR修复了这个问题


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #7319
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
