### PR TITLE
fix(types): 修复ITouchEvent里的changedTouches属性的类型错误

### DIFF
--- a/packages/taro-components/types/common.d.ts
+++ b/packages/taro-components/types/common.d.ts
@@ -107,7 +107,7 @@ export interface ITouchEvent<T = any> extends BaseEventOrig<T> {
   touches: Array<ITouch>
 
   /** 触摸事件，当前变化的触摸点信息的数组 */
-  changedTouches: Array<CanvasTouch>
+  changedTouches: Array<ITouch>
 }
 
 export interface CanvasTouch {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
实际测试在H5和微信小程序中，changedTouches的类型都是`Array<ITouch>`，原代码使用的`Array<CanvasTouch>`与实际不符。

从https://github.com/NervJS/taro/issues/5592 中 @ZakaryCode 提到的类型同步自https://github.com/wechat-miniprogram/api-typings/blob/master/types/wx/lib.wx.event.d.ts 的`TouchEvent`也可以看出`changedTouches`应和`touches`类型一致且都为`Array<ITouch>`（在微信小程序声明文件中实际为`Array<TouchDetail>`，其中`TouchDetail`等于Taro声明文件中的`ITouch`）。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #5461 #4798 #5592
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [x] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
