### PR TITLE
fix(mini-runner): [next]修复小程序混写时模板引入只有第一个生效的问题 close #5824 #5577

### DIFF
--- a/packages/taro-mini-runner/src/loaders/miniTemplateLoader.ts
+++ b/packages/taro-mini-runner/src/loaders/miniTemplateLoader.ts
@@ -12,7 +12,7 @@ export default function miniTemplateLoader (source) {
    *
    * 推荐方案1，这样在构建时会正常打入需要的包，但是若用户有 SrC 类似的写法导致引用失败，则可直接修正，不会认为是打包出现了问题
    **/
-  source = `<root>${source}</root>`
+  const sourceWithRoot = `<root>${source}</root>`
   const parser = sax.parser(false, { lowercase: true })
   const requests: Set<string> = new Set()
   const callback = this.async()
@@ -47,5 +47,5 @@ export default function miniTemplateLoader (source) {
       callback(error, source)
     }
   }
-  parser.write(source).close()
+  parser.write(sourceWithRoot).close()
 }

--- a/packages/taro-mini-runner/src/loaders/miniTemplateLoader.ts
+++ b/packages/taro-mini-runner/src/loaders/miniTemplateLoader.ts
@@ -3,6 +3,16 @@ import { isUrlRequest, urlToRequest } from 'loader-utils'
 
 export default function miniTemplateLoader (source) {
   this.cacheable && this.cacheable()
+  /**
+   * 两种fix方案：
+   * 1. 用任意xml标签包裹source，使之变成较标准的xml格式（含有一个根节点）
+   * 2. 修改 sax.parser 的第一个参数为 true，启用严格模式
+   *    2.1 该模式下小程序模板中的标签或属性不会处理（例如写入<Import SrC="..." />不会处理成<import src="..." />，而是保持原样
+   *    2.2 该模式将认为传入的xml为非标准的，无需标准化，且不按照以根节点模式处理，因此可以正常解析小程序模板
+   *
+   * 推荐方案1，这样在构建时会正常打入需要的包，但是若用户有 SrC 类似的写法导致引用失败，则可直接修正，不会认为是打包出现了问题
+   **/
+  source = `<root>${source}</root>`
   const parser = sax.parser(false, { lowercase: true })
   const requests: Set<string> = new Set()
   const callback = this.async()


### PR DESCRIPTION
#5824
#5577 

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
更改文件：更改了 `@taro/mini-runner` 下的 `loaders/miniTemplateLoader.ts` 文件
更改内容：给loader中拿到的source源文件内容字符串包裹了一层根节点，使sax可以正确解析出需要import的文件，使之正确打包。注释中也列出了第二种方案，但推荐采用本次PR中使用的方案。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #5824 #5577 
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [x] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [x] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
1. 在添加代码之前，mini-runner 包中的测试用例已有一些不通过。