### PR TITLE
fix(runtime): 修复列表顺序变化时，部分列表项点击事件失效的问题，fix #7227

### DIFF
--- a/packages/taro-runtime/src/dom/node.ts
+++ b/packages/taro-runtime/src/dom/node.ts
@@ -114,6 +114,11 @@ export class TaroNode extends TaroEventTarget {
     CurrentReconciler.insertBefore?.(this, newChild, refChild)
 
     this.enqueueUpdate(payload)
+
+    if (!eventSource.has(newChild.uid)) {
+      eventSource.set(newChild.uid, newChild)
+    }
+
     return newChild
   }
 


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

修复列表顺序变化时，部分列表项点击事件失效的问题。

`insertBefore` 时会先调用新节点的 `remove` 方法，此时会把此节点从 `eventSource` 删除，从而导致事件因 `getElementById` 找不到对应节点而不触发。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #7227 

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）