### PR TITLE
fix(mini-runner): 修复 app 样式打包错误的问题

### DIFF
--- a/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
+++ b/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
@@ -819,11 +819,11 @@ export default class TaroMiniPlugin {
 
     const originSource: string = assets[appStyle].source()
     const source = new ConcatSource()
+    source.add(originSource)
 
     Object.keys(assets).forEach(assetName => {
       const fileName = path.basename(assetName, path.extname(assetName))
       if (REG_STYLE.test(assetName) && this.options.commonChunks.includes(fileName)) {
-        source.add(originSource)
         source.add('\n')
         source.add(`@import ${JSON.stringify(urlToRequest(assetName))};`)
         assets[appStyle] = {


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

修复 app 样式时，重复 concat app css 的问题

before:

```sass
// app css
@import base
// app css
@import taro
```

after

```sass
// app css
@import base
@import taro
```

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix)

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）