### PR TITLE
fix: virtual-list relative size

### DIFF
--- a/packages/taro-components/virtual-list/react/createListComponent.js
+++ b/packages/taro-components/virtual-list/react/createListComponent.js
@@ -464,7 +464,6 @@ export default function createListComponent ({
         useIsScrolling,
         width,
         position,
-        unlimitedSize,
         renderBottom,
         ...rest
       } = this.props
@@ -485,31 +484,24 @@ export default function createListComponent ({
       if (itemCount > 0) {
         for (let index = startIndex; index <= stopIndex; index++) {
           const key = itemKey(index, itemData)
+          let style
           if (position === 'relative') {
             const size = getItemSize(this.props, index, this)
-            const style = unlimitedSize ? {} : {
-              height: this._getStyleValue(isHorizontal ? '100%' : size),
+            style = {
+              height: this._getStyleValue(!isHorizontal ? size : '100%'),
               width: this._getStyleValue(isHorizontal ? size : '100%')
             }
-            items.push(createElement(children, {
-              key,
-              id: `${id}-${index}`,
-              data: itemData,
-              index,
-              isScrolling: useIsScrolling ? isScrolling : undefined,
-              style
-            }))
           } else {
-            const style = this._getItemStyle(index)
-            items.push(createElement(itemElementType || itemTagName || 'div', {
-              key, style
-            }, createElement(children, {
-              id: `${id}-${index}`,
-              data: itemData,
-              index,
-              isScrolling: useIsScrolling ? isScrolling : undefined
-            })))
+            style = this._getItemStyle(index)
           }
+          items.push(createElement(itemElementType || itemTagName || 'div', {
+            key, style
+          }, createElement(children, {
+            id: `${id}-${index}`,
+            data: itemData,
+            index,
+            isScrolling: useIsScrolling ? isScrolling : undefined
+          })))
         }
       }
       // Read this value AFTER items have been created,

--- a/packages/taro-components/virtual-list/react/createListComponent.js
+++ b/packages/taro-components/virtual-list/react/createListComponent.js
@@ -464,6 +464,7 @@ export default function createListComponent ({
         useIsScrolling,
         width,
         position,
+        unlimitedSize,
         renderBottom,
         ...rest
       } = this.props
@@ -485,12 +486,18 @@ export default function createListComponent ({
         for (let index = startIndex; index <= stopIndex; index++) {
           const key = itemKey(index, itemData)
           if (position === 'relative') {
+            const size = getItemSize(this.props, index, this)
+            const style = unlimitedSize ? {} : {
+              height: this._getStyleValue(isHorizontal ? '100%' : size),
+              width: this._getStyleValue(isHorizontal ? size : '100%')
+            }
             items.push(createElement(children, {
               key,
               id: `${id}-${index}`,
               data: itemData,
               index,
-              isScrolling: useIsScrolling ? isScrolling : undefined
+              isScrolling: useIsScrolling ? isScrolling : undefined,
+              style
             }))
           } else {
             const style = this._getItemStyle(index)


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

relative 布局模式下，itemSize 和实际子节点高度不一致会导致显示错误

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [x] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [x] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
