### PR TITLE
fix(runtime): 补全 window 对象的关键属性, fix #8327

### DIFF
--- a/packages/taro-runtime/src/bom/window.ts
+++ b/packages/taro-runtime/src/bom/window.ts
@@ -26,4 +26,10 @@ if (process.env.TARO_ENV !== 'h5') {
   (window as any).requestAnimationFrame = raf;
   (window as any).cancelAnimationFrame = caf;
   (window as any).getComputedStyle = getComputedStyle
+  if (!('Date' in window)) {
+    (window as any).Date = Date
+  }
+  if (!('setTimeout' in window)) {
+    (window as any).setTimeout = setTimeout
+  }
 }


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

京东、支付宝小程序没有 global，会导致 React 必须的 Date、setTimeout 对象没有赋值在 global 上。
因此作一个兜底，当 window 没有这些对象时，直接赋值。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #8327

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）