### PR TITLE
fix(shared): 修复 Swiper 不能嵌套调用的问题，fix #7692

### DIFF
--- a/packages/shared/src/template.ts
+++ b/packages/shared/src/template.ts
@@ -80,7 +80,8 @@ const nestElements = new Map([
   ['slot-view', 8],
   ['label', 6],
   ['form', 4],
-  ['scroll-view', 4]
+  ['scroll-view', 4],
+  ['swiper', 4]
 ])
 
 const weixinAdapter: IAdapter = {

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/prerender.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/prerender.spec.ts.snap
@@ -2041,8 +2041,8 @@ require(\\"./taro\\");
 /** filePath: dist/utils.wxs **/
 module.exports = {
   a: function (l, n, s) {
-    var a = [\\"view\\",\\"cover-view\\",\\"block\\",\\"text\\",\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\"]
-    var b = [\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\"]
+    var a = [\\"view\\",\\"cover-view\\",\\"block\\",\\"text\\",\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\",\\"swiper\\"]
+    var b = [\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\",\\"swiper\\"]
     if (a.indexOf(n) === -1) {
       l = 0
     }
@@ -2070,7 +2070,7 @@ module.exports = {
     return 'tmpl_' + n + '_container'
   },
   f: function (l, n) {
-    var b = [\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\"]
+    var b = [\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\",\\"swiper\\"]
     if (b.indexOf(n) > -1) {
       if (l) l += ','
       l += n
@@ -4311,8 +4311,8 @@ require(\\"./taro\\");
 /** filePath: dist/utils.wxs **/
 module.exports = {
   a: function (l, n, s) {
-    var a = [\\"view\\",\\"cover-view\\",\\"block\\",\\"text\\",\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\"]
-    var b = [\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\"]
+    var a = [\\"view\\",\\"cover-view\\",\\"block\\",\\"text\\",\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\",\\"swiper\\"]
+    var b = [\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\",\\"swiper\\"]
     if (a.indexOf(n) === -1) {
       l = 0
     }
@@ -4340,7 +4340,7 @@ module.exports = {
     return 'tmpl_' + n + '_container'
   },
   f: function (l, n) {
-    var b = [\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\"]
+    var b = [\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\",\\"swiper\\"]
     if (b.indexOf(n) > -1) {
       if (l) l += ','
       l += n
@@ -6551,8 +6551,8 @@ require(\\"./taro\\");
 /** filePath: dist/utils.wxs **/
 module.exports = {
   a: function (l, n, s) {
-    var a = [\\"view\\",\\"cover-view\\",\\"block\\",\\"text\\",\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\"]
-    var b = [\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\"]
+    var a = [\\"view\\",\\"cover-view\\",\\"block\\",\\"text\\",\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\",\\"swiper\\"]
+    var b = [\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\",\\"swiper\\"]
     if (a.indexOf(n) === -1) {
       l = 0
     }
@@ -6580,7 +6580,7 @@ module.exports = {
     return 'tmpl_' + n + '_container'
   },
   f: function (l, n) {
-    var b = [\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\"]
+    var b = [\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\",\\"swiper\\"]
     if (b.indexOf(n) > -1) {
       if (l) l += ','
       l += n

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/qq.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/qq.spec.ts.snap
@@ -2512,8 +2512,8 @@ require(\\"./taro\\");
 /** filePath: dist/utils.wxs **/
 module.exports = {
   a: function (l, n, s) {
-    var a = [\\"view\\",\\"cover-view\\",\\"block\\",\\"text\\",\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\"]
-    var b = [\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\"]
+    var a = [\\"view\\",\\"cover-view\\",\\"block\\",\\"text\\",\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\",\\"swiper\\"]
+    var b = [\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\",\\"swiper\\"]
     if (a.indexOf(n) === -1) {
       l = 0
     }
@@ -2541,7 +2541,7 @@ module.exports = {
     return 'tmpl_' + n + '_container'
   },
   f: function (l, n) {
-    var b = [\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\"]
+    var b = [\\"slot\\",\\"slot-view\\",\\"label\\",\\"form\\",\\"scroll-view\\",\\"swiper\\"]
     if (b.indexOf(n) > -1) {
       if (l) l += ','
       l += n


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

修复 Swiper 不能嵌套调用的问题，默认可以循环 4 次。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #7692 

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）