### PR TITLE
fix(h5): previewImage 加载图片改为异步

### DIFF
--- a/packages/taro-components/src/components.d.ts
+++ b/packages/taro-components/src/components.d.ts
@@ -191,7 +191,7 @@ export namespace Components {
          */
         "duration": number;
         /**
-          * 给 prewviewImage API 使用，全屏显示 swiper
+          * 给 previewImage API 使用，全屏显示 swiper
          */
         "full": boolean;
         /**
@@ -890,7 +890,7 @@ declare namespace LocalJSX {
          */
         "duration"?: number;
         /**
-          * 给 prewviewImage API 使用，全屏显示 swiper
+          * 给 previewImage API 使用，全屏显示 swiper
          */
         "full"?: boolean;
         /**

--- a/packages/taro-components/src/components/swiper/swiper.tsx
+++ b/packages/taro-components/src/components/swiper/swiper.tsx
@@ -79,7 +79,7 @@ export class Swiper implements ComponentInterface {
   @Prop() displayMultipleItems = 1
 
   /**
-   * 给 prewviewImage API 使用，全屏显示 swiper
+   * 给 previewImage API 使用，全屏显示 swiper
    */
   @Prop() full = false
 

--- a/packages/taro-h5/src/api/image/index.js
+++ b/packages/taro-h5/src/api/image/index.js
@@ -4,4 +4,4 @@
 
 export { default as chooseImage } from './chooseImage'
 export { default as getImageInfo } from './getImageInfo'
-export { previewImage } from './preview_image'
+export { previewImage } from './previewImage'

--- a/packages/taro-h5/src/api/image/previewImage.js
+++ b/packages/taro-h5/src/api/image/previewImage.js
@@ -33,7 +33,9 @@ export async function previewImage (options) {
 
   let children = []
   try {
-    children = await Promise.all(urls.map(loadImage))
+    children = await Promise.all(
+      urls.map(e => loadImage(e, options.fail))
+    )
   } catch (error) {
     if (options.fail) {
       options.fail(error)
@@ -60,8 +62,8 @@ export async function previewImage (options) {
   }
 }
 
-function loadImage (url) {
-  return new Promise((resolve, reject) => {
+function loadImage (url, fail) {
+  return new Promise((resolve) => {
     const item = document.createElement('taro-swiper-item-core')
     item.style.cssText = `
       display: flex;
@@ -72,11 +74,12 @@ function loadImage (url) {
     image.style.maxWidth = '100%'
     image.src = url
     item.appendChild(image)
-    image.addEventListener('load', () => {
-      resolve(item)
-    })
-    image.addEventListener('error', (err) => {
-      reject(err)
-    })
+    // Note: 等待图片加载完后返回，会导致轮播被卡住
+    resolve(item)
+    if (typeof fail === 'function') {
+      image.addEventListener('error', (err) => {
+        fail(err)
+      })
+    }
   })
 }


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

previewImage API，会先等所有大图都加载完毕才会展示出预览的界面，如果有图片特别大或者网速慢的情况下，实际体验极差

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id
- [x] TypeScript 类型定义修改(Typings)
- [x] 文档修改(Docs)
- [x] 代码风格更新(Code style update)

**这个 PR 涉及以下平台:**

- [x] Web 平台（H5）
