### PR TITLE
fix(h5): 修复h5 Video组件在为获取到视频时长时(time可能为null或者undefined)显示NaN:NaN问题

### DIFF
--- a/packages/taro-components/src/components/video/utils.js
+++ b/packages/taro-components/src/components/video/utils.js
@@ -1,5 +1,5 @@
 export const formatTime = time => {
-  if (time === null) return ''
+  if (time == null) return ''
   const sec = Math.round(time % 60)
   const min = Math.round((time - sec) / 60)
   return `${min < 10 ? `0${min}` : min}:${sec < 10 ? `0${sec}` : sec}`


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

fix(h5): 修复h5 Video组件在为获取到视频时长时(time可能为null或者undefined)显示NaN:NaN问题


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
