### PR TITLE
fix(extend): 修复小程序使用 $.width() 获取不到正确宽度的问题

### DIFF
--- a/packages/taro-extend/src/jquery/zepto.js
+++ b/packages/taro-extend/src/jquery/zepto.js
@@ -716,7 +716,7 @@ export const Zepto = (function () {
             resolve({
               left: rect.left,
               top: rect.top,
-              width: rect.height,
+              width: rect.width,
               height: rect.height
             })
           }).exec()


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

修复小程序使用 $.width() 获取不到正确宽度的问题

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix)

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）