### PR TITLE
chore(release): publish 3.0.15

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -35,6 +35,6 @@
       "license": "MIT"
     }
   },
-  "version": "3.0.14",
+  "version": "3.0.15",
   "npmClient": "yarn"
 }

--- a/packages/babel-plugin-transform-taroapi/package.json
+++ b/packages/babel-plugin-transform-taroapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-transform-taroapi",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc"

--- a/packages/babel-preset-taro/package.json
+++ b/packages/babel-preset-taro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-taro",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "> TODO: description",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/babel-preset-taro#readme",
@@ -33,9 +33,9 @@
     "@babel/preset-react": "7.10.4",
     "@babel/preset-typescript": "7.10.4",
     "@babel/runtime": "^7.11.2",
-    "@tarojs/taro-h5": "3.0.14",
+    "@tarojs/taro-h5": "3.0.15",
     "babel-plugin-dynamic-import-node": "^2.3.3",
-    "babel-plugin-transform-taroapi": "3.0.14",
+    "babel-plugin-transform-taroapi": "3.0.15",
     "core-js": "^3.6.5"
   }
 }

--- a/packages/eslint-config-taro/package.json
+++ b/packages/eslint-config-taro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-taro",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "Taro specific linting rules for ESLint",
   "main": "index.js",
   "files": [

--- a/packages/eslint-plugin-taro/package.json
+++ b/packages/eslint-plugin-taro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-taro",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "Taro specific linting plugin for ESLint",
   "main": "index.js",
   "files": [

--- a/packages/postcss-plugin-constparse/package.json
+++ b/packages/postcss-plugin-constparse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-plugin-constparse",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "parse constants defined in config",
   "main": "index.js",
   "author": "Simba",

--- a/packages/postcss-pxtransform/package.json
+++ b/packages/postcss-pxtransform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-pxtransform",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "PostCSS plugin px 转小程序 rpx及h5 rem 单位",
   "keywords": [
     "postcss",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/shared",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "> TODO: description",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/shared#readme",

--- a/packages/taro-api/package.json
+++ b/packages/taro-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/api",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "Taro common API",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/api#readme",
@@ -29,6 +29,6 @@
     "url": "https://github.com/NervJS/taro/issues"
   },
   "dependencies": {
-    "@tarojs/runtime": "3.0.14"
+    "@tarojs/runtime": "3.0.15"
   }
 }

--- a/packages/taro-cli/package.json
+++ b/packages/taro-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/cli",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "cli tool for taro",
   "main": "index.js",
   "scripts": {
@@ -44,11 +44,11 @@
   "license": "MIT",
   "dependencies": {
     "@hapi/joi": "17.1.1",
-    "@tarojs/helper": "3.0.14",
-    "@tarojs/service": "3.0.14",
-    "@tarojs/shared": "3.0.14",
-    "@tarojs/taro": "3.0.14",
-    "@tarojs/taroize": "3.0.14",
+    "@tarojs/helper": "3.0.15",
+    "@tarojs/service": "3.0.15",
+    "@tarojs/shared": "3.0.15",
+    "@tarojs/taro": "3.0.15",
+    "@tarojs/taroize": "3.0.15",
     "@tarojs/transformer-wx": "^2.0.4",
     "@types/request": "^2.48.1",
     "@typescript-eslint/parser": "^2.0.0",
@@ -76,11 +76,11 @@
     "ejs": "^2.6.1",
     "envinfo": "^6.0.1",
     "eslint": "^6.1.0",
-    "eslint-config-taro": "3.0.14",
+    "eslint-config-taro": "3.0.15",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-react": "^7.4.0",
     "eslint-plugin-react-hooks": "^1.6.1",
-    "eslint-plugin-taro": "3.0.14",
+    "eslint-plugin-taro": "3.0.15",
     "eslint-plugin-vue": "^6.2.2",
     "fbjs": "^1.0.0",
     "find-yarn-workspace-root": "1.2.1",
@@ -103,7 +103,7 @@
     "postcss-modules-resolve-imports": "^1.3.0",
     "postcss-modules-scope": "^1.1.0",
     "postcss-modules-values": "^1.3.0",
-    "postcss-pxtransform": "3.0.14",
+    "postcss-pxtransform": "3.0.15",
     "postcss-reporter": "^6.0.1",
     "postcss-taro-unit-transform": "1.2.15",
     "postcss-url": "^7.3.2",
@@ -124,7 +124,7 @@
     "xxhashjs": "^0.2.2"
   },
   "devDependencies": {
-    "@tarojs/mini-runner": "3.0.14",
-    "@tarojs/webpack-runner": "3.0.14"
+    "@tarojs/mini-runner": "3.0.15",
+    "@tarojs/webpack-runner": "3.0.15"
   }
 }

--- a/packages/taro-components/package.json
+++ b/packages/taro-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/components",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "",
   "main:h5": "src/index.js",
   "main": "dist/index.js",
@@ -38,7 +38,7 @@
   "license": "MIT",
   "dependencies": {
     "@stencil/core": "~1.8.1",
-    "@tarojs/taro": "3.0.14",
+    "@tarojs/taro": "3.0.15",
     "better-scroll": "^1.14.1",
     "classnames": "^2.2.5",
     "intersection-observer": "^0.7.0",

--- a/packages/taro-extend/package.json
+++ b/packages/taro-extend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/extend",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "Taro extend functionality",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-extend#readme",

--- a/packages/taro-h5/package.json
+++ b/packages/taro-h5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taro-h5",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "Taro h5 framework",
   "main:h5": "src/index.js",
   "main": "dist/index.cjs.js",
@@ -33,9 +33,9 @@
   "author": "O2Team",
   "license": "MIT",
   "dependencies": {
-    "@tarojs/api": "3.0.14",
-    "@tarojs/router": "3.0.14",
-    "@tarojs/runtime": "3.0.14",
+    "@tarojs/api": "3.0.15",
+    "@tarojs/router": "3.0.15",
+    "@tarojs/runtime": "3.0.15",
     "base64-js": "^1.3.0",
     "jsonp-retry": "^1.0.3",
     "mobile-detect": "^1.4.2",

--- a/packages/taro-helper/package.json
+++ b/packages/taro-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/helper",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "Taro Helper",
   "main": "index.js",
   "types": "types/index.d.ts",
@@ -41,7 +41,7 @@
     "@babel/preset-typescript": "7.10.4",
     "@babel/register": "7.9.0",
     "@babel/runtime": "7.9.2",
-    "@tarojs/taro": "3.0.14",
+    "@tarojs/taro": "3.0.15",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "chalk": "3.0.0",
     "chokidar": "3.3.1",

--- a/packages/taro-loader/package.json
+++ b/packages/taro-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taro-loader",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "> TODO: description",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-loader#readme",
@@ -32,6 +32,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@tarojs/taro": "3.0.14"
+    "@tarojs/taro": "3.0.15"
   }
 }

--- a/packages/taro-mini-runner/package.json
+++ b/packages/taro-mini-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/mini-runner",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "Mini app runner for taro",
   "main": "index.js",
   "scripts": {
@@ -37,12 +37,12 @@
     "@babel/core": "7.11.1",
     "@babel/plugin-proposal-class-properties": "7.10.4",
     "@babel/preset-env": "7.11.0",
-    "@tarojs/helper": "3.0.14",
-    "@tarojs/runner-utils": "3.0.14",
-    "@tarojs/runtime": "3.0.14",
-    "@tarojs/shared": "3.0.14",
-    "@tarojs/taro": "3.0.14",
-    "@tarojs/taro-loader": "3.0.14",
+    "@tarojs/helper": "3.0.15",
+    "@tarojs/runner-utils": "3.0.15",
+    "@tarojs/runtime": "3.0.15",
+    "@tarojs/shared": "3.0.15",
+    "@tarojs/taro": "3.0.15",
+    "@tarojs/taro-loader": "3.0.15",
     "babel-loader": "8.0.6",
     "babel-types": "^6.26.0",
     "copy-webpack-plugin": "^5.0.3",
@@ -84,9 +84,9 @@
     "yauzl": "2.10.0"
   },
   "devDependencies": {
-    "@tarojs/cli": "3.0.14",
-    "@tarojs/components": "3.0.14",
-    "@tarojs/react": "3.0.14",
-    "babel-preset-taro": "3.0.14"
+    "@tarojs/cli": "3.0.15",
+    "@tarojs/components": "3.0.15",
+    "@tarojs/react": "3.0.15",
+    "babel-preset-taro": "3.0.15"
   }
 }

