### PR TITLE
chore(release): publish 3.1.2

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -41,6 +41,6 @@
       "license": "MIT"
     }
   },
-  "version": "3.1.1",
+  "version": "3.1.2",
   "npmClient": "yarn"
 }

--- a/packages/babel-plugin-transform-taroapi/package.json
+++ b/packages/babel-plugin-transform-taroapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-transform-taroapi",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc"

--- a/packages/babel-preset-taro/package.json
+++ b/packages/babel-preset-taro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-taro",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "> TODO: description",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/babel-preset-taro#readme",
@@ -33,9 +33,9 @@
     "@babel/preset-react": "7.12.13",
     "@babel/preset-typescript": "7.12.17",
     "@babel/runtime": "^7.11.2",
-    "@tarojs/taro-h5": "3.1.1",
+    "@tarojs/taro-h5": "3.1.2",
     "babel-plugin-dynamic-import-node": "^2.3.3",
-    "babel-plugin-transform-taroapi": "3.1.1",
+    "babel-plugin-transform-taroapi": "3.1.2",
     "core-js": "^3.6.5",
     "react-refresh": "0.9.0"
   }

--- a/packages/eslint-config-taro/package.json
+++ b/packages/eslint-config-taro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-taro",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Taro specific linting rules for ESLint",
   "main": "index.js",
   "files": [

--- a/packages/eslint-plugin-taro/package.json
+++ b/packages/eslint-plugin-taro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-taro",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Taro specific linting plugin for ESLint",
   "main": "index.js",
   "files": [

--- a/packages/postcss-plugin-constparse/package.json
+++ b/packages/postcss-plugin-constparse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-plugin-constparse",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "parse constants defined in config",
   "main": "index.js",
   "author": "Simba",

--- a/packages/postcss-pxtransform/package.json
+++ b/packages/postcss-pxtransform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-pxtransform",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "PostCSS plugin px 转小程序 rpx及h5 rem 单位",
   "keywords": [
     "postcss",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/shared",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "> TODO: description",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/shared#readme",

--- a/packages/taro-alipay/package.json
+++ b/packages/taro-alipay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-alipay",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "支付宝小程序平台插件",
   "author": "Chen-jj",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-alipay#readme",
@@ -27,8 +27,8 @@
     "url": "https://github.com/NervJS/taro/issues"
   },
   "dependencies": {
-    "@tarojs/components": "3.1.1",
-    "@tarojs/service": "3.1.1",
-    "@tarojs/shared": "3.1.1"
+    "@tarojs/components": "3.1.2",
+    "@tarojs/service": "3.1.2",
+    "@tarojs/shared": "3.1.2"
   }
 }

--- a/packages/taro-api/package.json
+++ b/packages/taro-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/api",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Taro common API",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/api#readme",
@@ -29,6 +29,6 @@
     "url": "https://github.com/NervJS/taro/issues"
   },
   "dependencies": {
-    "@tarojs/runtime": "3.1.1"
+    "@tarojs/runtime": "3.1.2"
   }
 }

