### PR TITLE
fix(mini-runner): 修复 baseLevel 配置不生效的问题

### DIFF
--- a/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
+++ b/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
@@ -118,8 +118,8 @@ export default class TaroMiniPlugin {
     }, options)
 
     const { template, baseLevel } = this.options
-    if (template instanceof UnRecursiveTemplate && baseLevel > 0) {
-      template.baseLevel = baseLevel
+    if (template.isSupportRecursive === false && baseLevel > 0) {
+      (template as UnRecursiveTemplate).baseLevel = baseLevel
     }
   }
 


### PR DESCRIPTION
**这个 PR 做了什么?**

全局 CLI 和项目里 mini-runner 包引用的 share 包是不同的，这里 instanceof 永不会为 true。
因此改为使用 isSupportRecursive 属性进行判断。

**这个 PR 是什么类型?**

- [x] 错误修复(Bugfix)

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）