### PR TITLE
fix: 将taro-rn依赖移到devDependencies

### DIFF
--- a/packages/babel-preset-taro/package.json
+++ b/packages/babel-preset-taro/package.json
@@ -35,7 +35,6 @@
     "@babel/runtime": "^7.11.2",
     "@tarojs/helper": "3.2.10",
     "@tarojs/taro-h5": "3.2.10",
-    "@tarojs/taro-rn": "3.2.10",
     "babel-plugin-dynamic-import-node": "^2.3.3",
     "babel-plugin-global-define": "^1.0.3",
     "babel-plugin-transform-imports-api": "^1.0.0",
@@ -44,5 +43,8 @@
     "core-js": "^3.6.5",
     "metro-react-native-babel-preset": "^0.63.0",
     "react-refresh": "0.9.0"
+  },
+  "devDependencies": {
+    "@tarojs/taro-rn": "3.2.10"
   }
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

@tarojs/taro-rn 依赖至于 dependencies 中会导致rn相关依赖被安装。

移动至 devDependencies 中，因为cli在启动rn时会安装 @tarojs/taro-rn 固不影响使用。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #9477
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
