### PR TITLE
feat(runtime): 同步 3.1 修改，让小程序 app 对象上可以挂载自定义属性

### DIFF
--- a/packages/taro-runtime/src/dsl/instance.ts
+++ b/packages/taro-runtime/src/dsl/instance.ts
@@ -76,4 +76,6 @@ export interface AppInstance extends Show {
   onLaunch? (options?: string): void
   mount? (component: React.ComponentClass | ComponentOptions<VueCtor> | Vue3Component, id: string, cb: () => void): void
   unmount? (id: string, cb: () => void): void
+  onPageNotFound? (res: any): void
+  taroGlobalData?: Record<any, any>
 }

--- a/packages/taro-runtime/src/dsl/react.ts
+++ b/packages/taro-runtime/src/dsl/react.ts
@@ -233,6 +233,29 @@ export function createReactApp (App: React.ComponentClass, react: typeof React, 
         // eslint-disable-next-line react/no-render-return-value
         wrapper = ReactDOM.render(R.createElement(AppWrapper), document.getElementById('app'))
         const app = ref.current
+
+        // For taroize
+        // 把 App Class 上挂载的额外属性同步到全局 app 对象中
+        if (app?.taroGlobalData) {
+          const globalData = app.taroGlobalData
+          const keys = Object.keys(globalData)
+          const descriptors = Object.getOwnPropertyDescriptors(globalData)
+          keys.forEach(key => {
+            Object.defineProperty(this, key, {
+              configurable: true,
+              enumerable: true,
+              get () {
+                return globalData[key]
+              },
+              set (value) {
+                globalData[key] = value
+              }
+            })
+          })
+          Object.defineProperties(this, descriptors)
+        }
+        this.$app = app
+
         if (app != null && isFunction(app.onLaunch)) {
           app.onLaunch(options)
         }


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

同步 3.1 修改，让小程序 app 对象上可以挂载自定义属性。

用法：

```js
import { Component } from 'react'
import './app.scss'

class App extends Component {
  taroGlobalData = {
    x: 1,
    userInfo: {
      name: 'jack',
      age: 20
    },
    foo () {
      console.log('foo')
    }
  }

  // this.props.children 是将要会渲染的页面
  render () {
    return this.props.children
  }
}

export default App
```

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）