### PR TITLE
fix(react-dom): 修复newProps内值为null时，属性丢失问题

### DIFF
--- a/packages/taro-components/src/components/video/video.tsx
+++ b/packages/taro-components/src/components/video/video.tsx
@@ -509,7 +509,11 @@ export class Video implements ComponentInterface {
           style={{
             'object-fit': objectFit
           }}
-          ref={dom => (this.videoRef = dom as HTMLVideoElement)}
+          ref={dom => {
+            if (dom) {
+              this.videoRef = dom as HTMLVideoElement
+            }
+          }}
           src={src}
           autoplay={autoplay}
           loop={loop}

--- a/packages/taro-react/__tests__/props.spec.js
+++ b/packages/taro-react/__tests__/props.spec.js
@@ -94,6 +94,15 @@ describe('Context', () => {
       expect(container.firstChild.getAttribute('b')).toBe('b')
     })
 
+    it('not remove null properties', () => {
+      const container = document.createElement('div')
+      render(<div id='1' a={null} />, container)
+      render(<div id='1' a='a' b='b' />, container)
+      expect(container.firstChild.id).toBe('1')
+      expect(container.firstChild.getAttribute('a')).toBe('a')
+      expect(container.firstChild.getAttribute('b')).toBe('b')
+    })
+
     it('should ignore ref', () => {
       const container = document.createElement('div')
       render(<div ref={React.createRef} />, container)

--- a/packages/taro-react/__tests__/props.spec.js
+++ b/packages/taro-react/__tests__/props.spec.js
@@ -94,13 +94,12 @@ describe('Context', () => {
       expect(container.firstChild.getAttribute('b')).toBe('b')
     })
 
-    it('not remove null properties', () => {
+    it('not remove null properties', () => {
       const container = document.createElement('div')
       render(<div id='1' a={null} />, container)
-      render(<div id='1' a='a' b='b' />, container)
+      render(<div id='1' a='a' />, container)
       expect(container.firstChild.id).toBe('1')
       expect(container.firstChild.getAttribute('a')).toBe('a')
-      expect(container.firstChild.getAttribute('b')).toBe('b')
     })
 
     it('should ignore ref', () => {

--- a/packages/taro-react/src/props.ts
+++ b/packages/taro-react/src/props.ts
@@ -21,7 +21,7 @@ export function updateProps (dom: TaroElement, oldProps: Props, newProps: Props)
   const isFormElement = dom instanceof FormElement
   for (i in newProps) {
     if (oldProps[i] !== newProps[i] || (isFormElement && i === 'value')) {
-      setProperty(dom, i, newProps[i], oldProps[i])
+      setProperty(dom, i, newProps[i], oldProps[i], newProps)
     }
   }
 }
@@ -78,7 +78,7 @@ interface DangerouslySetInnerHTML {
   __html?: string
 }
 
-function setProperty (dom: TaroElement, name: string, value: unknown, oldValue?: unknown) {
+function setProperty (dom: TaroElement, name: string, value: unknown, oldValue?: unknown, newProps?: Props) {
   name = name === 'className' ? 'class' : name
 
   if (
@@ -125,7 +125,11 @@ function setProperty (dom: TaroElement, name: string, value: unknown, oldValue?:
     }
   } else if (!isFunction(value)) {
     if (value == null) {
-      dom.removeAttribute(name)
+      if (newProps && newProps.hasOwnProperty(name)) {
+        dom.setAttribute(name, value as string)
+      } else {
+        dom.removeAttribute(name)
+      }
     } else {
       dom.setAttribute(name, value as string)
     }


### PR DESCRIPTION
fix(react-dom): 修复newProps内值为null时，属性丢失问题

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
prop更新时，不移除newProps内为null的属性


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
