### PR TITLE
fix: 完善ref类型推导

### DIFF
--- a/packages/taro-components/types/common.d.ts
+++ b/packages/taro-components/types/common.d.ts
@@ -1,4 +1,5 @@
 import {CSSProperties} from 'react';
+import {MutableRefObject} from '@tarojs/taro';
 
 export type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never })[keyof T]>;
 
@@ -18,7 +19,7 @@ export interface StandardProps extends EventProps {
   /** 动画属性 */
   animation?: { actions: object[] }
   /** 引用 */
-  ref?: string | ((node: any) => any)
+  ref?: string | ((node: any) => any) | MutableRefObject<any>
 }
 
 export interface FormItemProps {


### PR DESCRIPTION
**这个 PR 做了什么?**
完善组件 ref 属性的类型推导，解决如下类型推导报错。

```typescript
import Taro, {useRef} from '@tarojs/taro'

const MyComponent = () => {
    const ref = useRef()
    return <View ref={ref} /> // Error: the expected type comes from property 'ref'.
}
```

**这个 PR 是什么类型?** 

- [x] TypeScript 类型定义修改(Typings)
