### PR TITLE
修复saveFile下的SuccessCallbackResult中的savedFilePath类型定义问题

### DIFF
--- a/packages/taro/types/api/files/index.d.ts
+++ b/packages/taro/types/api/files/index.d.ts
@@ -24,7 +24,7 @@ declare namespace Taro {
     }
     interface SuccessCallbackResult extends General.CallbackResult {
       /** 存储后的文件路径 */
-      savedFilePath: number
+      savedFilePath: string
       /** 调用结果 */
       errMsg: string
     }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

将packages\taro\types\api\files\index.d.ts中saveFile下SuccessCallbackResult中的saveFilePath类型从number更改为string

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [√] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [√] 提交到 master 分支
- [√] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [√] 所有测试用例已经通过
- [√] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [√] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [√] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
