### PR TITLE
fix(mini-runner): 修复 vue2 出现多余空格文本节点的问题，fix #8884

### DIFF
--- a/packages/taro-mini-runner/src/webpack/vue.ts
+++ b/packages/taro-mini-runner/src/webpack/vue.ts
@@ -35,6 +35,7 @@ export function customVueChain (chain) {
         'cover-image': 'src'
       },
       compilerOptions: {
+        whitespace: 'condense',
         modules: [{
           preTransformNode (el) {
             const nodeName = el.tag


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

修复 vue2 出现多余空格文本节点的问题，fix #8884

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #8884 
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
