### PR TITLE
fix(runtime): 修复Vue3 style设置css变量解析错误问题，fix #8736

### DIFF
--- a/packages/taro-runtime/src/dom/style.ts
+++ b/packages/taro-runtime/src/dom/style.ts
@@ -41,6 +41,10 @@ function initStyle (ctor: typeof Style) {
   Object.defineProperties(ctor.prototype, properties)
 }
 
+function isCssVariable (propertyName) {
+  return /^--/.test(propertyName)
+}
+
 export class Style {
   public _usedStyleProp: Set<string>
 
@@ -72,7 +76,8 @@ export class Style {
     this._usedStyleProp.forEach(key => {
       const val = this[key]
       if (!val) return
-      text += `${toDashed(key)}: ${val};`
+      const styleName = isCssVariable(key) ? key : toDashed(key)
+      text += `${styleName}: ${val};`
     })
     return text
   }
@@ -110,7 +115,7 @@ export class Style {
   }
 
   public setProperty (propertyName: string, value?: string | null) {
-    if (propertyName[0] === '-') {
+    if (isCssVariable(propertyName)) {
       this.setCssVariables(propertyName)
     } else {
       propertyName = toCamelCase(propertyName)


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

修复 Vue3 为 style 设置以驼峰形式命名的 css 变量时，解析错误的问题

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #8736

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）