### PR TITLE
fix(shared/cli): 修复 map 组件，fix #7762

### DIFF
--- a/packages/shared/src/components.ts
+++ b/packages/shared/src/components.ts
@@ -98,7 +98,7 @@ const Map = {
   'enable-rotate': 'false',
   'enable-satellite': 'false',
   'enable-traffic': 'false',
-  setting: '[]',
+  setting: '{}',
   bindMarkerTap: '',
   bindLabelTap: '',
   bindControlTap: '',

--- a/packages/taro-cli/src/presets/platforms/alipay.ts
+++ b/packages/taro-cli/src/presets/platforms/alipay.ts
@@ -21,8 +21,11 @@ export class Template extends RecursiveTemplate {
     return '<import-sjs name="xs" from="./utils.sjs" />'
   }
 
-  replacePropName (name, value) {
+  replacePropName (name, value, compName) {
     if (value === 'eh') return name.replace('bind', 'on')
+    if (compName === 'map' && value === 'i.polygons') {
+      name = 'polygon'
+    }
     return name
   }
 


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

1. setting 默认值改为 {}，避免钉钉安卓真机地图定位失败
2. 支付宝中用户的 polygons 属性应该绑定小程序的 polygon 属性

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #7762 

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）