--- a/packages/taro-cli/package.json
+++ b/packages/taro-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/cli",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "cli tool for taro",
   "main": "index.js",
   "scripts": {
@@ -44,17 +44,17 @@
   "license": "MIT",
   "dependencies": {
     "@hapi/joi": "17.1.1",
-    "@tarojs/helper": "3.1.1",
-    "@tarojs/plugin-platform-alipay": "3.1.1",
-    "@tarojs/plugin-platform-jd": "3.1.1",
-    "@tarojs/plugin-platform-qq": "3.1.1",
-    "@tarojs/plugin-platform-swan": "3.1.1",
-    "@tarojs/plugin-platform-tt": "3.1.1",
-    "@tarojs/plugin-platform-weapp": "3.1.1",
-    "@tarojs/service": "3.1.1",
-    "@tarojs/shared": "3.1.1",
-    "@tarojs/taro": "3.1.1",
-    "@tarojs/taroize": "3.1.1",
+    "@tarojs/helper": "3.1.2",
+    "@tarojs/plugin-platform-alipay": "3.1.2",
+    "@tarojs/plugin-platform-jd": "3.1.2",
+    "@tarojs/plugin-platform-qq": "3.1.2",
+    "@tarojs/plugin-platform-swan": "3.1.2",
+    "@tarojs/plugin-platform-tt": "3.1.2",
+    "@tarojs/plugin-platform-weapp": "3.1.2",
+    "@tarojs/service": "3.1.2",
+    "@tarojs/shared": "3.1.2",
+    "@tarojs/taro": "3.1.2",
+    "@tarojs/taroize": "3.1.2",
     "@tarojs/transformer-wx": "^2.0.4",
     "@types/request": "^2.48.1",
     "@typescript-eslint/parser": "^4.15.1",
@@ -80,11 +80,11 @@
     "ejs": "^2.6.1",
     "envinfo": "^6.0.1",
     "eslint": "^6.1.0",
-    "eslint-config-taro": "3.1.1",
+    "eslint-config-taro": "3.1.2",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-react": "^7.4.0",
     "eslint-plugin-react-hooks": "^1.6.1",
-    "eslint-plugin-taro": "3.1.1",
+    "eslint-plugin-taro": "3.1.2",
     "eslint-plugin-vue": "^6.2.2",
     "fbjs": "^1.0.0",
     "find-yarn-workspace-root": "1.2.1",
@@ -107,7 +107,7 @@
     "postcss-modules-resolve-imports": "^1.3.0",
     "postcss-modules-scope": "^1.1.0",
     "postcss-modules-values": "^1.3.0",
-    "postcss-pxtransform": "3.1.1",
+    "postcss-pxtransform": "3.1.2",
     "postcss-reporter": "^6.0.1",
     "postcss-taro-unit-transform": "1.2.15",
     "postcss-url": "^7.3.2",
@@ -128,7 +128,7 @@
     "xxhashjs": "^0.2.2"
   },
   "devDependencies": {
-    "@tarojs/mini-runner": "3.1.1",
-    "@tarojs/webpack-runner": "3.1.1"
+    "@tarojs/mini-runner": "3.1.2",
+    "@tarojs/webpack-runner": "3.1.2"
   }
 }

--- a/packages/taro-components/package.json
+++ b/packages/taro-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/components",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "",
   "main:h5": "src/index.js",
   "main": "dist/index.js",
@@ -38,7 +38,7 @@
   "license": "MIT",
   "dependencies": {
     "@stencil/core": "2.4.0",
-    "@tarojs/taro": "3.1.1",
+    "@tarojs/taro": "3.1.2",
     "better-scroll": "^1.14.1",
     "classnames": "^2.2.5",
     "intersection-observer": "^0.7.0",

--- a/packages/taro-extend/package.json
+++ b/packages/taro-extend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/extend",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Taro extend functionality",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-extend#readme",

--- a/packages/taro-h5/package.json
+++ b/packages/taro-h5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taro-h5",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Taro h5 framework",
   "main:h5": "src/index.js",
   "main": "dist/index.cjs.js",
@@ -33,9 +33,9 @@
   "author": "O2Team",
   "license": "MIT",
   "dependencies": {
-    "@tarojs/api": "3.1.1",
-    "@tarojs/router": "3.1.1",
-    "@tarojs/runtime": "3.1.1",
+    "@tarojs/api": "3.1.2",
+    "@tarojs/router": "3.1.2",
+    "@tarojs/runtime": "3.1.2",
     "base64-js": "^1.3.0",
     "jsonp-retry": "^1.0.3",
     "mobile-detect": "^1.4.2",

--- a/packages/taro-helper/package.json
+++ b/packages/taro-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/helper",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Taro Helper",
   "main": "index.js",
   "types": "types/index.d.ts",
@@ -41,7 +41,7 @@
     "@babel/preset-typescript": "7.12.17",
     "@babel/register": "7.9.0",
     "@babel/runtime": "7.9.2",
-    "@tarojs/taro": "3.1.1",
+    "@tarojs/taro": "3.1.2",
     "chalk": "3.0.0",
     "chokidar": "3.3.1",
     "cross-spawn": "7.0.3",

--- a/packages/taro-jd/package.json
+++ b/packages/taro-jd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-jd",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "京东小程序平台插件",
   "author": "Chen-jj",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-jd#readme",
@@ -27,7 +27,7 @@
     "url": "https://github.com/NervJS/taro/issues"
   },
   "dependencies": {
-    "@tarojs/service": "3.1.1",
-    "@tarojs/shared": "3.1.1"
+    "@tarojs/service": "3.1.2",
+    "@tarojs/shared": "3.1.2"
   }
 }

