### PR TITLE
fix(runtime): 修复 Vue3 静态节点渲染错误的问题，fix #7128

### DIFF
--- a/packages/taro-runtime/src/dom/html/tags.ts
+++ b/packages/taro-runtime/src/dom/html/tags.ts
@@ -1,3 +1,5 @@
+import { internalComponents } from '@tarojs/shared'
+
 export function makeMap (
   str: string,
   expectsLowerCase?: boolean
@@ -15,8 +17,12 @@ export const specialMiniElements = {
   iframe: 'web-view'
 }
 
+const internalCompsList = Object.keys(internalComponents)
+  .map(i => i.toLowerCase())
+  .join(',')
+
 // https://developers.weixin.qq.com/miniprogram/dev/component
-export const isMiniElements = makeMap('input,canvas,progress,video,audio,form', true)
+export const isMiniElements = makeMap(internalCompsList, true)
 
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements
 export const isInlineElements = makeMap('a,i,abbr,iframe,select,acronym,slot,small,bdi,kbd,strong,big,map,sub,sup,br,mark,mark,meter,template,canvas,textarea,cite,object,time,code,output,u,data,picture,tt,datalist,var,dfn,del,q,em,s,embed,samp', true)


### PR DESCRIPTION
**这个 PR 做了什么?**

修复 Vue3 静态节点渲染错误的问题。

Vue3 的静态节点会使用 `node.innerHTML` 渲染 DOM 树，小程序端渲染 `innerHTML` 时需要识别出所有小程序对应组件。

目前是静态列出若干 H5 标签对应的小程序组件，但不齐全，这里予以补全。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #7128 