### PR TITLE
fix(taro/types): 事件名仅支持Symbol类型

### DIFF
--- a/packages/taro/types/taro.extend.d.ts
+++ b/packages/taro/types/taro.extend.d.ts
@@ -8,17 +8,17 @@ declare namespace Taro {
     /**
      * 监听一个事件，接受参数
      */
-    on(eventName: string | symbol, listener: (...args: any[]) => void): this
+    on(eventName: string, listener: (...args: any[]) => void): this
 
     /**
      * 添加一个事件监听，并在事件触发完成之后移除Callbacks链
      */
-    once(eventName: string | symbol, listener: (...args: any[]) => void): this
+    once(eventName: string, listener: (...args: any[]) => void): this
 
     /**
      * 取消监听一个事件
      */
-    off(eventName: string | symbol, listener?: (...args: any[]) => void): this
+    off(eventName: string, listener?: (...args: any[]) => void): this
 
     /**
      * 取消监听的所有事件
@@ -28,7 +28,7 @@ declare namespace Taro {
     /**
      * 触发一个事件，传参
      */
-    trigger(eventName: string | symbol, ...args: any[]): boolean
+    trigger(eventName: string, ...args: any[]): boolean
   }
 
   // eventCenter


### PR DESCRIPTION
**这个 PR 做了什么?** 

修改 @tarojs/taro 中的 Events 类型定义，事件名不支持 Symbol 类型。详见：https://github.com/NervJS/taro/pull/7558#issuecomment-715379416

**这个 PR 是什么类型?**

- [x] TypeScript 类型定义修改(Typings)


**这个 PR 满足以下需求:**

- [x] 提交到 next分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能