### PR TITLE
feat(runtime): 增加 onAddEvent 钩子

### DIFF
--- a/packages/taro-runtime/src/dom/event_target.ts
+++ b/packages/taro-runtime/src/dom/event_target.ts
@@ -1,4 +1,5 @@
 import { isArray, isObject, warn } from '@tarojs/shared'
+import { CurrentReconciler } from '../reconciler'
 
 interface EventListenerOptions {
   capture?: boolean;
@@ -17,6 +18,7 @@ export class TaroEventTarget {
   public __handlers: Record<string, EventHandler[]> = {}
 
   public addEventListener (type: string, handler: EventHandler, options?: boolean | AddEventListenerOptions) {
+    CurrentReconciler.onAddEvent?.(type, handler, options)
     if (type === 'regionchange') {
       // map 组件的 regionchange 事件非常特殊，详情：https://github.com/NervJS/taro/issues/5766
       this.addEventListener('begin', handler, options)

--- a/packages/taro-runtime/src/reconciler.ts
+++ b/packages/taro-runtime/src/reconciler.ts
@@ -8,6 +8,7 @@ import type { NodeType } from './dom/node_types'
 import type { EventsType } from './emitter/emitter'
 import { TaroEvent, MpEvent } from './dom/event'
 import type { Func } from './utils/types'
+import type { EventHandler } from './dom/event_target'
 
 type Inst = Instance<PageProps>
 
@@ -40,6 +41,8 @@ export interface Reconciler<Instance, DOMElement = TaroElement, TextElement = Ta
   modifyDispatchEvent? (event: TaroEvent, tagName: string): void
 
   batchedEventUpdates?(cb: () => void): void
+
+  onAddEvent?(type: string, handler: EventHandler, options: any): void
 
   // h5
   createPullDownComponent?(el: Instance, path: string, framework, customWrapper?: any)


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

runtime 增加 `onAddEvent` 钩子，支持在 `addEventListener` 的时刻插入逻辑。

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
