### PR TITLE
feat: 让微信小程序可以自定义project.config.json文件的源文件名

### DIFF
--- a/packages/taro-cli/src/presets/platforms/weapp.ts
+++ b/packages/taro-cli/src/presets/platforms/weapp.ts
@@ -43,7 +43,7 @@ export default (ctx: IPluginContext) => {
 
       // 生成 project.config.json
       ctx.generateProjectConfig({
-        srcConfigName: 'project.config.json',
+        srcConfigName: config.projectConfigName || 'project.config.json',
         distConfigName: 'project.config.json'
       })
 


### PR DESCRIPTION
用户可以通过在config/index.js、config/dev.js或者其它配置文件里面添加projectConfigName: "project1.config.json"
来指定project.config.json的源文件.
可以用于在不同的编译目标里指定不同的appid,实现一份代码同时编译成多个不同appid的小程序，上传给不同的商家使用。
使用场景不限于上面描述的。
目前该改动只支持微信小程序, 未对其它程序类型做支持。

该改动兼容老的逻辑，无副作用。


**这个 PR 做了什么?** (简要描述所做更改)
weapp.ts在拷贝project.config.json文件时检查项目配置里面是否有projectConfigName,如果有，则拷贝projectConfigName指向的文件,没有则拷贝默认的project.config.json文件。


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
该功能在微信群8讨论过，没有收到异议。