### PR TITLE
fix(runtime): 在微信中clearTimeout要绑定global，fix #7749

### DIFF
--- a/packages/taro-runtime/src/bom/raf.ts
+++ b/packages/taro-runtime/src/bom/raf.ts
@@ -24,10 +24,20 @@ let lastTime = 0
 
 // https://gist.github.com/paulirish/1579671
 // https://gist.github.com/jalbam/5fe05443270fa6d8136238ec72accbc0
-export const raf = typeof requestAnimationFrame !== 'undefined' && requestAnimationFrame !== null ? requestAnimationFrame : function (callback) {
+let raf = typeof requestAnimationFrame !== 'undefined' && requestAnimationFrame !== null ? requestAnimationFrame : function (callback) {
   const _now = now()
   const nextTime = Math.max(lastTime + 16, _now) // First time will execute it immediately but barely noticeable and performance is gained.
   return setTimeout(function () { callback(lastTime = nextTime) }, nextTime - _now)
 }
 
-export const caf = typeof cancelAnimationFrame !== 'undefined' && cancelAnimationFrame !== null ? cancelAnimationFrame : clearTimeout
+let caf = typeof cancelAnimationFrame !== 'undefined' && cancelAnimationFrame !== null ? cancelAnimationFrame : clearTimeout
+
+if (global) {
+  raf = raf.bind(global)
+  caf = caf.bind(global)
+}
+
+export {
+  raf,
+  caf
+}


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

微信中 `clearTimeout` 要绑定 global

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #7749 

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）