### PR TITLE
fix(typing): 给与getStorageSync泛型默认值any

### DIFF
--- a/packages/taro/types/api/storage/index.d.ts
+++ b/packages/taro/types/api/storage/index.d.ts
@@ -20,7 +20,7 @@ declare namespace Taro {
     /** 本地缓存中指定的 key */
     key: string,
     /** 需要存储的内容。只支持原生类型、Date、及能够通过`JSON.stringify`序列化的对象。 */
-    data: any,
+    data: any
   ): void
 
   namespace setStorage {
@@ -93,7 +93,7 @@ declare namespace Taro {
    */
   function removeStorageSync(
     /** 本地缓存中指定的 key */
-    key: string,
+    key: string
   ): void
 
   namespace removeStorage {
@@ -155,9 +155,9 @@ declare namespace Taro {
    * ```
    * @see https://developers.weixin.qq.com/miniprogram/dev/api/storage/wx.getStorageSync.html
    */
-  function getStorageSync<T=any>(
+  function getStorageSync<T = any>(
     /** 本地缓存中指定的 key */
-    key: string,
+    key: string
   ): T
 
   namespace getStorageInfoSync {

--- a/packages/taro/types/api/storage/index.d.ts
+++ b/packages/taro/types/api/storage/index.d.ts
@@ -155,7 +155,7 @@ declare namespace Taro {
    * ```
    * @see https://developers.weixin.qq.com/miniprogram/dev/api/storage/wx.getStorageSync.html
    */
-  function getStorageSync<T>(
+  function getStorageSync<T=any>(
     /** 本地缓存中指定的 key */
     key: string,
   ): T


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

使用getStorageSync时给予泛型默认值为any。目的是为了向下兼容以前没有指定泛型的情况。

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [x] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [x] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [x] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
