### PR TITLE
fix(components-rn): 修复 rn 下 video onError 报错

### DIFF
--- a/packages/taro-components-rn/src/components/Video/index.tsx
+++ b/packages/taro-components-rn/src/components/Video/index.tsx
@@ -181,12 +181,14 @@ class _Video extends Component<Props, any> {
   };
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-  onError = (e: any): void => {
-    Object.defineProperty(e, 'detail', {
-      enumerable: true,
-      value: { errMsg: e.srcElement.error.code },
-    })
-    this.props.onError && this.props.onError(e)
+  onError = (e: string): void => {
+    if (this.props.onError) {
+      const error = Object.defineProperty({}, 'detail', {
+        enumerable: true,
+        value: { errMsg: e },
+      })
+      this.props.onError(error)
+    }
   };
 
   onLoad = (status: AVPlaybackStatus): void => {


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
根据 [expo-av](https://docs.expo.io/versions/latest/sdk/video/) 的文档描述，Video 的 onError 参数是一个字符串。原代码中错误的将其当做对象处理，导致报错。这个 PR 修复了这个问题。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix)
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
无