### PR TITLE
fix(components-compact): 修复兼容性组件库引用报错的问题

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,23 +20,15 @@ https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
 - [ ] 代码风格更新(Code style update)
 - [ ] 其他，请描述(Other, please describe):
 
-**这个 PR 满足以下需求:**
-
-- [ ] 提交到 master 分支
-- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
-- [ ] 所有测试用例已经通过
-- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
-- [ ] 在本地测试可用，不会影响到其它功能
-
 **这个 PR 涉及以下平台:**
 
+- [ ] 所有小程序
 - [ ] 微信小程序
 - [ ] 支付宝小程序
 - [ ] 百度小程序
-- [ ] 头条小程序
+- [ ] 字节跳动小程序
 - [ ] QQ 轻应用
+- [ ] 京东小程序
 - [ ] 快应用平台（QuickApp）
 - [ ] Web 平台（H5）
 - [ ] 移动端（React-Native）
-
-**其它需要 Reviewer 或社区知晓的内容：**

--- a/packages/eslint-config-taro/index.js
+++ b/packages/eslint-config-taro/index.js
@@ -70,7 +70,11 @@ module.exports = {
           }
         ],
         'no-useless-constructor': 'off',
-        '@typescript-eslint/no-useless-constructor': 'warn'
+        '@typescript-eslint/no-useless-constructor': 'warn',
+
+        // https://github.com/typescript-eslint/typescript-eslint/issues/2471
+        'no-shadow': 'off',
+        '@typescript-eslint/no-shadow': 'error'
       }
     }
   ]

--- a/packages/taro-components-react/package.json
+++ b/packages/taro-components-react/package.json
@@ -8,7 +8,8 @@
   "types": "types/index.d.ts",
   "sideEffects": [],
   "files": [
-    "dist"
+    "dist",
+    "index.js"
   ],
   "scripts": {
     "build": "rollup -c",

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/babel.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/babel.spec.ts.snap
@@ -1366,7 +1366,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/common-style.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/common-style.spec.ts.snap
@@ -1366,7 +1366,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/config.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/config.spec.ts.snap
@@ -1366,7 +1366,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",
@@ -4407,7 +4406,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",
@@ -7272,7 +7270,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/css-modules.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/css-modules.spec.ts.snap
@@ -1366,7 +1366,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",
@@ -4249,7 +4248,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/custom-tabbar.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/custom-tabbar.spec.ts.snap
@@ -1366,7 +1366,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/nerv.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/nerv.spec.ts.snap
@@ -1366,7 +1366,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/parse-html.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/parse-html.spec.ts.snap
@@ -1366,7 +1366,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/prerender.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/prerender.spec.ts.snap
@@ -1540,7 +1540,6 @@ require(\\"./taro\\");
             \\"report-submit-timeout\\": \\"0\\"
         },
         Input: {
-            \\"auto-focus\\": \\"false\\",
             \\"always-embed\\": \\"false\\",
             \\"adjust-position\\": \\"true\\",
             \\"hold-keyboard\\": \\"false\\",
@@ -5867,7 +5866,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",
@@ -10160,7 +10158,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/qq.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/qq.spec.ts.snap
@@ -1366,7 +1366,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",
@@ -4851,7 +4850,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/react.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/react.spec.ts.snap
@@ -1366,7 +1366,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/sass.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/sass.spec.ts.snap
@@ -1366,7 +1366,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",
@@ -4232,7 +4231,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",
@@ -7098,7 +7096,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",
@@ -9964,7 +9961,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/subpackages.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/subpackages.spec.ts.snap
@@ -1366,7 +1366,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/tabbar.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/tabbar.spec.ts.snap
@@ -3732,7 +3732,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/ts.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/ts.spec.ts.snap
@@ -1366,7 +1366,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/vue.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/vue.spec.ts.snap
@@ -1362,7 +1362,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/vue3.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/vue3.spec.ts.snap
@@ -1364,7 +1364,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/wx-hybrid.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/wx-hybrid.spec.ts.snap
@@ -1147,7 +1147,6 @@ require(\\"./taro\\");
                 \\"report-submit-timeout\\": \\"0\\"
             },
             Input: {
-                \\"auto-focus\\": \\"false\\",
                 \\"always-embed\\": \\"false\\",
                 \\"adjust-position\\": \\"true\\",
                 \\"hold-keyboard\\": \\"false\\",

--- a/packages/taro-weapp/src/components.ts
+++ b/packages/taro-weapp/src/components.ts
@@ -53,7 +53,6 @@ export const components = {
     'report-submit-timeout': '0'
   },
   Input: {
-    'auto-focus': 'false',
     'always-embed': 'false',
     'adjust-position': 'true',
     'hold-keyboard': 'false',

--- a/packages/taro-weapp/types/components.d.ts
+++ b/packages/taro-weapp/types/components.d.ts
@@ -50,7 +50,6 @@ export declare const components: {
         'report-submit-timeout': string;
     };
     Input: {
-        'auto-focus': string;
         'always-embed': string;
         'adjust-position': string;
         'hold-keyboard': string;


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

- 修复兼容性组件库引用报错的问题
- 移除微信端 `Input` 组件废弃属性 `auto-focus`，fix #9102 
- 修复使用 TS 时出现 ESLint 报错 `no-shadow`，fix #9089 

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) 

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）