### PR TITLE
fix(h5): 修复getPropertyValue拿不到style属性值

### DIFF
--- a/packages/taro-h5/src/api/createSelectorQuery/index.js
+++ b/packages/taro-h5/src/api/createSelectorQuery/index.js
@@ -1,4 +1,4 @@
-import { findDOM } from '../utils'
+import Nerv from 'nervjs'
 
 /**
  * WXML节点信息API
@@ -13,7 +13,7 @@ function queryBat (queue, cb) {
     /* eslint-disable */
     const container = (
       component !== null ?
-        (findDOM(component) || document) :
+        (Nerv.findDOMNode(component) || document) :
         document
     )
     /* eslint-enable */
@@ -81,6 +81,8 @@ function filter (fields, dom, selector) {
   if (scrollOffset) {
     res.scrollLeft = dom.scrollLeft
     res.scrollTop = dom.scrollTop
+    res.scrollHeight = dom.scrollHeight
+    res.scrollWidth = dom.scrollWidth
   }
   if (properties.length) {
     properties.forEach(prop => {
@@ -93,6 +95,7 @@ function filter (fields, dom, selector) {
     computedStyle.forEach(key => {
       const value = styles.getPropertyValue(key)
       if (value) res[key] = value
+      else res[key] = styles[key]
     })
   }
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复getPropertyValue拿不到值时再直接用property获取style的属性值，实际上应该还会有其他的property拿不到的case，通过getPropertyValue拿不到时，直接通过属性property访问获取。

![image](https://user-images.githubusercontent.com/47242696/117232584-076cf880-ae54-11eb-80b4-17aa15b2f398.png)


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
