### PR TITLE
fix(swan/request): 百度小程序请求无需RequestQueue

### DIFF
--- a/packages/taro/apis/swan.js
+++ b/packages/taro/apis/swan.js
@@ -8,35 +8,6 @@ const {
   Link
 } = Taro
 
-const RequestQueue = {
-  MAX_REQUEST: 5,
-  queue: [],
-  request (options) {
-    this.push(options)
-    // 返回request task
-    return this.run()
-  },
-
-  push (options) {
-    this.queue.push(options)
-  },
-
-  run () {
-    if (!this.queue.length) {
-      return
-    }
-    if (this.queue.length <= this.MAX_REQUEST) {
-      const options = this.queue.shift()
-      const completeFn = options.complete
-      options.complete = () => {
-        completeFn && completeFn.apply(options, [...arguments])
-        this.run()
-      }
-      return swan.request(options)
-    }
-  }
-}
-
 function taroInterceptor (chain) {
   return request(chain.requestParams)
 }
@@ -68,7 +39,7 @@ function request (options) {
       originComplete && originComplete(res)
     }
 
-    requestTask = RequestQueue.request(options)
+    requestTask = swan.request(options)
   })
   p.abort = (cb) => {
     cb && cb()


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

经实际实验，百度小程序并不需要请求队列，反而还有限制百度小程序请求的并发

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #7561

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 百度小程序
