### PR TITLE
refactor(babel-plugin-transform-jsx-to-stylesheet): 插件升级到babel7

### DIFF
--- a/packages/babel-plugin-transform-jsx-to-stylesheet/.babelrc
+++ b/packages/babel-plugin-transform-jsx-to-stylesheet/.babelrc
@@ -1,10 +1,9 @@
 {
   "presets": [
-    "env",
-    "react",
-    "stage-0"
+    "@babel/preset-env",
+    "@babel/preset-react"
   ],
   "plugins": [
-    "babel-plugin-transform-class-properties"
+    "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/packages/babel-plugin-transform-jsx-to-stylesheet/package.json
+++ b/packages/babel-plugin-transform-jsx-to-stylesheet/package.json
@@ -16,16 +16,16 @@
   },
   "homepage": "https://github.com/NervJS/taro#readme",
   "engines": {
-    "npm": ">=3.0.0"
+    "npm": ">=8.0.0"
   },
   "devDependencies": {
-    "babel-core": "^6.23.1",
-    "babel-jest": "^23.6.0",
-    "babel-plugin-syntax-jsx": "^6.18.0",
-    "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-preset-env": "^1.7.0",
-    "babel-preset-react": "^6.24.1",
-    "babel-preset-stage-0": "^6.24.1",
-    "jest": "^23.6.0"
+    "@babel/core": "^7.11.6",
+    "@babel/plugin-proposal-class-properties": "^7.10.4",
+    "@babel/plugin-syntax-jsx": "^7.10.4",
+    "@babel/preset-env": "^7.11.5",
+    "@babel/preset-react": "^7.10.4",
+    "@babel/preset-stage-0": "^7.8.3",
+    "babel-jest": "^26.3.0",
+    "jest": "^26.4.2"
   }
 }

--- a/packages/babel-plugin-transform-jsx-to-stylesheet/src/__tests__/index.js
+++ b/packages/babel-plugin-transform-jsx-to-stylesheet/src/__tests__/index.js
@@ -1,18 +1,15 @@
 import jSXStylePlugin from '../index'
-import syntaxJSX from 'babel-plugin-syntax-jsx'
-import { transform } from 'babel-core'
+import syntaxJSX from '@babel/plugin-syntax-jsx'
+import { transform } from '@babel/core'
 
 const mergeStylesFunctionTemplate = `function _mergeStyles() {
   var newTarget = {};
-
   for (var index = 0; index < arguments.length; index++) {
     var target = arguments[index];
-
     for (var key in target) {
       newTarget[key] = Object.assign(newTarget[key] || {}, target[key]);
     }
   }
-
   return newTarget;
 }`
 
@@ -40,86 +37,77 @@ const getClassNameFunctionTemplate = `function _getClassName() {
   }
 
   return className.join(' ').trim();
-}`
+}
+`
 
-const getStyleFunctionTemplete = `function _getStyle(classNameExpression) {
-  var cache = _styleSheet.__cache || (_styleSheet.__cache = {});
-
+const getStyleFunctionTemplate = `function _getStyle(classNameExpression) {
   var className = _getClassName(classNameExpression);\n
   var classNameArr = className.split(/\\s+/);
-  var style = cache[className];
+  var style = [];
 
-  if (!style) {
-    style = {};
-
-    if (classNameArr.length === 1) {
-      style = _styleSheet[classNameArr[0].trim()];
-    } else {
-      classNameArr.forEach(function (cls) {
-        style = Object.assign(style, _styleSheet[cls.trim()]);
-      });
-    }
-
-    cache[className] = style;
+  if (classNameArr.length === 1) {
+    style.push(_styleSheet[classNameArr[0].trim()]);
+  } else {
+    classNameArr.forEach(function (cls) {
+      style.push(_styleSheet[cls.trim()]);
+    });
   }
 
   return style;
-}`
+}
+`
 
 describe('jsx style plugin', () => {
-  function getTransfromCode (code) {
+  function getTransformCode (code) {
     return transform(code, {
       plugins: [jSXStylePlugin, syntaxJSX]
     }).code
   }
 
   it('transform only one className to style as member', () => {
-    expect(getTransfromCode(`
+    expect(getTransformCode(`
 import { createElement, Component } from 'rax';
 import './app.css';
-
 class App extends Component {
   render() {
     return <div className="header" />;
   }
-}`)).toBe(`
-import { createElement, Component } from 'rax';
-import appStyleSheet from './app.css';
-
+}`)).toBe(`import { createElement, Component } from 'rax';
+import appStyleSheet from './app_styles';
 var _styleSheet = appStyleSheet;
+
 class App extends Component {
   render() {
     return <div style={_styleSheet["header"]} />;
   }
+
 }`)
