### PR TITLE
fix(h5): unify the default content-type

### DIFF
--- a/packages/taro-h5/__test__/request-test.js
+++ b/packages/taro-h5/__test__/request-test.js
@@ -73,11 +73,10 @@ describe('request', () => {
         expect(fetch.mock.calls[0][0]).toBe('https://github.com')
         expect(fetch.mock.calls[0][1]).toEqual({
           method: 'POST',
-          body: {
-            arg: 123
-          },
+          body: JSON.stringify({ arg: 123 }),
           headers: {
-            'A': 'CCC'
+            'A': 'CCC',
+            'Content-Type': 'application/json'
           },
           mode: 'cors',
           cache: 'no-cache',

--- a/packages/taro-h5/src/api/request/index.js
+++ b/packages/taro-h5/src/api/request/index.js
@@ -52,9 +52,9 @@ function _request (options) {
   if (methodUpper === 'GET' || methodUpper === 'HEAD') {
     url = generateRequestUrlWithParams(url, options.data)
   } else if (typeof options.data === 'object') {
-    options.header = options.header || {};
+    options.header = options.header || {}
     options.header['Content-Type'] = options.header['Content-Type'] || options.header['content-type'] || 'application/json'
-    const contentType = options.header['Content-Type'];
+    const contentType = options.header['Content-Type']
 
     if (contentType.indexOf('application/json') >= 0) {
       params.body = JSON.stringify(options.data)

--- a/packages/taro-h5/src/api/request/index.js
+++ b/packages/taro-h5/src/api/request/index.js
@@ -52,10 +52,11 @@ function _request (options) {
   if (methodUpper === 'GET' || methodUpper === 'HEAD') {
     url = generateRequestUrlWithParams(url, options.data)
   } else if (typeof options.data === 'object') {
-    const contentType = options.header && (options.header['Content-Type'] || options.header['content-type'])
-    if (contentType && contentType.indexOf('application/json') >= 0) {
+    const contentType = (options.header && (options.header['Content-Type'] || options.header['content-type'])) || 'application/json'
+    
+    if (contentType.indexOf('application/json') >= 0) {
       params.body = JSON.stringify(options.data)
-    } else if (contentType && contentType.indexOf('application/x-www-form-urlencoded') >= 0) {
+    } else if (contentType.indexOf('application/x-www-form-urlencoded') >= 0) {
       params.body = serializeParams(options.data)
     } else {
       params.body = options.data

--- a/packages/taro-h5/src/api/request/index.js
+++ b/packages/taro-h5/src/api/request/index.js
@@ -52,7 +52,9 @@ function _request (options) {
   if (methodUpper === 'GET' || methodUpper === 'HEAD') {
     url = generateRequestUrlWithParams(url, options.data)
   } else if (typeof options.data === 'object') {
-    const contentType = (options.header && (options.header['Content-Type'] || options.header['content-type'])) || 'application/json'
+    options.header = options.header || {};
+    options.header['Content-Type'] = options.header['Content-Type'] || options.header['content-type'] || 'application/json'
+    const contentType = options.header['Content-Type'];
 
     if (contentType.indexOf('application/json') >= 0) {
       params.body = JSON.stringify(options.data)

--- a/packages/taro-h5/src/api/request/index.js
+++ b/packages/taro-h5/src/api/request/index.js
@@ -53,7 +53,7 @@ function _request (options) {
     url = generateRequestUrlWithParams(url, options.data)
   } else if (typeof options.data === 'object') {
     const contentType = (options.header && (options.header['Content-Type'] || options.header['content-type'])) || 'application/json'
-    
+
     if (contentType.indexOf('application/json') >= 0) {
       params.body = JSON.stringify(options.data)
     } else if (contentType.indexOf('application/x-www-form-urlencoded') >= 0) {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

将 `Taro.request` 中 `content-type` 的默认值设置为 `application/json`，使其和官方文档中的描述一致，方便开发者使用。
这个 issue 最初报在 #1280, 现在可以使用 https://github.com/yuezk/taro_bug/tree/master/h5_request__contentType 复现
![image](https://user-images.githubusercontent.com/3297602/95535456-181ed280-0a1b-11eb-8602-4c2908e0eedd.png)


翻了一下代码的历史记录，发现 #1280 被 https://github.com/NervJS/taro/commit/103f7301f1be726ecc5ab2a164ff009cd0ffdb25 这个 commit 修复，但随后又[被 revert 了](https://github.com/NervJS/taro/commit/ae5c42ba05a84378fe30a0319fc02d5df8de8d00)。看了一下修复的方法，发现原来的方案中添加默认的 `content-type` 的位置不对，这会导致给所有的没有设置 `content-type` 的请求设置一个 `application/json` 的 `content-type`，进而会使一些请求出问题。

比较的合适的时机应该当传入的 `data` 是 object，并且没有指定 `content-type` 的时候，给 `content-type` 一个默认值 `application/json`。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #1280
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