--- a/packages/taro-loader/package.json
+++ b/packages/taro-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taro-loader",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "> TODO: description",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-loader#readme",
@@ -26,7 +26,7 @@
     "url": "https://github.com/NervJS/taro/issues"
   },
   "dependencies": {
-    "@tarojs/helper": "3.1.1",
+    "@tarojs/helper": "3.1.2",
     "acorn": "^8.0.4",
     "acorn-walk": "^8.0.0",
     "loader-utils": "^1.2.3"
@@ -35,6 +35,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@tarojs/taro": "3.1.1"
+    "@tarojs/taro": "3.1.2"
   }
 }

--- a/packages/taro-mini-runner/package.json
+++ b/packages/taro-mini-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/mini-runner",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Mini app runner for taro",
   "main": "index.js",
   "scripts": {
@@ -38,18 +38,18 @@
     "@babel/core": "7.11.1",
     "@babel/plugin-proposal-class-properties": "7.10.4",
     "@babel/preset-env": "7.11.0",
-    "@tarojs/helper": "3.1.1",
-    "@tarojs/plugin-platform-alipay": "3.1.1",
-    "@tarojs/plugin-platform-jd": "3.1.1",
-    "@tarojs/plugin-platform-qq": "3.1.1",
-    "@tarojs/plugin-platform-swan": "3.1.1",
-    "@tarojs/plugin-platform-tt": "3.1.1",
-    "@tarojs/plugin-platform-weapp": "3.1.1",
-    "@tarojs/runner-utils": "3.1.1",
-    "@tarojs/runtime": "3.1.1",
-    "@tarojs/shared": "3.1.1",
-    "@tarojs/taro": "3.1.1",
-    "@tarojs/taro-loader": "3.1.1",
+    "@tarojs/helper": "3.1.2",
+    "@tarojs/plugin-platform-alipay": "3.1.2",
+    "@tarojs/plugin-platform-jd": "3.1.2",
+    "@tarojs/plugin-platform-qq": "3.1.2",
+    "@tarojs/plugin-platform-swan": "3.1.2",
+    "@tarojs/plugin-platform-tt": "3.1.2",
+    "@tarojs/plugin-platform-weapp": "3.1.2",
+    "@tarojs/runner-utils": "3.1.2",
+    "@tarojs/runtime": "3.1.2",
+    "@tarojs/shared": "3.1.2",
+    "@tarojs/taro": "3.1.2",
+    "@tarojs/taro-loader": "3.1.2",
     "babel-loader": "8.0.6",
     "babel-types": "^6.26.0",
     "copy-webpack-plugin": "5.1.2",
@@ -92,8 +92,8 @@
     "yauzl": "2.10.0"
   },
   "devDependencies": {
-    "@tarojs/components": "3.1.1",
-    "@tarojs/react": "3.1.1",
-    "babel-preset-taro": "3.1.1"
+    "@tarojs/components": "3.1.2",
+    "@tarojs/react": "3.1.2",
+    "babel-preset-taro": "3.1.2"
   }
 }

--- a/packages/taro-qq/package.json
+++ b/packages/taro-qq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-qq",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "QQ 小程序平台插件",
   "author": "Chen-jj",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-qq#readme",
@@ -25,8 +25,8 @@
     "url": "https://github.com/NervJS/taro/issues"
   },
   "dependencies": {
-    "@tarojs/plugin-platform-weapp": "3.1.1",
-    "@tarojs/service": "3.1.1",
-    "@tarojs/shared": "3.1.1"
+    "@tarojs/plugin-platform-weapp": "3.1.2",
+    "@tarojs/service": "3.1.2",
+    "@tarojs/shared": "3.1.2"
   }
 }

