### PR TITLE
docs(fix)，在 2.0.0-alpha.68 中需要设置 dark 模式下 logo 路径

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -249,6 +249,7 @@ const siteConfigTaroZone = {
       logo: {
         alt: 'Taro logo',
         src: 'img/logo-taro.png',
+        srcDark: 'img/logo-taro.png'
       },
       items: [
         {


### PR DESCRIPTION
在 2.0.0-alpha.68 中需要设置 dark 模式下 logo 路径，不然 logo 会消失