### PR TITLE
fix(shared/react/runtime): 修复 map 组件

### DIFF
--- a/packages/shared/src/components.ts
+++ b/packages/shared/src/components.ts
@@ -98,7 +98,6 @@ const Map = {
   'enable-rotate': 'false',
   'enable-satellite': 'false',
   'enable-traffic': 'false',
-  setting: '{}',
   bindMarkerTap: '',
   bindLabelTap: '',
   bindControlTap: '',
@@ -106,7 +105,15 @@ const Map = {
   bindUpdated: '',
   bindRegionChange: '',
   bindPoiTap: '',
-  ...touchEvents
+  ...touchEvents,
+  ...selectEnv({
+    alipay: {
+      setting: '{}'
+    },
+    default: {
+      setting: '[]'
+    }
+  })
 }
 
 const Progress = {

--- a/packages/taro-react/src/props.ts
+++ b/packages/taro-react/src/props.ts
@@ -49,7 +49,12 @@ function setEvent (dom: TaroElement, name: string, value: unknown, oldValue?: un
     if (!oldValue) {
       dom.addEventListener(eventName, eventProxy, isCapture)
     }
-    dom.__handlers[eventName][0] = value
+    if (eventName === 'regionchange') {
+      dom.__handlers.begin[0] = value
+      dom.__handlers.end[0] = value
+    } else {
+      dom.__handlers[eventName][0] = value
+    }
   } else {
     dom.removeEventListener(eventName, eventProxy)
   }

--- a/packages/taro-runtime/src/dom/event_target.ts
+++ b/packages/taro-runtime/src/dom/event_target.ts
@@ -17,7 +17,12 @@ export class TaroEventTarget {
   public __handlers: Record<string, EventHandler[]> = {}
 
   public addEventListener (type: string, handler: EventHandler, options?: boolean | AddEventListenerOptions) {
-    warn(type === 'regionchange', 'map 组件的 regionchange 事件非常特殊，请使用 begin/end 事件替代。详情：https://github.com/NervJS/taro/issues/5766')
+    if (type === 'regionchange') {
+      // map 组件的 regionchange 事件非常特殊，详情：https://github.com/NervJS/taro/issues/5766
+      this.addEventListener('begin', handler, options)
+      this.addEventListener('end', handler, options)
+      return
+    }
     type = type.toLowerCase()
     const handlers = this.__handlers[type]
     let isCapture = Boolean(options)


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

* 在微信中 Map 组件 setting 属性还是要用 [] 做默认值，用 {} 会报错
* 可以绑定 onRegionChange

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #7687 

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
