### PR TITLE
fix(taro-h5): support fileName parameter when using Taro.uploadFile api (#7377)

### DIFF
--- a/packages/taro-h5/src/api/fileTransfer/uploadFile.js
+++ b/packages/taro-h5/src/api/fileTransfer/uploadFile.js
@@ -6,7 +6,7 @@ import {
   XHR_STATS
 } from './utils'
 
-const createUploadTask = ({ url, filePath, formData, name, header, success, error }) => {
+const createUploadTask = ({ url, filePath, formData, name, header, fileName, success, error }) => {
   let timeout
   let formKey
   const apiName = 'uploadFile'
@@ -81,7 +81,7 @@ const createUploadTask = ({ url, filePath, formData, name, header, success, erro
 
   convertObjectUrlToBlob(filePath)
     .then(fileObj => {
-      form.append(name, fileObj, fileObj.name || `file-${Date.now()}`)
+      form.append(name, fileObj, fileName || fileObj.name || `file-${Date.now()}`)
       send()
     })
     .catch(e => {
@@ -137,12 +137,13 @@ const createUploadTask = ({ url, filePath, formData, name, header, success, erro
  * @param {string} object.name 文件对应的 key，开发者在服务端可以通过这个 key 获取文件的二进制内容
  * @param {Object} [object.header] HTTP 请求 Header，Header 中不能设置 Referer
  * @param {Object} [object.formData] HTTP 请求中其他额外的 form data
+ * @param {string} object.fileName 上传的文件名
  * @param {function} [object.success] 接口调用成功的回调函数
  * @param {function} [object.fail] 接口调用失败的回调函数
  * @param {function} [object.complete] 接口调用结束的回调函数（调用成功、失败都会执行）
  * @returns {UploadTask}
  */
-const uploadFile = ({ url, filePath, name, header, formData, success, fail, complete }) => {
+const uploadFile = ({ url, filePath, name, header, formData, fileName, success, fail, complete }) => {
   let task
   const promise = new Promise((resolve, reject) => {
     task = createUploadTask({
@@ -151,6 +152,7 @@ const uploadFile = ({ url, filePath, name, header, formData, success, fail, comp
       name,
       filePath,
       formData,
+      fileName,
       success: res => {
         success && success(res)
         complete && complete()


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
H5 环境下 Taro.uploadFile api 支持 fileName 参数（fix: #7377）


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #7377
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
