### PR TITLE
fix(h5): 修复 h5 ContentType 重复设置的问题，fix #7972

### DIFF
--- a/packages/taro-h5/src/api/request/index.js
+++ b/packages/taro-h5/src/api/request/index.js
@@ -53,8 +53,12 @@ function _request (options) {
     url = generateRequestUrlWithParams(url, options.data)
   } else if (typeof options.data === 'object') {
     options.header = options.header || {}
-    options.header['Content-Type'] = options.header['Content-Type'] || options.header['content-type'] || 'application/json'
-    const contentType = options.header['Content-Type']
+
+    const keyOfContentType = Object.keys(options.header).find(item => item.toLowerCase() === 'content-type')
+    if (!keyOfContentType) {
+      options.header['Content-Type'] = 'application/json'
+    }
+    const contentType = options.header[keyOfContentType || 'Content-Type']
 
     if (contentType.indexOf('application/json') >= 0) {
       params.body = JSON.stringify(options.data)


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

修复 h5 ContentType 重复设置的问题

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #7972 

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）