### PR TITLE
fix: 移除sass-loader 中不必要的 fibers 依赖 #9291 #9322

### DIFF
--- a/packages/taro-mini-runner/package.json
+++ b/packages/taro-mini-runner/package.json
@@ -54,7 +54,6 @@
     "css-loader": "^3.0.0",
     "css-what": "3.3.0",
     "csso-webpack-plugin": "2.0.0-beta.1",
-    "fibers": "5.0.0",
     "file-loader": "^6.0.0",
     "fs-extra": "^8.0.1",
     "html-minifier": "^4.0.0",

--- a/packages/taro-mini-runner/src/webpack/chain.ts
+++ b/packages/taro-mini-runner/src/webpack/chain.ts
@@ -258,7 +258,7 @@ export const getModule = (appPath: string, {
     implementation: sass,
     sassOptions: {
       outputStyle: 'expanded',
-      fiber: require('fibers'),
+      fiber: false,
       importer (url, prev, done) {
         // 让 sass 文件里的 @import 能解析小程序原生样式文体，如 @import "a.wxss";
         const extname = path.extname(url)

--- a/packages/taro-webpack-runner/package.json
+++ b/packages/taro-webpack-runner/package.json
@@ -43,7 +43,6 @@
     "css-loader": "3.4.2",
     "csso-webpack-plugin": "2.0.0-beta.1",
     "detect-port": "1.3.0",
-    "fibers": "5.0.0",
     "file-loader": "^6.0.0",
     "fs-extra": "^5.0.0",
     "html-webpack-include-assets-plugin": "1.0.5",

--- a/packages/taro-webpack-runner/src/util/chain.ts
+++ b/packages/taro-webpack-runner/src/util/chain.ts
@@ -411,7 +411,7 @@ export const getModule = (appPath: string, {
     implementation: sass,
     sassOptions: {
       outputStyle: 'expanded',
-      fiber: require('fibers'),
+      fiber: false,
       importer (url, prev, done) {
         // 让 sass 文件里的 @import 能解析小程序原生样式文体，如 @import "a.wxss";
         const extname = path.extname(url)


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
当前 fibers 不再兼容新版本 nodejs，且 sass-loader 已不再推荐使用 fibers 来改善性能。所以 fibers 的依赖可以移除。
[https://github.com/NervJS/taro/issues/9291](url)

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
