### PR TITLE
fix(mini-runner):  修复 Vue3 swiper 渲染问题，fix #7481

### DIFF
--- a/packages/taro-mini-runner/src/webpack/vue3.ts
+++ b/packages/taro-mini-runner/src/webpack/vue3.ts
@@ -54,6 +54,7 @@ export function customVue3Chain (chain) {
             const nodeName = node.tag
 
             if (capitalize(toCamelCase(nodeName)) in internalComponents) {
+              node.tagType = 0
               componentConfig.includes.add(nodeName)
             }
 


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

修复 Vue3 swiper 渲染问题:
vue-loader 识别出内置组件时，把 tagType 置为 0，表示是内置组件。
不然有可能为 1，也就是为自定义组件，从而导致奇怪的问题。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #7481 

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）