### PR TITLE
fix(mini-runner): 修复 Vue3 运行时报错，fix #8426

### DIFF
--- a/packages/taro-mini-runner/src/webpack/build.conf.ts
+++ b/packages/taro-mini-runner/src/webpack/build.conf.ts
@@ -163,7 +163,8 @@ export default (appPath: string, mode, config: Partial<IBuildConfig>): any => {
     document: ['@tarojs/runtime', 'document'],
     navigator: ['@tarojs/runtime', 'navigator'],
     requestAnimationFrame: ['@tarojs/runtime', 'requestAnimationFrame'],
-    cancelAnimationFrame: ['@tarojs/runtime', 'cancelAnimationFrame']
+    cancelAnimationFrame: ['@tarojs/runtime', 'cancelAnimationFrame'],
+    Element: ['@tarojs/runtime', 'TaroElement']
   })
 
   const isCssoEnabled = !((csso && csso.enable === false))


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

修复 Vue3 运行时报错：

Vue3 使用了 `Element` 对象，小程序环境使用 `ProvidePlugin` 直接替换为 `TaroElement`

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #8426 

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）