### PR TITLE
fix(router/components): 修复切换tab时会销毁当前tab的问题

### DIFF
--- a/packages/taro-components/src/components/tabbar/tabbar.tsx
+++ b/packages/taro-components/src/components/tabbar/tabbar.tsx
@@ -145,7 +145,7 @@ export class Tabbar implements ComponentInterface {
 
   switchTab = (index: number) => {
     this.selectedIndex = index
-    Taro.redirectTo({
+    Taro.navigateTo({
       url: this.list[index].pagePath
     })
   }

--- a/packages/taro-h5/src/api/tabBar/index.js
+++ b/packages/taro-h5/src/api/tabBar/index.js
@@ -10,41 +10,6 @@ export function initTabBarApis (_App = {}) {
 }
 
 /**
- * 跳转到 tabBar 页面，并关闭其他所有非 tabBar 页面
- * @param {Object} options
- * @param {string} options.url 需要跳转的 tabBar 页面的路径（需在 app.json 的 tabBar 字段定义的页面），路径后不能带参数。
- * @param {function} [options.success] 接口调用成功的回调函数
- * @param {function} [options.fail] 接口调用失败的回调函数
- * @param {function} [options.complete] 接口调用结束的回调函数（调用成功、失败都会执行）
- */
-export function switchTab (options = {}) {
-  // options must be an Object
-  const isObject = shouleBeObject(options)
-  if (!isObject.res) {
-    const res = { errMsg: `showTabBarRedDot${isObject.msg}` }
-    console.error(res.errMsg)
-    return Promise.reject(res)
-  }
-
-  const { url, success, fail, complete } = options
-  return new Promise((resolve, reject) => {
-    Taro.eventCenter.trigger('__taroSwitchTab', {
-      url,
-      successHandler: res => {
-        success && success(res)
-        complete && complete(res)
-        resolve(res)
-      },
-      errorHandler: res => {
-        fail && fail(res)
-        complete && complete(res)
-        reject(res)
-      }
-    })
-  })
-}
-
-/**
  * 为 tabBar 某一项的右上角添加文本
  * @param {Object} options
  * @param {number} options.index tabBar 的哪一项，从左边算起

--- a/packages/taro-h5/src/taro/index.js
+++ b/packages/taro-h5/src/taro/index.js
@@ -83,5 +83,12 @@ export {
   pxTransform,
   canIUseWebp,
   interceptors,
-  history, navigateBack, navigateTo, createRouter, reLaunch, redirectTo, getCurrentPages
+  history,
+  navigateBack,
+  navigateTo,
+  createRouter,
+  reLaunch,
+  redirectTo,
+  getCurrentPages,
+  switchTab
 }


### PR DESCRIPTION
**这个 PR 做了什么?**

修复切换 tab 时会销毁当前 tab 的问题

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix)

**这个 PR 满足以下需求:**

- [x] 提交到 next 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）