--- a/packages/taro-react/package.json
+++ b/packages/taro-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/react",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "like react-dom, but for mini apps.",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-react#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/NervJS/taro/issues"
   },
   "dependencies": {
-    "@tarojs/runtime": "3.1.1",
-    "@tarojs/shared": "3.1.1",
+    "@tarojs/runtime": "3.1.2",
+    "@tarojs/shared": "3.1.2",
     "react-reconciler": "0.25.1",
     "scheduler": "^0.17.0"
   },

--- a/packages/taro-router/package.json
+++ b/packages/taro-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/router",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Taro-router",
   "main:h5": "dist/router.esm.js",
   "main": "dist/index.js",
@@ -27,7 +27,7 @@
   "author": "O2Team",
   "license": "MIT",
   "dependencies": {
-    "@tarojs/runtime": "3.1.1",
+    "@tarojs/runtime": "3.1.2",
     "history": "^4.10.1",
     "universal-router": "^8.3.0",
     "url-parse": "^1.4.7"

--- a/packages/taro-runner-utils/package.json
+++ b/packages/taro-runner-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/runner-utils",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Taro runner utilities.",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/core": "7.11.1",
-    "@tarojs/helper": "3.1.1",
+    "@tarojs/helper": "3.1.2",
     "chalk": "^3.0.0",
     "fs-extra": "^8.1.0",
     "lodash": "^4.17.15",

--- a/packages/taro-runtime/package.json
+++ b/packages/taro-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/runtime",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "taro runtime for mini apps.",
   "main": "dist/runtime.esm.js",
   "module": "dist/runtime.esm.js",
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@tarojs/shared": "3.1.1",
+    "@tarojs/shared": "3.1.2",
     "lodash-es": "4.17.15"
   }
 }

--- a/packages/taro-service/package.json
+++ b/packages/taro-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/service",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Taro Service",
   "main": "index.js",
   "types": "types/index.d.ts",
@@ -34,9 +34,9 @@
   "homepage": "https://github.com/NervJS/taro#readme",
   "dependencies": {
     "@hapi/joi": "17.1.1",
-    "@tarojs/helper": "3.1.1",
-    "@tarojs/shared": "3.1.1",
-    "@tarojs/taro": "3.1.1",
+    "@tarojs/helper": "3.1.2",
+    "@tarojs/shared": "3.1.2",
+    "@tarojs/taro": "3.1.2",
     "fs-extra": "8.1.0",
     "lodash": "4.17.20",
     "resolve": "1.15.1",

--- a/packages/taro-swan/package.json
+++ b/packages/taro-swan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-swan",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "百度小程序平台插件",
   "author": "Chen-jj",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-swan#readme",
@@ -27,8 +27,8 @@
     "url": "https://github.com/NervJS/taro/issues"
   },
   "dependencies": {
-    "@tarojs/components": "3.1.1",
-    "@tarojs/service": "3.1.1",
-    "@tarojs/shared": "3.1.1"
+    "@tarojs/components": "3.1.2",
+    "@tarojs/service": "3.1.2",
+    "@tarojs/shared": "3.1.2"
   }
 }

--- a/packages/taro-tt/package.json
+++ b/packages/taro-tt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-tt",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "头条小程序平台插件",
   "author": "Chen-jj",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-tt#readme",
@@ -27,7 +27,7 @@
     "url": "https://github.com/NervJS/taro/issues"
   },
   "dependencies": {
-    "@tarojs/service": "3.1.1",
-    "@tarojs/shared": "3.1.1"
+    "@tarojs/service": "3.1.2",
+    "@tarojs/shared": "3.1.2"
   }
 }

--- a/packages/taro-weapp/package.json
+++ b/packages/taro-weapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-weapp",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "微信小程序平台插件",
   "author": "drchan",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-weapp#readme",
@@ -27,8 +27,8 @@
     "url": "https://github.com/NervJS/taro/issues"
   },
   "dependencies": {
-    "@tarojs/components": "3.1.1",
-    "@tarojs/service": "3.1.1",
-    "@tarojs/shared": "3.1.1"
+    "@tarojs/components": "3.1.2",
+    "@tarojs/service": "3.1.2",
+    "@tarojs/shared": "3.1.2"
   }
 }

