### PR TITLE
fix(runtime): 修复多次跳转相同参数的同一页面时生命周期不触发的问题，fix #8874

### DIFF
--- a/packages/taro-runtime/src/dsl/common.ts
+++ b/packages/taro-runtime/src/dsl/common.ts
@@ -105,11 +105,12 @@ export function createPageConfig (component: any, pageName?: string, data?: Reco
       if (this.options == null) {
         this.options = options
       }
+      this.options.$taroTimestamp = Date.now()
 
-      const path = getPath(id, options)
+      const path = getPath(id, this.options)
       const router = isBrowser ? path : this.route || this.__route__
       Current.router = {
-        params: options,
+        params: this.options,
         path: addLeadingSlash(router),
         onReady: getOnReadyEventKey(id),
         onShow: getOnShowEventKey(id),
@@ -121,7 +122,7 @@ export function createPageConfig (component: any, pageName?: string, data?: Reco
           pageElement = document.getElementById<TaroRootElement>(path)
 
           ensure(pageElement !== null, '没有找到页面实例。')
-          safeExecute(path, 'onLoad', options)
+          safeExecute(path, 'onLoad', this.options)
           if (!isBrowser) {
             pageElement.ctx = this
             pageElement.performUpdate(true, cb)


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

fix(runtime): 修复多次跳转相同参数的同一页面时生命周期不触发的问题，fix #8874

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #8874 
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