--- a/packages/taro-react/package.json
+++ b/packages/taro-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/react",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "like react-dom, but for mini apps.",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-react#readme",
@@ -24,7 +24,7 @@
     "url": "https://github.com/NervJS/taro/issues"
   },
   "dependencies": {
-    "@tarojs/runtime": "3.0.14",
+    "@tarojs/runtime": "3.0.15",
     "react-reconciler": "^0.23.0",
     "scheduler": "^0.17.0"
   },

--- a/packages/taro-router/package.json
+++ b/packages/taro-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/router",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "Taro-router",
   "main:h5": "dist/router.esm.js",
   "main": "dist/index.js",
@@ -27,7 +27,7 @@
   "author": "O2Team",
   "license": "MIT",
   "dependencies": {
-    "@tarojs/runtime": "3.0.14",
+    "@tarojs/runtime": "3.0.15",
     "history": "^4.10.1",
     "universal-router": "^8.3.0",
     "url-parse": "^1.4.7"

--- a/packages/taro-runner-utils/package.json
+++ b/packages/taro-runner-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/runner-utils",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "Taro runner utilities.",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/core": "7.11.1",
-    "@tarojs/helper": "3.0.14",
+    "@tarojs/helper": "3.0.15",
     "chalk": "^3.0.0",
     "fs-extra": "^8.1.0",
     "lodash": "^4.17.15",

--- a/packages/taro-runtime/package.json
+++ b/packages/taro-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/runtime",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "taro runtime for mini apps.",
   "main": "dist/runtime.esm.js",
   "module": "dist/runtime.esm.js",

--- a/packages/taro-service/package.json
+++ b/packages/taro-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/service",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "Taro Service",
   "main": "index.js",
   "types": "types/index.d.ts",
@@ -34,8 +34,8 @@
   "homepage": "https://github.com/NervJS/taro#readme",
   "dependencies": {
     "@hapi/joi": "17.1.1",
-    "@tarojs/helper": "3.0.14",
-    "@tarojs/taro": "3.0.14",
+    "@tarojs/helper": "3.0.15",
+    "@tarojs/taro": "3.0.15",
     "fs-extra": "8.1.0",
     "lodash": "4.17.20",
     "resolve": "1.15.1",

--- a/packages/taro-webpack-runner/package.json
+++ b/packages/taro-webpack-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/webpack-runner",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "webpack runner for taro",
   "main": "index.js",
   "scripts": {
@@ -31,11 +31,11 @@
   "homepage": "https://github.com/NervJS/taro#readme",
   "dependencies": {
     "@babel/core": "7.11.1",
-    "@tarojs/helper": "3.0.14",
-    "@tarojs/runner-utils": "3.0.14",
-    "@tarojs/runtime": "3.0.14",
-    "@tarojs/shared": "3.0.14",
-    "@tarojs/taro-loader": "3.0.14",
+    "@tarojs/helper": "3.0.15",
+    "@tarojs/runner-utils": "3.0.15",
+    "@tarojs/runtime": "3.0.15",
+    "@tarojs/shared": "3.0.15",
+    "@tarojs/taro-loader": "3.0.15",
     "autoprefixer": "9.7.4",
     "babel-loader": "8.0.6",
     "copy-webpack-plugin": "5.1.1",
@@ -53,8 +53,8 @@
     "open": "7.0.2",
     "ora": "4.0.3",
     "postcss-loader": "3.0.0",
-    "postcss-plugin-constparse": "3.0.14",
-    "postcss-pxtransform": "3.0.14",
+    "postcss-plugin-constparse": "3.0.15",
+    "postcss-pxtransform": "3.0.15",
     "resolve": "1.15.1",
     "resolve-url-loader": "3.1.1",
     "sass": "^1.25.0",
@@ -70,8 +70,8 @@
     "webpack-format-messages": "2.0.3"
   },
   "devDependencies": {
-    "@tarojs/components": "3.0.14",
-    "@tarojs/taro": "3.0.14",
+    "@tarojs/components": "3.0.15",
+    "@tarojs/taro": "3.0.15",
     "@types/autoprefixer": "9.7.0",
     "@types/detect-port": "1.1.0",
     "@types/lodash": "4.14.149",
@@ -79,7 +79,7 @@
     "@types/resolve": "1.14.0",
     "@types/webpack": "4.41.6",
     "@types/webpack-dev-server": "3.11.0",
-    "babel-plugin-transform-taroapi": "3.0.14",
-    "babel-preset-taro": "3.0.14"
+    "babel-plugin-transform-taroapi": "3.0.15",
+    "babel-preset-taro": "3.0.15"
   }
 }

--- a/packages/taro-with-weapp/package.json
+++ b/packages/taro-with-weapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/with-weapp",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "taroize 之后的运行时",
   "main": "index.js",
   "scripts": {
@@ -22,8 +22,8 @@
   "author": "yuche",
   "license": "MIT",
   "dependencies": {
-    "@tarojs/runtime": "3.0.14",
-    "@tarojs/taro": "3.0.14",
+    "@tarojs/runtime": "3.0.15",
+    "@tarojs/taro": "3.0.15",
     "lodash": "^4.17.11"
   }
 }

--- a/packages/taro/package.json
+++ b/packages/taro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taro",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "Taro framework",
   "main": "index.js",
   "main:h5": "h5.js",
@@ -31,10 +31,10 @@
   "author": "O2Team",
   "license": "MIT",
   "dependencies": {
-    "@tarojs/api": "3.0.14",
-    "@tarojs/taro-h5": "3.0.14"
+    "@tarojs/api": "3.0.15",
+    "@tarojs/taro-h5": "3.0.15"
   },
   "devDependencies": {
-    "@tarojs/runtime": "3.0.14"
+    "@tarojs/runtime": "3.0.15"
   }
 }

--- a/packages/taroize/package.json
+++ b/packages/taroize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taroize",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "转换原生微信小程序代码为 Taro 代码",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## Breaking Changes

- 将 **file-loader** 的 `esModule` 参数默认设置为 **false**
  解决 Vue `template` 中不能直接使用图片链接的问题，#7869

  开发者在 Taro v3.0 - v3.0.14 中，**require** 资源需要加 `.default`， v3.0.15 之后直接 **require** 即可：

```html
// v3.0.0 - v3.0.14
<Image src="{require('someImage').default}" />
// v3.0.15+
<Image src="{require('someImage')}" />
```

## 修复问题
 
### 小程序
 
- 支持支付宝小程序 `Swiper` 组件的 `disable-touch` 属性，by @Jetsly 
- 修复 `PickerView` value 设置问题，#7638
- 修复 Vue3 eslint 配置没有发布的问题， #7814
- 修复钉钉小程序地图组件问题，#7762
- 修复 Map 组件 `onRegionChange` 触发失败的问题，#7687
- 修复 Vue3 `onShow` 无法访问 this 中属性的问题，#7771
- 修复获取不到 Taro.env 的问题，#7392
- 修复支付宝小程序 `Swiper` 组件模板多嵌套了一层 `View` 组件的问题
- 修复 Vue3 `Swiper` 组件渲染问题，#7481
- 修复设置带有默认值的 `innerHTML` 时失败的问题，#7127
- 支持 `getBatteryInfo` API，#7846
- 支持 `Swiper` 组件的 `acceleration` 属性，#7801 

### H5
 
- 修复 Taro request API 的 `Content-Type`、修复测试用例，by @yuezk
- 修复 h5 端开启 `enablePullDownRefresh` 后不能触发 `componentDidShow` 的问题，by @lukezhange001
- 默认指定 h5 router mode 为 **hash**，#7871
 
### typings
 
- 修复 `getStorageSync` 类型，by @xiaoyao96
- 修复 `Button` 组件类型，by @wuchangming
- 修复 `Icon` 组件类型，by @k55k32 
- 修复 `saveFile` API 的类型，by @Soul-Stone
- 修复 `Map` 组件类型，#7507

### 其他
 
- 修复模板中 **eslintrc** 格式问题，#7772