### PR TITLE
fix: 解构 props 后，如果作用域中不包含 children， 其他 renderProps 可能识别失败 close #7315

### DIFF
--- a/packages/taro-transformer-wx/__tests__/render-props.spec.ts
+++ b/packages/taro-transformer-wx/__tests__/render-props.spec.ts
@@ -173,4 +173,35 @@ describe('render props', () => {
     `)
     )
   })
+
+  test('fix #7315', () => {
+    const { template, ast, code } = transform({
+      ...baseOptions,
+      isRoot: true,
+      code: buildComponent(`
+      const {renderHeader, renderFooter} = this.props
+
+      return (
+        <View>
+          <Block>{renderHeader}</Block>
+          <Block>{renderFooter}</Block>
+        </View>
+      )
+      `, ``)
+    })
+    expect(template).toMatch(
+      prettyPrint(`
+      <block>
+          <view>
+              <block>
+                  <slot name="header"></slot>
+              </block>
+              <block>
+                  <slot name="footer"></slot>
+              </block>
+          </view>
+      </block>
+    `)
+    )
+  })
 })

--- a/packages/taro-transformer-wx/src/class.ts
+++ b/packages/taro-transformer-wx/src/class.ts
@@ -776,7 +776,7 @@ class Transformer {
               }
             }
           } else if (path.isReferencedIdentifier()) {
-            if (isDerivedFromProps(path.scope, 'children')) {
+            if (isDerivedFromProps(path.scope, path.node.name)) {
               parentPath.replaceWith(slot)
             }
           }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)



**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [x] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
