### PR TITLE
fix(components): taro input unexpected type

### DIFF
--- a/packages/taro-components/src/components/input/input.tsx
+++ b/packages/taro-components/src/components/input/input.tsx
@@ -1,8 +1,10 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Component, h, ComponentInterface, Prop, Event, EventEmitter, Element } from '@stencil/core'
 import { EventHandler, TaroEvent } from '../../../types'
 
-function getTrueType (type: string, confirmType: string, password: boolean) {
+function getTrueType (type: string | undefined, confirmType: string, password: boolean) {
+  if (typeof type === 'undefined') {
+    return 'text';
+  }
   if (!type) {
     throw new Error('unexpected type')
   }
@@ -28,7 +30,7 @@ export class Input implements ComponentInterface {
   private fileListener: EventHandler
 
   @Prop() value: string
-  @Prop() type = 'text'
+  @Prop() type = undefined
   @Prop() password = false
   @Prop() placeholder: string
   @Prop() disabled = false

--- a/packages/taro-components/src/components/input/input.tsx
+++ b/packages/taro-components/src/components/input/input.tsx
@@ -89,7 +89,7 @@ export class Input implements ComponentInterface {
     }
   }
 
-  hanldeInput = (e: TaroEvent<HTMLInputElement>) => {
+  handleInput = (e: TaroEvent<HTMLInputElement>) => {
     e.stopPropagation()
     const {
       type,
@@ -193,7 +193,7 @@ export class Input implements ComponentInterface {
         maxlength={maxlength}
         autofocus={autoFocus}
         name={name}
-        onInput={this.hanldeInput}
+        onInput={this.handleInput}
         onFocus={this.handleFocus}
         onBlur={this.handleBlur}
         onChange={this.handleChange}


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)



**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**

`Input` 组件的 `type` prop 目前的类型是 `"number" | "text" | "idcard" | "digit" | undefined`，当传入 `undefined` 时，初次 render 效果符合预期，但在组件更新 rerender 时会抛出 `unexpected type` 错误（如图）：

![image](https://user-images.githubusercontent.com/12277082/113689077-80195180-96fc-11eb-8642-ed165069aa7d.png)



在排查后发现：初次渲染效果是正常的，是因为 `Input` 组件实例的 `type` prop 被设置了默认值；而在 rerender 的时候，`Input` 内部对新旧 props 进行对比，认为 type=undefined 是 newVal 并将原有的默认值 `"text"` 置为 `undefined`，导致后续 `getTrueType` 方法抛出了错误。