--- a/packages/taro-webpack-runner/package.json
+++ b/packages/taro-webpack-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/webpack-runner",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "webpack runner for taro",
   "main": "index.js",
   "scripts": {
@@ -32,11 +32,11 @@
   "dependencies": {
     "@babel/core": "7.11.1",
     "@pmmmwh/react-refresh-webpack-plugin": "0.4.3",
-    "@tarojs/helper": "3.1.1",
-    "@tarojs/runner-utils": "3.1.1",
-    "@tarojs/runtime": "3.1.1",
-    "@tarojs/shared": "3.1.1",
-    "@tarojs/taro-loader": "3.1.1",
+    "@tarojs/helper": "3.1.2",
+    "@tarojs/runner-utils": "3.1.2",
+    "@tarojs/runtime": "3.1.2",
+    "@tarojs/shared": "3.1.2",
+    "@tarojs/taro-loader": "3.1.2",
     "autoprefixer": "9.7.4",
     "babel-loader": "8.0.6",
     "copy-webpack-plugin": "5.1.1",
@@ -54,8 +54,8 @@
     "open": "7.0.2",
     "ora": "4.0.3",
     "postcss-loader": "3.0.0",
-    "postcss-plugin-constparse": "3.1.1",
-    "postcss-pxtransform": "3.1.1",
+    "postcss-plugin-constparse": "3.1.2",
+    "postcss-pxtransform": "3.1.2",
     "react-refresh": "0.9.0",
     "resolve": "1.15.1",
     "resolve-url-loader": "3.1.1",
@@ -72,8 +72,8 @@
     "webpack-format-messages": "^2.0.5"
   },
   "devDependencies": {
-    "@tarojs/components": "3.1.1",
-    "@tarojs/taro": "3.1.1",
+    "@tarojs/components": "3.1.2",
+    "@tarojs/taro": "3.1.2",
     "@types/autoprefixer": "9.7.0",
     "@types/detect-port": "1.3.0",
     "@types/lodash": "4.14.149",
@@ -81,7 +81,7 @@
     "@types/resolve": "1.19.0",
     "@types/webpack": "4.41.6",
     "@types/webpack-dev-server": "3.11.0",
-    "babel-plugin-transform-taroapi": "3.1.1",
-    "babel-preset-taro": "3.1.1"
+    "babel-plugin-transform-taroapi": "3.1.2",
+    "babel-preset-taro": "3.1.2"
   }
 }

--- a/packages/taro-with-weapp/package.json
+++ b/packages/taro-with-weapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/with-weapp",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "taroize 之后的运行时",
   "main": "index.js",
   "scripts": {
@@ -23,8 +23,8 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "7.12.5",
-    "@tarojs/runtime": "3.1.1",
-    "@tarojs/taro": "3.1.1",
+    "@tarojs/runtime": "3.1.2",
+    "@tarojs/taro": "3.1.2",
     "lodash": "^4.17.11"
   }
 }

--- a/packages/taro/package.json
+++ b/packages/taro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taro",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Taro framework",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro#readme",
   "main": "index.js",
@@ -26,8 +26,8 @@
   "author": "O2Team",
   "license": "MIT",
   "dependencies": {
-    "@tarojs/api": "3.1.1",
-    "@tarojs/runtime": "3.1.1",
-    "@tarojs/taro-h5": "3.1.1"
+    "@tarojs/api": "3.1.2",
+    "@tarojs/runtime": "3.1.2",
+    "@tarojs/taro-h5": "3.1.2"
   }
 }

--- a/packages/taroize/package.json
+++ b/packages/taroize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taroize",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "转换原生微信小程序代码为 Taro 代码",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## 修复

### 小程序

- 修复渲染 html 时，带属性的 `style` 标签无法识别的问题，#8827，by @LiHDong 
- 补全 API `getUserProfile`，#8810
- 补全 `Map` 组件属性 `optimize`，#8784
- 修复使用原生组件时属性传递失败的问题，#8797
- 修复 `pure-view` 与 `static-view` 的转换问题，#8789

### H5

- 升级 Stencil 到最新版本，修复报错： "TypeError: Cannot read property 'childNodes' of null"，#8798

### Typings

- 修复 `ITouchEvent` 里的 `changedTouches` 属性的类型错误，by @ryougifujino 

