### PR TITLE
fix(runtime): SVGElement not defined since vue@3.0.8

### DIFF
--- a/packages/taro-mini-runner/src/webpack/build.conf.ts
+++ b/packages/taro-mini-runner/src/webpack/build.conf.ts
@@ -180,7 +180,8 @@ export default (appPath: string, mode, config: Partial<IBuildConfig>): any => {
     navigator: ['@tarojs/runtime', 'navigator'],
     requestAnimationFrame: ['@tarojs/runtime', 'requestAnimationFrame'],
     cancelAnimationFrame: ['@tarojs/runtime', 'cancelAnimationFrame'],
-    Element: ['@tarojs/runtime', 'TaroElement']
+    Element: ['@tarojs/runtime', 'TaroElement'],
+    SVGElement: ['@tarojs/runtime', 'TaroElement'],
   })
 
   const isCssoEnabled = !((csso && csso.enable === false))

--- a/packages/taro-runtime/src/bom/document.ts
+++ b/packages/taro-runtime/src/bom/document.ts
@@ -26,7 +26,7 @@ export class TaroDocument extends TaroElement {
 
   // an ugly fake createElementNS to deal with @vue/runtime-dom's
   // support mounting app to svg container since vue@3.0.8
-  public createElementNS (svgNS: string, type: string) {
+  public createElementNS (_svgNS: string, type: string) {
     return this.createElement(type)
   }
 

--- a/packages/taro-runtime/src/bom/document.ts
+++ b/packages/taro-runtime/src/bom/document.ts
@@ -24,6 +24,12 @@ export class TaroDocument extends TaroElement {
     return new TaroElement(NodeType.ELEMENT_NODE, type)
   }
 
+  // an ugly fake createElementNS to deal with @vue/runtime-dom's
+  // support mounting app to svg container since vue@3.0.8
+  public createElementNS (svgNS: string, type: string) {
+    return this.createElement(type)
+  }
+
   public createTextNode (text: string) {
     return new TaroText(text)
   }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
自 `vue@3.0.8` 起，`@vue/runtime-dom` 开始支持将 app 挂载到 svg 容器（[runtime-dom: support mounting app to svg container](https://github.com/vuejs/vue-next/pull/2929)）。这会导致 Taro Vue3 框架的 vue 依赖更新到 `3.0.8` 后，出现 `SVGElement is not defined` 的错误。

本 PR 主要将 `SVGElement` 指向 `TaroElement`, 并在 `taro-runtime/src/bom/document.ts ` 中添加 `createElementNS` 方法，以实现对 `SVGElement` 的伪支持。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #8968
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 master 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 所有测试用例已经通过
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
