### PR TITLE
fix(runtime): 修复react事件回调里没有合并更新的问题，fix #8516

### DIFF
--- a/packages/taro-runtime/src/dom/event.ts
+++ b/packages/taro-runtime/src/dom/event.ts
@@ -100,6 +100,13 @@ export function eventHandler (event: MpEvent) {
 
   const node = document.getElementById(event.currentTarget.id)
   if (node != null) {
-    node.dispatchEvent(createEvent(event, node))
+    const dispatch = () => {
+      node.dispatchEvent(createEvent(event, node))
+    }
+    if (typeof CurrentReconciler.batchedEventUpdates === 'function') {
+      CurrentReconciler.batchedEventUpdates(dispatch)
+    } else {
+      dispatch()
+    }
   }
 }

--- a/packages/taro-runtime/src/dsl/react.ts
+++ b/packages/taro-runtime/src/dsl/react.ts
@@ -113,6 +113,9 @@ function setReconciler () {
     },
     modifyEventType (event) {
       event.type = event.type.replace(/-/g, '')
+    },
+    batchedEventUpdates (cb) {
+      ReactDOM.unstable_batchedUpdates(cb)
     }
   }
 

--- a/packages/taro-runtime/src/reconciler.ts
+++ b/packages/taro-runtime/src/reconciler.ts
@@ -27,6 +27,8 @@ export interface Reconciler<Instance, DOMElement = TaroElement, TextElement = Ta
 
   getLifecyle(instance: Instance, lifecyle: keyof PageInstance): Function | undefined | Array<Function>
 
+  batchedEventUpdates?(cb: () => void): void
+
   // h5
   createPullDownComponent?(el: Instance, path: string, framework)
 


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

修复 react 事件回调里没有 batchedUpdates 的问题

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #8516 

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）