-  })
+})
 
   it('transform multiple classNames to style as array', () => {
-    expect(getTransfromCode(`
+    expect(getTransformCode(`
 import { createElement, Component } from 'rax';
-import './app.css';
-
+import "./app.css";
 class App extends Component {
   render() {
     return <div className="header1 header2" />;
   }
-}`)).toBe(`
-import { createElement, Component } from 'rax';
-import appStyleSheet from './app.css';
-
+}`)).toBe(`import { createElement, Component } from 'rax';
+import appStyleSheet from "./app_styles";
 var _styleSheet = appStyleSheet;
+
 class App extends Component {
   render() {
     return <div style={[_styleSheet["header1"], _styleSheet["header2"]]} />;
   }
+
 }`)
   })
 
   it('transform array, object and expressions', () => {
-    expect(getTransfromCode(`
+    expect(getTransformCode(`
 import { createElement, Component } from 'rax';
 import './app.css';
-
 class App extends Component {
   render() {
     return <div className={'header'}>
@@ -129,182 +117,172 @@ class App extends Component {
       <div className={getClassName()} />
     </div>;
   }
-}`)).toBe(`
-import { createElement, Component } from 'rax';
-import appStyleSheet from './app.css';
-
+}`)).toBe(`import { createElement, Component } from 'rax';
+import appStyleSheet from './app_styles';
 var _styleSheet = appStyleSheet;
 
 ${getClassNameFunctionTemplate}
-
-${getStyleFunctionTemplete}
-
+${getStyleFunctionTemplate}
 class App extends Component {
   render() {
     return <div style={_styleSheet["header"]}>
-      <div style={_getStyle({ active: props.isActive })} />
-      <div style={_getStyle(['header1 header2', 'header3', { active: props.isActive }])} />
+      <div style={_getStyle({
+        active: props.isActive
+      })} />
+      <div style={_getStyle(['header1 header2', 'header3', {
+        active: props.isActive
+      }])} />
       <div style={_getStyle(props.visible ? 'show' : 'hide')} />
       <div style={_getStyle(getClassName())} />
     </div>;
   }
+
 }`)
   })
 
   it('combine one style and className', () => {
-    expect(getTransfromCode(`
+    expect(getTransformCode(`
 import { createElement, Component } from 'rax';
 import './app.css';
 import style from './style.css';
-
 class App extends Component {
   render() {
     return <div className="header2" style={styles.header1} />;
   }
-}`)).toBe(`${mergeStylesFunctionTemplate}
-
-import { createElement, Component } from 'rax';
-import appStyleSheet from './app.css';
-import styleStyleSheet from './style.css';
-
-var _styleSheet = _mergeStyles(appStyleSheet, styleStyleSheet);
+}`)).toBe(`import { createElement, Component } from 'rax';
+import appStyleSheet from './app_styles';
+var _styleSheet = appStyleSheet;
 
 class App extends Component {
   render() {
     return <div style={[_styleSheet["header2"], styles.header1]} />;
   }
+
 }`)
   })
 
   it('combine inline style object and className', () => {
-    expect(getTransfromCode(`
+    expect(getTransformCode(`
 import { createElement, Component } from 'rax';
 import './app.css';
-
 class App extends Component {
   render() {
     return <div className="header" style={{
       height: 100
     }} />;
   }
-}`)).toBe(`
-import { createElement, Component } from 'rax';
-import appStyleSheet from './app.css';
-
+}`)).toBe(`import { createElement, Component } from 'rax';
+import appStyleSheet from './app_styles';
 var _styleSheet = appStyleSheet;
+
 class App extends Component {
   render() {
     return <div style={[_styleSheet["header"], {
       height: 100
     }]} />;
   }
+
 }`)
   })
 
   it('combine multiple styles and className', () => {
-    expect(getTransfromCode(`
+    expect(getTransformCode(`
 import { createElement, Component } from 'rax';
 import './app.css';
 import style from './style.css';
-
 class App extends Component {
   render() {
     return <div className="header2" style={[styles.header1, styles.header3]} />;
   }
-}`)).toBe(`${mergeStylesFunctionTemplate}
-
-import { createElement, Component } from 'rax';
-import appStyleSheet from './app.css';
-import styleStyleSheet from './style.css';
-
-var _styleSheet = _mergeStyles(appStyleSheet, styleStyleSheet);
+}`)).toBe(`import { createElement, Component } from 'rax';
+import appStyleSheet from './app_styles';
+var _styleSheet = appStyleSheet;
 
 class App extends Component {
   render() {
     return <div style={[_styleSheet["header2"], styles.header1, styles.header3]} />;
   }
+
 }`)
   })
 
-  it('do not transfrom code when no css file', () => {
+  it('do not transform code when no css file', () => {
     const code = `
 import { createElement, Component } from 'rax';
-
 class App extends Component {
   render() {
     return <div className="header" />;
   }
 }`
-
-    expect(getTransfromCode(code)).toBe(code)
-  })
-
-  it('transform scss file', () => {
-    expect(getTransfromCode(`
-import { createElement, Component } from 'rax';
-import './app.scss';
+    expect(getTransformCode(code))
+    .toBe(`import { createElement, Component } from 'rax';
 
 class App extends Component {
   render() {
     return <div className="header" />;
   }
-}`)).toBe(`
-import { createElement, Component } from 'rax';
-import appStyleSheet from './app.scss';
 
+}`)
+})
+
+  it('transform scss file', () => {
+    expect(getTransformCode(`
+import { createElement, Component } from 'rax';
+import './app.scss';
+class App extends Component {
+  render() {
+    return <div className="header" />;
+  }
+}`)).toBe(`import { createElement, Component } from 'rax';
+import appStyleSheet from './app_styles';
 var _styleSheet = appStyleSheet;
+
 class App extends Component {
   render() {
     return <div style={_styleSheet["header"]} />;
   }
+
 }`)
   })
 
   it('transform scss file with hyphen(-) in the filename', () => {
-    expect(getTransfromCode(`
+    expect(getTransformCode(`
 import { createElement, Component } from 'rax';
 import './app-style.scss';
-
 class App extends Component {
   render() {
     return <div className="header" />;
   }
-}`)).toBe(`
-import { createElement, Component } from 'rax';
-import app_styleStyleSheet from './app-style.scss';
-
+}`)).toBe(`import { createElement, Component } from 'rax';
+import app_styleStyleSheet from './app-style_styles';
 var _styleSheet = app_styleStyleSheet;
+
 class App extends Component {
   render() {
     return <div style={_styleSheet["header"]} />;
   }
+
 }`)
   })
 
   it('transform constant elements in render', () => {
-    expect(getTransfromCode(`
+    expect(getTransformCode(`
 import { createElement, render } from 'rax';
 import './app.css';
-
 render(<div className="header" />);
-`)).toBe(`
-import { createElement, render } from 'rax';
-import appStyleSheet from './app.css';
-
+`)).toBe(`import { createElement, render } from 'rax';
+import appStyleSheet from './app_styles';
 var _styleSheet = appStyleSheet;
 render(<div style={_styleSheet["header"]} />);`)
   })
 
   it('transform stylus in render', () => {
-    expect(getTransfromCode(`
+    expect(getTransformCode(`
 import { createElement, render } from 'rax';
 import './app.styl';
-
 render(<div className="header" />);
-`)).toBe(`
-import { createElement, render } from 'rax';
+`)).toBe(`import { createElement, render } from 'rax';
 import appStyleSheet from './app_styles';
-
 var _styleSheet = appStyleSheet;
 render(<div style={_styleSheet["header"]} />);`)
   })

--- a/packages/babel-plugin-transform-jsx-to-stylesheet/src/index.js
+++ b/packages/babel-plugin-transform-jsx-to-stylesheet/src/index.js
@@ -8,22 +8,7 @@ const NAME_SUFFIX = 'StyleSheet'
 const cssSuffixs = ['.css', '.scss', '.sass', '.less', '.styl']
 let styleNames = [] // css module 写法中 import 的 Identifier
 
-module.exports = function ({types: t, template}) {
-  const mergeStylesFunctionTemplate = template(`
-function ${MERGE_STYLES_FUNC_NAME}() {
-  var newTarget = {};
-
-  for (var index = 0; index < arguments.length; index++) {
-    var target = arguments[index];
-
-    for (var key in target) {
-      newTarget[key] = Object.assign(newTarget[key] || {}, target[key]);
-    }
-  }
-
-  return newTarget;
-}
-  `)
+module.exports = function ({ types: t, template }) {
   const getClassNameFunctionTemplate = template(`
 function ${GET_CLS_NAME_FUNC_NAME}() {
   var className = [];
@@ -69,11 +54,9 @@ function ${GET_STYLE_FUNC_NAME}(classNameExpression) {
   `)
 
   const getClassNameFunctionAst = getClassNameFunctionTemplate()
-  const mergeStylesFunctionAst = mergeStylesFunctionTemplate()
   const getStyleFunctionAst = getStyleFunctionTemplete()
 
   function getArrayExpression (value) {
-    let expression
     let str
 
     if (!value || value.value === '') {
@@ -113,12 +96,12 @@ function ${GET_STYLE_FUNC_NAME}(classNameExpression) {
   return {
     visitor: {
       Program: {
-        exit (astPath, {file}) {
+        exit (astPath, { file }) {
           const node = astPath.node
           // const cssFileCount = file.get('cssFileCount')
           const injectGetStyle = file.get('injectGetStyle')
           const lastImportIndex = findLastImportIndex(node.body)
-          let cssParamIdentifiers = file.get('cssParamIdentifiers')
+          const cssParamIdentifiers = file.get('cssParamIdentifiers')
           let callExpression
 
           if (cssParamIdentifiers) {
@@ -147,10 +130,10 @@ function ${GET_STYLE_FUNC_NAME}(classNameExpression) {
           astPath.traverse({
             JSXOpeningElement (astPath) {
               astPath.traverse({
-                JSXAttribute ({node}) {
+                JSXAttribute ({ node }) {
                   if (node.name && node.name.name === 'style') {
                     astPath.traverse({
-                      MemberExpression ({node}) {
+                      MemberExpression ({ node }) {
                         if (node.object.type === 'Identifier' && styleNames.indexOf(node.object.name) > -1) {
                           node.object.name = STYLE_SHEET_NAME
                         }
@@ -165,7 +148,7 @@ function ${GET_STYLE_FUNC_NAME}(classNameExpression) {
           styleNames = []
         }
       },
-      JSXOpeningElement ({container}, {file}) {
+      JSXOpeningElement ({ container }, { file }) {
         const cssFileCount = file.get('cssFileCount') || 0
         if (cssFileCount < 1) {
           return
@@ -212,8 +195,8 @@ function ${GET_STYLE_FUNC_NAME}(classNameExpression) {
           }
 
           if (hasStyleAttribute && styleAttribute.value) {
-            let expression = styleAttribute.value.expression
-            let expressionType = expression.type
+            const expression = styleAttribute.value.expression
+            const expressionType = expression.type
 
             // style={[styles.a, styles.b]} ArrayExpression
             if (expressionType === 'ArrayExpression') {
@@ -229,14 +212,14 @@ function ${GET_STYLE_FUNC_NAME}(classNameExpression) {
               styleAttribute.value.expression = t.arrayExpression(arrayExpression.concat(expression))
             }
           } else {
-            let expression = arrayExpression.length === 1 ? arrayExpression[0] : t.arrayExpression(arrayExpression)
+            const expression = arrayExpression.length === 1 ? arrayExpression[0] : t.arrayExpression(arrayExpression)
             attributes.push(t.jSXAttribute(t.jSXIdentifier('style'), t.jSXExpressionContainer(expression)))
           }
         }
       },
       // 由于目前 js 引入的文件样式默认会全部合并，故进插入一个就好，其余的全部 remove
       ImportDeclaration (astPath, state) {
-        const {file} = state
+        const { file } = state
         const node = astPath.node
         const sourceValue = node.source.value
         const specifiers = node.specifiers
@@ -244,7 +227,7 @@ function ${GET_STYLE_FUNC_NAME}(classNameExpression) {
         const extname = path.extname(sourceValue)
         const cssIndex = cssSuffixs.indexOf(extname)
         let cssFileCount = file.get('cssFileCount') || 0
-        let cssParamIdentifiers = file.get('cssParamIdentifiers') || []
+        const cssParamIdentifiers = file.get('cssParamIdentifiers') || []
 
         if (cssIndex > -1) {
           // `import styles from './foo.css'` kind


### PR DESCRIPTION
这个 PR 做了什么? (简要描述所做更改)
1 升级到babel7
2 更新测试用例
3 保持和原有import样式文件类似

[*] 代码重构(Refactor)
这个 PR 涉及以下平台:

[*] 移动端（React-Native）