### PR TITLE
fix(taro-rn): 修复 getLocation 在安卓上报错

### DIFF
--- a/packages/taro-rn/package.json
+++ b/packages/taro-rn/package.json
@@ -35,6 +35,7 @@
     "@react-native-async-storage/async-storage": "^1.13.2",
     "@react-native-community/cameraroll": "^4.0.1",
     "@react-native-community/clipboard": "^1.5.1",
+    "@react-native-community/geolocation": "^2.0.2",
     "@react-native-community/netinfo": "^5.9.7",
     "@tarojs/runtime-rn": "3.2.0-beta.0",
     "babel-preset-expo": "^5.2.0",

--- a/packages/taro-rn/src/lib/getLocation/index.ts
+++ b/packages/taro-rn/src/lib/getLocation/index.ts
@@ -1,4 +1,4 @@
-import { getCurrentPositionAsync, LocationAccuracy } from 'expo-location'
+import Geolocation from '@react-native-community/geolocation'
 import { Permissions } from 'react-native-unimodules'
 import { askAsyncPermissions } from '../../utils/premissions'
 
@@ -17,35 +17,42 @@ export async function getLocation(opts: Taro.getLocation.Option = {}): Promise<T
     return Promise.reject(res)
   }
 
-  const { isHighAccuracy = false, success, fail, complete } = opts
+  const { isHighAccuracy = false, highAccuracyExpireTime = 3000, success, fail, complete } = opts
 
   return new Promise((resolve, reject) => {
-    getCurrentPositionAsync({
-      accuracy: isHighAccuracy ? LocationAccuracy.High : LocationAccuracy.Balanced
-    }).then((resp) => {
-      const { coords } = resp
-      const { latitude, longitude, altitude, accuracy, speed } = coords
-      const res = {
-        latitude,
-        longitude,
-        speed: speed ?? 0,
-        altitude: altitude ?? 0,
-        accuracy: accuracy ?? 0,
-        verticalAccuracy: 0,
-        horizontalAccuracy: 0,
-        errMsg: 'getLocation:ok'
+    Geolocation.getCurrentPosition(
+      ({ coords }) => {
+        const { latitude, longitude, altitude, accuracy, altitudeAccuracy, heading, speed } = coords
+        const res = {
+          latitude,
+          longitude,
+          speed: speed ?? 0,
+          altitude: altitude ?? 0,
+          accuracy,
+          verticalAccuracy: 0,
+          horizontalAccuracy: 0,
+          errMsg: 'getLocation:ok'
+        }
+        success?.(res)
+        complete?.(res)
+        resolve(res)
+      },
+      (err) => {
+        const res = {
+          errMsg: 'getLocation fail',
+          err
+        }
+        fail?.(res)
+        complete?.(res)
+        reject(res)
+      },
+      {
+        // 当 maximumAge 为 0 时，如果不设置 timeout 或 timeout 太少可能会超时
+        timeout: highAccuracyExpireTime,
+        // maximumAge 设置为 0 则会获取当前位置，而不是获取一个前不久缓存的位置
+        maximumAge: 0,
+        enableHighAccuracy: isHighAccuracy
       }
-      success?.(res)
-      complete?.(res)
-      resolve(res)
-    }).catch((err) => {
-      const res = {
-        errMsg: 'getLocation fail',
-        err
-      }
-      fail?.(res)
-      complete?.(res)
-      reject(res)
-    })
+    )
   })
 }


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
因为国内很多安卓机不支持 GMS, 导致 expo-location 无法正常获取位置,现改为
调用 @react-native-community/geolocation


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
