### PR TITLE
fix(runtime): 修复pure-view设置属性后不能变为static-view的问题

### DIFF
--- a/packages/taro-runtime/src/dom/element.ts
+++ b/packages/taro-runtime/src/dom/element.ts
@@ -94,6 +94,14 @@ export class TaroElement extends TaroNode {
       eventSource.set(value, this)
       qualifiedName = 'uid'
     } else {
+      // pure-view => static-view
+      if (this.nodeName === 'view' && !isHasExtractProp(this) && !this.isAnyEventBinded()) {
+        this.enqueueUpdate({
+          path: `${this._path}.${Shortcuts.NodeName}`,
+          value: 'static-view'
+        })
+      }
+
       this.props[qualifiedName] = value as string
       if (qualifiedName === 'class') {
         qualifiedName = Shortcuts.Class
@@ -102,12 +110,6 @@ export class TaroElement extends TaroNode {
           this.dataset = Object.create(null)
         }
         this.dataset[toCamelCase(qualifiedName.replace(/^data-/, ''))] = value
-      } else if (this.nodeName === 'view' && !isHasExtractProp(this) && !this.isAnyEventBinded()) {
-        // pure-view => static-view
-        this.enqueueUpdate({
-          path: `${this._path}.${Shortcuts.NodeName}`,
-          value: 'static-view'
-        })
       }
     }
 


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

修复pure-view设置属性后不能变为static-view的问题

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix)

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [x] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）