### PR TITLE
fix(taro-mini-runner): update vue build feature flags to silent warning

### DIFF
--- a/packages/taro-mini-runner/src/webpack/vue3.ts
+++ b/packages/taro-mini-runner/src/webpack/vue3.ts
@@ -29,8 +29,8 @@ export function customVue3Chain (chain) {
   chain
     .plugin('defined')
     .use(webpack.DefinePlugin, [{
-      __VUE_OPTIONS_API__: JSON.stringify(true),
-      __VUE_PROD_DEVTOOLS__: JSON.stringify(false)
+      __VUE_OPTIONS_API__: true,
+      __VUE_PROD_DEVTOOLS__: false
     }])
 
   chain.module


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

Vue 3.0.0-rc.3 开始，[要求 Build Feature Flags 以布尔字面量形式提供](https://github.com/vuejs/vue-next/tree/master/packages/vue#bundler-build-feature-flags)。更新 taro-mini-runner 的 Vue3 构建配置以避免警告。

![截屏2021-05-08 上午1 05 38](https://user-images.githubusercontent.com/8158163/117484322-84ee5100-af99-11eb-87c3-6e2ccffce969.png)

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
