### PR TITLE
fix(runtime): 区分冒泡事件，对于非冒泡事件不需要在祖先节点批量触发

### DIFF
--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -1,0 +1,18 @@
+/**
+ * 支持冒泡的事件, 除 支付宝小程序外，其余的可冒泡事件都和微信保持一致
+ * 详见 见 https://developers.weixin.qq.com/miniprogram/dev/framework/view/wxml/event.html
+ */
+export const BUBBLE_EVENTS = new Set([
+  'touchstart',
+  'touchmove',
+  'touchcancel',
+  'touchend',
+  'touchforcechange',
+  'tap',
+  'longpress',
+  'longtap',
+  'transitionend',
+  'animationstart',
+  'animationiteration',
+  'animationend'
+])

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -1,4 +1,5 @@
 import { internalComponents } from './components'
+import { BUBBLE_EVENTS } from './events'
 
 export const EMPTY_OBJ: any = {}
 
@@ -6,7 +7,12 @@ export const EMPTY_ARR = []
 
 export const noop = (..._: unknown[]) => {}
 
-export const defaultReconciler = {}
+export const defaultReconciler = {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  isBubbleEvent (eventName: string) {
+    return BUBBLE_EVENTS.has(eventName)
+  }
+}
 
 /**
  * Boxed value.

--- a/packages/taro-alipay/src/runtime-utils.ts
+++ b/packages/taro-alipay/src/runtime-utils.ts
@@ -18,8 +18,23 @@ export {
 }
 export * from './components'
 export * from './apis-list'
+
+// 见 https://opendocs.alipay.com/mini/framework/events
+const BUBBLE_EVENTS = new Set([
+  'touchStart',
+  'touchMove',
+  'touchEnd',
+  'touchCancel',
+  'tap',
+  'longTap'
+])
+
 export const hostConfig = {
   initNativeApi,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  isBubbleEvent (eventName: string, tagName: string) {
+    return BUBBLE_EVENTS.has(eventName)
+  },
   getEventCenter (Events) {
     if (!my.taroEventCenter) {
       my.taroEventCenter = new Events()

--- a/packages/taro-alipay/types/runtime-utils.d.ts
+++ b/packages/taro-alipay/types/runtime-utils.d.ts
@@ -4,6 +4,7 @@ export * from './components';
 export * from './apis-list';
 export declare const hostConfig: {
     initNativeApi: typeof initNativeApi;
+    isBubbleEvent(eventName: string, tagName: string): boolean;
     getEventCenter(Events: any): any;
     modifyDispatchEvent(event: any, tagName: any): void;
 };

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/alipay.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/alipay.spec.ts.snap
@@ -607,10 +607,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v
@@ -1772,8 +1777,12 @@ require(\\"./taro\\");
                     \\"ext-info\\": \\"\\"
                 }
             };
+            var BUBBLE_EVENTS = new Set([ \\"touchStart\\", \\"touchMove\\", \\"touchEnd\\", \\"touchCancel\\", \\"tap\\", \\"longTap\\" ]);
             var hostConfig = {
                 initNativeApi: initNativeApi,
+                isBubbleEvent: function isBubbleEvent(eventName, tagName) {
+                    return BUBBLE_EVENTS.has(eventName);
+                },
                 getEventCenter: function getEventCenter(Events) {
                     if (!my.taroEventCenter) {
                         my.taroEventCenter = new Events;

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/babel.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/babel.spec.ts.snap
@@ -594,10 +594,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/bytedance.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/bytedance.spec.ts.snap
@@ -594,10 +594,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/common-style.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/common-style.spec.ts.snap
@@ -594,10 +594,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/config.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/config.spec.ts.snap
@@ -594,10 +594,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v
@@ -3647,10 +3652,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v
@@ -6524,10 +6534,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/css-modules.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/css-modules.spec.ts.snap
@@ -594,10 +594,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v
@@ -3489,10 +3494,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/custom-tabbar.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/custom-tabbar.spec.ts.snap
@@ -594,10 +594,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/jd.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/jd.spec.ts.snap
@@ -594,10 +594,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/nerv.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/nerv.spec.ts.snap
@@ -594,10 +594,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/parse-html.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/parse-html.spec.ts.snap
@@ -594,10 +594,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/prerender.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/prerender.spec.ts.snap
@@ -491,10 +491,15 @@ require(\\"./taro\\");
     var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
     var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
     var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+    var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
     var EMPTY_OBJ = {};
     var EMPTY_ARR = [];
     var noop = function noop() {};
-    var defaultReconciler = {};
+    var defaultReconciler = {
+        isBubbleEvent: function isBubbleEvent(eventName) {
+            return BUBBLE_EVENTS.has(eventName);
+        }
+    };
     var box = function box(v) {
         return {
             v: v
@@ -5123,10 +5128,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v
@@ -9432,10 +9442,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/qq.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/qq.spec.ts.snap
@@ -594,10 +594,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v
@@ -4091,10 +4096,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/react.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/react.spec.ts.snap
@@ -594,10 +594,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/sass.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/sass.spec.ts.snap
@@ -594,10 +594,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v
@@ -3472,10 +3477,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v
@@ -6350,10 +6360,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v
@@ -9228,10 +9243,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/subpackages.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/subpackages.spec.ts.snap
@@ -594,10 +594,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/swan.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/swan.spec.ts.snap
@@ -597,10 +597,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/tabbar.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/tabbar.spec.ts.snap
@@ -470,8 +470,12 @@ require(\\"./taro\\");
                     \\"ext-info\\": \\"\\"
                 }
             };
+            var BUBBLE_EVENTS = new Set([ \\"touchStart\\", \\"touchMove\\", \\"touchEnd\\", \\"touchCancel\\", \\"tap\\", \\"longTap\\" ]);
             var hostConfig = {
                 initNativeApi: initNativeApi,
+                isBubbleEvent: function isBubbleEvent(eventName, tagName) {
+                    return BUBBLE_EVENTS.has(eventName);
+                },
                 getEventCenter: function getEventCenter(Events) {
                     if (!my.taroEventCenter) {
                         my.taroEventCenter = new Events;
@@ -1163,10 +1167,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v
@@ -3000,10 +3009,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/ts.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/ts.spec.ts.snap
@@ -594,10 +594,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/vue.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/vue.spec.ts.snap
@@ -590,10 +590,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/vue3.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/vue3.spec.ts.snap
@@ -592,10 +592,15 @@ require(\\"./taro\\");
         var focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         var voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         var nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        var BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         var EMPTY_OBJ = {};
         var EMPTY_ARR = [];
         var noop = function noop() {};
-        var defaultReconciler = {};
+        var defaultReconciler = {
+            isBubbleEvent: function isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         var box = function box(v) {
             return {
                 v: v

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/wx-hybrid.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/wx-hybrid.spec.ts.snap
@@ -473,10 +473,15 @@ require(\\"./taro\\");
         const focusComponents = new Set([ \\"input\\", \\"textarea\\" ]);
         const voidElements = new Set([ \\"progress\\", \\"icon\\", \\"rich-text\\", \\"input\\", \\"textarea\\", \\"slider\\", \\"switch\\", \\"audio\\", \\"ad\\", \\"official-account\\", \\"open-data\\", \\"navigation-bar\\" ]);
         const nestElements = new Map([ [ \\"view\\", -1 ], [ \\"catch-view\\", -1 ], [ \\"cover-view\\", -1 ], [ \\"static-view\\", -1 ], [ \\"pure-view\\", -1 ], [ \\"block\\", -1 ], [ \\"text\\", -1 ], [ \\"static-text\\", 6 ], [ \\"slot\\", 8 ], [ \\"slot-view\\", 8 ], [ \\"label\\", 6 ], [ \\"form\\", 4 ], [ \\"scroll-view\\", 4 ], [ \\"swiper\\", 4 ], [ \\"swiper-item\\", 4 ] ]);
+        const BUBBLE_EVENTS = new Set([ \\"touchstart\\", \\"touchmove\\", \\"touchcancel\\", \\"touchend\\", \\"touchforcechange\\", \\"tap\\", \\"longpress\\", \\"longtap\\", \\"transitionend\\", \\"animationstart\\", \\"animationiteration\\", \\"animationend\\" ]);
         const EMPTY_OBJ = {};
         const EMPTY_ARR = [];
         const noop = (..._) => {};
-        const defaultReconciler = {};
+        const defaultReconciler = {
+            isBubbleEvent(eventName) {
+                return BUBBLE_EVENTS.has(eventName);
+            }
+        };
         const box = v => ({
             v: v
         });

--- a/packages/taro-runtime/src/__tests__/event.spec.js
+++ b/packages/taro-runtime/src/__tests__/event.spec.js
@@ -104,6 +104,22 @@ describe('event', () => {
     expect(containerSpy).toBeCalledTimes(0)
   })
 
+  it('非冒泡事件不会在父元素触发', () => {
+    const eventName = 'unknown'
+    const container = document.createElement('container')
+    const div = document.createElement('div')
+    container.appendChild(div)
+    const containerSpy = jest.fn()
+    const divSpy = jest.fn()
+    container.addEventListener(eventName, containerSpy)
+    div.addEventListener(eventName, divSpy)
+    const event = runtime.createEvent({ type: eventName }, div)
+    div.dispatchEvent(event)
+    container.dispatchEvent(event) // buble event
+    expect(divSpy).toBeCalledTimes(1)
+    expect(containerSpy).toBeCalledTimes(1)
+  })
+
   it('preventDefault', () => {
     const container = document.createElement('container')
     const div = document.createElement('div')

--- a/packages/taro-runtime/src/reconciler.ts
+++ b/packages/taro-runtime/src/reconciler.ts
@@ -38,6 +38,9 @@ export interface Reconciler<Instance, DOMElement = TaroElement, TextElement = Ta
 
   getEventCenter(Events: EventsType): InstanceType<EventsType>
 
+  // 是否为冒泡事件
+  isBubbleEvent? (eventName: string, tagName: string): boolean
+
   modifyDispatchEvent? (event: TaroEvent, tagName: string): void
 
   batchedEventUpdates?(cb: () => void): void

--- a/packages/taro-runtime/src/utils/index.ts
+++ b/packages/taro-runtime/src/utils/index.ts
@@ -2,6 +2,7 @@ import { TaroElement } from '../dom/element'
 import { TaroText } from '../dom/text'
 import { NodeType } from '../dom/node_types'
 import { TaroNode } from '../dom/node'
+import { CurrentReconciler } from '../reconciler'
 
 export const incrementId = () => {
   let id = 0
@@ -28,7 +29,11 @@ export function isHasExtractProp (el: TaroElement): boolean {
  * @param node 当前组件
  * @param type 事件类型
  */
-export function isParentBinded (node: TaroElement | null, type: string): boolean {
+export function isParentBinded (node: TaroElement, type: string): boolean {
+  if (CurrentReconciler.isBubbleEvent?.(type, node.tagName) === false) {
+    return false
+  }
+
   let res = false
   while (node?.parentElement && node.parentElement._path !== 'root') {
     if (node.parentElement.__handlers[type]?.length) {


### PR DESCRIPTION


<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

小程序平台对于冒泡事件有明确的定义，对于非冒泡事件不需要在祖先节点批量触发。fix 9344, 9316

详见微信小程序事件系统文档： https://developers.weixin.qq.com/miniprogram/dev/framework/view/wxml/event.html

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
