### PR TITLE
fix(components): 修复 H5 虚拟列表滚动后不能点击的问题，fix #7140

### DIFF
--- a/packages/taro-components/virtual-list/react/createListComponent.js
+++ b/packages/taro-components/virtual-list/react/createListComponent.js
@@ -401,7 +401,7 @@ export default function createListComponent ({
         ref: innerRef,
         style: {
           height: this._getStyleValue(isHorizontal ? '100%' : estimatedTotalSize),
-          pointerEvents: isScrolling ? 'none' : undefined,
+          pointerEvents: isScrolling ? 'none' : 'auto',
           width: this._getStyleValue(isHorizontal ? estimatedTotalSize : '100%')
         }
       }))

--- a/packages/taro-runtime/src/dom/style_properties.ts
+++ b/packages/taro-runtime/src/dom/style_properties.ts
@@ -385,6 +385,7 @@ export const styleProperties = [
   'placeItems',
   'placeSelf',
   'playDuring',
+  'pointerEvents',
   'position',
   'quotes',
   'regionFragment',


### PR DESCRIPTION
**这个 PR 做了什么?**

* 修复 H5 虚拟列表滚动后不能点击的问题
* 修复小程序端不能设置 pointer-events 样式的问题

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #7140 

**这个 PR 满足以下需求:**

- [x] 提交到 next 分支

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）