### PR TITLE
fix(runtime): 修复使用vant时一系列问题，fix #8407 #8242 #8364

### DIFF
--- a/packages/shared/src/template.ts
+++ b/packages/shared/src/template.ts
@@ -22,7 +22,7 @@ import {
 } from './components'
 import { Shortcuts } from './shortcuts'
 import { isBooleanStringLiteral, isNumber, isFunction } from './is'
-import { toCamelCase, toDashed, hasOwn } from './utils'
+import { toCamelCase, toKebabCase, toDashed, hasOwn } from './utils'
 
 interface Component {
   nodeName: string;
@@ -224,12 +224,23 @@ export class BaseTemplate {
 
   protected buildThirdPartyAttr (attrs: Set<string>) {
     return Array.from(attrs).reduce((str, attr) => {
-      if (attr.startsWith('@')) { // vue event
-        return str + `bind${attr.slice(1)}="eh" `
+      if (attr.startsWith('@')) {
+        // vue2
+        let value = attr.slice(1)
+        if (value.indexOf('-') > -1) {
+          value = `:${value}`
+        }
+        return str + `bind${value}="eh" `
       } else if (attr.startsWith('bind')) {
         return str + `${attr}="eh" `
       } else if (attr.startsWith('on')) {
-        return str + `bind${attr.slice(2).toLowerCase()}="eh" `
+        // react, vue3
+        let value = toKebabCase(attr.slice(2))
+        if (value.indexOf('-') > -1) {
+          // 兼容如 vant 某些组件的 bind:a-b 这类属性
+          value = `:${value}`
+        }
+        return str + `bind${value}="eh" `
       }
 
       return str + `${attr}="{{i.${toCamelCase(attr)}}}" `

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -53,7 +53,6 @@ export const toKebabCase = function (string) {
   return string.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()
 }
 
-
 export function capitalize (s: string) {
   return s.charAt(0).toUpperCase() + s.slice(1)
 }

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -49,6 +49,11 @@ export function toCamelCase (s: string) {
   return camel
 }
 
+export const toKebabCase = function (string) {
+  return string.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()
+}
+
+
 export function capitalize (s: string) {
   return s.charAt(0).toUpperCase() + s.slice(1)
 }

--- a/packages/taro-mini-runner/src/webpack/vue3.ts
+++ b/packages/taro-mini-runner/src/webpack/vue3.ts
@@ -66,7 +66,11 @@ export function customVue3Chain (chain) {
                 } else if ((prop as any).type === 7 /* DIRECTIVE */) {
                   prop = prop as DirectiveNode
                   if (prop.arg?.type === 4 /* SimpleExpression */) {
-                    usingComponent.add((prop.arg as SimpleExpressionNode).content)
+                    let value = (prop.arg as SimpleExpressionNode).content
+                    if (prop.name === 'on') {
+                      value = `on${value}`
+                    }
+                    usingComponent.add(value)
                   }
                 }
               })

--- a/packages/taro-runtime/src/dom/event.ts
+++ b/packages/taro-runtime/src/dom/event.ts
@@ -2,6 +2,7 @@ import { TaroNode } from './node'
 import { EMPTY_OBJ } from '@tarojs/shared'
 import { document } from '../bom/document'
 import { TaroElement } from './element'
+import { CurrentReconciler } from '../reconciler'
 
 interface EventOptions {
   bubbles: boolean;
@@ -91,6 +92,8 @@ export function createEvent (event: MpEvent | string, _?: TaroElement) {
 }
 
 export function eventHandler (event: MpEvent) {
+  CurrentReconciler.modifyEventType?.(event)
+
   if (event.currentTarget == null) {
     event.currentTarget = event.target
   }

--- a/packages/taro-runtime/src/dsl/react.ts
+++ b/packages/taro-runtime/src/dsl/react.ts
@@ -110,6 +110,9 @@ function setReconciler () {
           next[item] = [...(next[item] || []), ...prev[item]]
         }
       })
+    },
+    modifyEventType (event) {
+      event.type = event.type.replace(/-/g, '')
     }
   }
 

--- a/packages/taro-runtime/src/dsl/vue3.ts
+++ b/packages/taro-runtime/src/dsl/vue3.ts
@@ -76,6 +76,9 @@ function setReconciler () {
       } else {
         delete dom.props[qualifiedName]
       }
+    },
+    modifyEventType (event) {
+      event.type = event.type.replace(/-/g, '')
     }
   }
 

--- a/packages/taro-runtime/src/reconciler.ts
+++ b/packages/taro-runtime/src/reconciler.ts
@@ -3,6 +3,7 @@ import type { TaroText } from './dom/text'
 import type { DataTree, TaroNode } from './dom/node'
 import type { TaroRootElement } from './dom/root'
 import type { Instance, PageInstance, PageProps } from './dsl/instance'
+import { MpEvent } from './dom/event'
 
 type Inst = Instance<PageProps>
 
@@ -21,6 +22,8 @@ export interface Reconciler<Instance, DOMElement = TaroElement, TextElement = Ta
   prepareUpdateData?(data: DataTree, page: TaroRootElement): DataTree
 
   appendInitialPage?(data: DataTree, page: TaroRootElement): DataTree
+
+  modifyEventType?(event: MpEvent): void
 
   getLifecyle(instance: Instance, lifecyle: keyof PageInstance): Function | undefined | Array<Function>
 


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

1. 修复 react、vue、vue3 都不能使用 vant 的 kebab-case 事件的问题
2. 修复 vue3 使用第三方组件时事件绑定错误的问题

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #8407 #8242 #8364 

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）