### PR TITLE
feat(h5): hideHomeButton 提示不支持

### DIFF
--- a/packages/taro-h5/src/api/unsupportedApi/index.js
+++ b/packages/taro-h5/src/api/unsupportedApi/index.js
@@ -68,6 +68,7 @@ export const canIUse = temporarilyNotSupport('canIUse')
 // 界面
 // export const hideToast = temporarilyNotSupport('hideToast')
 // export const hideLoading = temporarilyNotSupport('hideLoading')
+export const hideHomeButton = temporarilyNotSupport('hideHomeButton')
 export const showNavigationBarLoading = temporarilyNotSupport('showNavigationBarLoading')
 export const hideNavigationBarLoading = temporarilyNotSupport('hideNavigationBarLoading')
 // export const createAnimation = temporarilyNotSupport('createAnimation')


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)



**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**

目前直接将小程序转为 H5，`Taro.hideHomeButton` 调用会导致报错 
```
"export 'hideHomeButton' (imported as '_hideHomeButton') was not found in '@tarojs/taro'
```