### PR TITLE
fix(babel-preset): 修复Vue SFC使用TS语法报错的问题，fix #7335

### DIFF
--- a/packages/babel-preset-taro/index.js
+++ b/packages/babel-preset-taro/index.js
@@ -6,6 +6,8 @@ module.exports = (_, options = {}) => {
   const plugins = []
   const isReact = options.framework === 'react'
   const isNerv = options.framework === 'nerv'
+  const isVue = options.framework === 'vue'
+  const isVue3 = options.framework === 'vue3'
   const moduleName = options.framework.charAt(0).toUpperCase() + options.framework.slice(1)
 
   if (isNerv || isReact) {
@@ -19,6 +21,9 @@ module.exports = (_, options = {}) => {
     const config = {}
     if (isNerv || isReact) {
       config.jsxPragma = moduleName
+    }
+    if (isVue || isVue3) {
+      config.allExtensions = true
     }
     presets.push([require('@babel/preset-typescript'), config])
   }


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

修复Vue SFC使用TS语法报错的问题，`@babel/preset-typescript` 增加 `allExtensions: true` 配置，使得可以识别 `.vue` 文件

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #7335

**这个 PR 满足以下需求:**

- [x] 提交到 next 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
