### PR TITLE
fix: 补全 cover-view 在配合 map 组件使用时的特殊属性

### DIFF
--- a/packages/shared/src/components.ts
+++ b/packages/shared/src/components.ts
@@ -251,6 +251,8 @@ const CoverImage = {
 
 const CoverView = {
   'scroll-top': 'false',
+  'marker-id': '',
+  'slot': '',
   ...touchEvents
 }
 

--- a/packages/shared/src/components.ts
+++ b/packages/shared/src/components.ts
@@ -251,8 +251,6 @@ const CoverImage = {
 
 const CoverView = {
   'scroll-top': 'false',
-  'marker-id': '',
-  'slot': '',
   ...touchEvents
 }
 

--- a/packages/taro-components/types/CoverView.d.ts
+++ b/packages/taro-components/types/CoverView.d.ts
@@ -6,6 +6,17 @@ interface CoverViewProps extends ViewProps {
    * @supported weapp
    */
   scrollTop?: number
+
+  /**
+   * 适用于地图组件 map 的自定义气泡 customCallout
+   * @supported weapp
+   */
+  markerId?: string
+
+  /**
+   * @supported weapp
+   */
+  slot?: string
 }
 
 /** 覆盖在原生组件之上的文本视图。可覆盖的原生组件包括 map、video、canvas、camera、live-player、live-pusher 只支持嵌套 cover-view、cover-image，可在 cover-view 中使用 button。

--- a/packages/taro-weapp/src/components.ts
+++ b/packages/taro-weapp/src/components.ts
@@ -175,7 +175,7 @@ export const components = {
   },
   CoverView: {
     'marker-id': '',
-    slot: '',
+    slot: ''
   },
   // ======== 额外组件 ========
   Editor: {

--- a/packages/taro-weapp/src/components.ts
+++ b/packages/taro-weapp/src/components.ts
@@ -173,6 +173,10 @@ export const components = {
     'ad-type': singleQuote('banner'),
     'ad-theme': singleQuote('white')
   },
+  CoverView: {
+    'marker-id': '',
+    slot: '',
+  },
   // ======== 额外组件 ========
   Editor: {
     'read-only': 'false',


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

补全了 cover-view 在配合微信小程序 map 组件使用时，自定义气泡框所需要的特殊属性，`marker-id` 和 `slot`

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [ ] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
