### PR TITLE
fix: 修复 radio-group 子组件 wrapper 导致事件错误问题 fix #6475

### DIFF
--- a/packages/taro-components/src/components/radio/index.js
+++ b/packages/taro-components/src/components/radio/index.js
@@ -29,6 +29,7 @@ class Radio extends Nerv.Component {
           name={name}
           className={cls}
           checked={checked}
+          onClick={e => e.stopPropagation()}
         />
         {className ? (false) : (<i className='weui-icon-checked' />) }
         {this.props.children}

--- a/packages/taro-components/src/components/radio/radio-group.js
+++ b/packages/taro-components/src/components/radio/radio-group.js
@@ -14,11 +14,12 @@ class RadioGroup extends Nerv.Component {
   }
 
   toggleChange (e, i) {
+    const val = e.target.value || e.target.querySelector('input[type=radio]').value
     let checkValue
     let _value = this.radioValue.map((item, idx) => {
       let curValue = item.value
       if (isNumber(item.value)) curValue = item.value.toString()
-      if (e.target.value === curValue) {
+      if (val === curValue) {
         checkValue = item.value
         return {
           name: item.name,
@@ -45,67 +46,45 @@ class RadioGroup extends Nerv.Component {
     const children = Nerv.Children.toArray(this.props.children).map(
       (item, i) => {
         let _key = item.props.for || i
-        const chd = Nerv.Children.toArray(item.props.children).map(ch => {
-          if (ch.name === 'Radio') {
-            if (ch.props.checked) {
-              this.radioValue[i] = {
-                name: ch.props.name,
-                value: ch.props.value,
-                checked: true
-              }
-            } else {
-              this.radioValue[i] = {
-                name: ch.props.name,
-                value: ch.props.value,
-                checked: false
-              }
-            }
-            return Nerv.cloneElement(ch, {
-              onChange: e => this.toggleChange(e, i),
-              for: _key,
-              name: name
-            })
+        if (item.name === 'Radio') {
+          this.radioValue[i] = {
+            name: item.props.name,
+            value: item.props.value,
+            checked: !!item.props.checked
           }
-          return ch
-        })
-        return Nerv.cloneElement(item, { for: _key }, chd)
+          return Nerv.cloneElement(item, {
+            onChange: e => this.toggleChange(e, i),
+            for: _key,
+            name: name
+          })
+        } else {
+          const chd = Nerv.Children.toArray(item.props.children).map(ch => {
+            if (ch.name === 'Radio') {
+              this.radioValue[i] = {
+                name: ch.props.name,
+                value: ch.props.value,
+                checked: !!ch.props.checked
+              }
+              return Nerv.cloneElement(ch, {
+                onChange: e => this.toggleChange(e, i),
+                for: _key,
+                name: name
+              })
+            }
+            return ch
+          })
+          return Nerv.cloneElement(item, { for: _key }, chd)
+        }
       }
     )
 
-    function isChildOf (child, parent) {
-      // console.log('参数child=' + child + '-' + child.nodeName, '参数parent=' + parent + '-' + parent.nodeName)
-      if (child && parent) {
-        if (child === parent) return true
-        var myParentNode = child.parentNode // 定义临时变量，并初始化为child参数的父节点
-        while (myParentNode) {
-          // console.log('myParentNode=' + myParentNode + '-' + myParentNode.nodeName)
-          if (myParentNode === parent) {
-            // 如果myParentNode等于parent参数，则证明child参数是parent参数的后代
-            return true
-          } else {
-            // 找myParentNode的上一代
-            myParentNode = myParentNode.parentNode
-          }
-        }
-      }
-      // 遍历结束后，都没有返回true，则说明child参数找不到它的祖先parent参数
-      return false
-    }
     /* TODO 规避Nerv数组diff问题 */
     return (<div className='weui-cells_radiogroup'
+      name={name}
       {...omit(this.props, [
+        'name',
         'onChange'
-      ])}
-      onClick={e => {
-        let index = -1
-        const cs = (e && e.currentTarget && e.currentTarget.children) || []
-        for (let i = 0; i < cs.length; i++) {
-          if (isChildOf(e.toElement, cs[i])) index = i
-        }
-        if (index > -1 && this.props.onChange && typeof this.props.onChange === 'function') {
-          this.props.onChange(e, index)
-        }
-      }}>{children}
+      ])}>{children}
     </div>)
   }
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
radio-group 的子组件包裹会导致 事件多次触发，且部分事件 value 值错误设置

> input change 会在值变更时自动触发，并冒泡触发上层事件，导致 onChange 被多次执行


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #6475
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
