### PR TITLE
fix(taro-h5): fix (#7280) that canvas is null when using related api such as canvasToTempFilePath in h5 environment

### DIFF
--- a/packages/taro-h5/src/api/canvas/canvasGetImageData.js
+++ b/packages/taro-h5/src/api/canvas/canvasGetImageData.js
@@ -18,7 +18,7 @@ import { findDOM } from '../utils/index'
  */
 const canvasGetImageData = ({ canvasId, success, fail, complete, x, y, width, height }, inst) => {
   /** @type {HTMLCanvasElement} */
-  const canvas = findDOM(inst).querySelector(`[canvasId=${canvasId}]`)
+  const canvas = findDOM(inst).querySelector(`canvas[canvas-id=${canvasId}]`)
 
   try {
     const ctx = canvas.getContext('2d')

--- a/packages/taro-h5/src/api/canvas/canvasPutImageData.js
+++ b/packages/taro-h5/src/api/canvas/canvasPutImageData.js
@@ -20,7 +20,7 @@ import { findDOM } from '../utils/index'
  */
 const canvasPutImageData = ({ canvasId, data, x, y, success, fail, complete }, inst) => {
   /** @type {HTMLCanvasElement} */
-  const canvas = findDOM(inst).querySelector(`[canvasId=${canvasId}]`)
+  const canvas = findDOM(inst).querySelector(`canvas[canvas-id=${canvasId}]`)
 
   try {
     const ctx = canvas.getContext('2d')

--- a/packages/taro-h5/src/api/canvas/canvasToTempFilePath.js
+++ b/packages/taro-h5/src/api/canvas/canvasToTempFilePath.js
@@ -23,7 +23,7 @@ import { findDOM } from '../utils/index'
  */
 const canvasToTempFilePath = ({ canvasId, fileType, quality, success, fail, complete }) => {
   /** @type {HTMLCanvasElement} */
-  const canvas = findDOM().querySelector(`[canvasId=${canvasId}]`)
+  const canvas = findDOM().querySelector(`canvas[canvas-id=${canvasId}]`)
 
   try {
     // /** @type {CanvasRenderingContext2D} */


### PR DESCRIPTION

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复 H5 环境下 以下 api 获取 canvas 为 null 的问题 #7280 
- [x] canvasToTempFilePath
- [x] canvasGetImageData
- [x] canvasPutImageData


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #7280 
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
