### PR TITLE
fix(cli): 默认模版增加头条小程序的配置文件

### DIFF
--- a/packages/taro-cli/templates/default/project.tt.json
+++ b/packages/taro-cli/templates/default/project.tt.json
@@ -1,0 +1,9 @@
+{
+  "miniprogramRoot": "./dist",
+  "projectname": "<%= projectName %>",
+  "appid": "touristappid",
+  "setting": {
+    "es6": false,
+    "minified": false
+  }
+}


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

默认模版中，增加字节小程序的配置文件 `project.tt.json`，避免字节小程序 IDE 打开项目失败

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) 

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [x] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）