### PR TITLE
docs(fix) 修复在996像素下侧边导航顶部logo不可见，首页顶部导航按钮对比度低的问题

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -237,6 +237,13 @@ a, a:hover {
 }
 
 @media (max-width: 996px) {
+  .navbar .navbar__toggle {
+    display: inherit;
+    color: #fff;
+  }
+  .navbar .navbar-sidebar__brand {
+    background-image: linear-gradient(180deg, #0000c2, #0000c2);
+  }
   .grid_c1,
   .footer_link_container,
   .footer .footer_logo_container {


### PR DESCRIPTION
996像素下侧边导航顶部底色为白色、导致logo不可见，首页顶部导航按钮为黑色，现改为白色