### PR TITLE
fix: taro-img__mode-scaletofill修改为fill

### DIFF
--- a/packages/taro-components/src/components/image/style/index.css
+++ b/packages/taro-components/src/components/image/style/index.css
@@ -16,7 +16,7 @@ img[src=""] {
 }
 
 .taro-img__mode-scaletofill {
-  object-fit: contain;
+  object-fit: fill;
   width: 100%;
   height: 100%;
 }


### PR DESCRIPTION
scaleToFill模式为【缩放模式，不保持纵横比缩放图片，使图片的宽高完全拉伸至填满 image 元素】，object-fit属性值应为fill

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
h5编译的image组件scaleToFill模式为【缩放模式，不保持纵横比缩放图片，使图片的宽高完全拉伸至填满 image 元素】，object-fit属性值应为fill



**这个 PR 是什么类型?** (至少选择一个)

- [*] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [*] Web 平台（H5）
- [ ] 移动端（React-Native）
