### PR TITLE
fix(runtime): 修复设置有默认值时的innerHTML时失败的问题，fix #7127

### DIFF
--- a/packages/taro-runtime/src/dom/html/html.ts
+++ b/packages/taro-runtime/src/dom/html/html.ts
@@ -2,7 +2,9 @@ import { parser } from './parser'
 import { TaroNode } from '../node'
 
 export function setInnerHTML (element: TaroNode, html: string) {
-  element.textContent = ''
+  element.childNodes.forEach(node => {
+    element.removeChild(node)
+  })
   const children = parser(html)
 
   for (let i = 0; i < children.length; i++) {


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

修复设置有默认值时的innerHTML时失败的问题

使用 removeChild 代替 textContent = ''，不同点在于：
removChild 的 hydrate 时会重新算 children 节点数据，
而 textContent 会把 cn 置为 []，并不会算 children，又因为 textContent = '' 后 appendChild 增加的数据会因为 performUpdate 的 resetPaths 逻辑被删掉，从而导致了问题。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #7127 

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）