### PR TITLE
feat(runtime): support insertAdjacentHTML

### DIFF
--- a/packages/taro-runtime/src/__tests__/dom.spec.js
+++ b/packages/taro-runtime/src/__tests__/dom.spec.js
@@ -123,6 +123,30 @@ describe('DOM', () => {
       container.textContent = ''
       expect(container.hasChildNodes()).toBe(false)
     })
+
+    it('insertAdjacentHTML', () => {
+      const container = document.createElement('container')
+      const div = document.createElement('div')
+      const text = document.createTextNode('text')
+      container.appendChild(div)
+      container.firstChild.appendChild(text)
+
+      const divBeforeInsert = container.firstChild
+      divBeforeInsert.insertAdjacentHTML('beforebegin', '<view />')
+      divBeforeInsert.insertAdjacentHTML('afterbegin', '<button />')
+      divBeforeInsert.insertAdjacentHTML('beforeend', '<input />')
+      divBeforeInsert.insertAdjacentHTML('afterend', '<image />')
+
+      expect(container.childNodes.length).toBe(3)
+      expect(container.childNodes[0].nodeName).toBe('view')
+      expect(container.childNodes[1].nodeName).toBe('div')
+      expect(container.childNodes[2].nodeName).toBe('image')
+
+      const divAfterInsert = container.childNodes[1]
+      expect(divAfterInsert.childNodes.length).toBe(3)
+      expect(divAfterInsert.firstChild.nodeName).toBe('button')
+      expect(divAfterInsert.lastChild.nodeName).toBe('input')
+    })
   })
 
   describe('text', () => {

--- a/packages/taro-runtime/src/dom/node.ts
+++ b/packages/taro-runtime/src/dom/node.ts
@@ -226,7 +226,7 @@ export class TaroNode extends TaroEventTarget {
     switch (position) {
       case 'beforebegin':
         for (const n of parsedNodes) {
-          this.parentNode.insertBefore(n, this)
+          this.parentNode?.insertBefore(n, this)
         }
         break
       case 'afterbegin':

--- a/packages/taro-runtime/src/dom/node.ts
+++ b/packages/taro-runtime/src/dom/node.ts
@@ -220,7 +220,7 @@ export class TaroNode extends TaroEventTarget {
   /**
    * An implementation of `Element.insertAdjacentHTML()`
    * to support Vue 3 with a version of or greater than `vue@3.1.2`
-   */ 
+   */
   public insertAdjacentHTML (
     position: 'beforebegin' | 'afterbegin' | 'beforeend' | 'afterend',
     html: string

--- a/packages/taro-runtime/src/dom/node.ts
+++ b/packages/taro-runtime/src/dom/node.ts
@@ -234,7 +234,7 @@ export class TaroNode extends TaroEventTarget {
           if (this.hasChildNodes()) {
             this.childNodes[0].insertBefore(n)
           } else {
-           this.appendChild(n)
+            this.appendChild(n)
           }
         }
         break
@@ -251,7 +251,7 @@ export class TaroNode extends TaroEventTarget {
     }
   }
 
-  protected findIndex(childeNodes: TaroNode[], refChild: TaroNode) {
+  protected findIndex (childeNodes: TaroNode[], refChild: TaroNode) {
     const index = childeNodes.indexOf(refChild)
     ensure(index !== -1, 'The node to be replaced is not a child of this node.')
 

--- a/packages/taro-runtime/src/dom/node.ts
+++ b/packages/taro-runtime/src/dom/node.ts
@@ -217,37 +217,37 @@ export class TaroNode extends TaroEventTarget {
     return ''
   }
 
+  /**
+   * An implementation of `Element.insertAdjacentHTML()`
+   * to support Vue 3 with a version of or greater than `vue@3.1.2`
+   */ 
   public insertAdjacentHTML (
     position: 'beforebegin' | 'afterbegin' | 'beforeend' | 'afterend',
     html: string
   ) {
     const parsedNodes = parser(html)
 
-    switch (position) {
-      case 'beforebegin':
-        for (const n of parsedNodes) {
+    for (let i = 0; i < parsedNodes.length; i++) {
+      const n = parsedNodes[i]
+
+      switch (position) {
+        case 'beforebegin':
           this.parentNode?.insertBefore(n, this)
-        }
-        break
-      case 'afterbegin':
-        for (const n of parsedNodes) {
+          break
+        case 'afterbegin':
           if (this.hasChildNodes()) {
             this.childNodes[0].insertBefore(n)
           } else {
             this.appendChild(n)
           }
-        }
-        break
-      case 'beforeend':
-        for (const n of parsedNodes) {
+          break
+        case 'beforeend':
           this.appendChild(n)
-        }
-        break
-      case 'afterend':
-        for (const n of parsedNodes) {
+          break
+        case 'afterend':
           this.parentNode?.appendChild(n)
-        }
-        break
+          break
+      }
     }
   }
 

--- a/packages/taro-runtime/src/dom/node.ts
+++ b/packages/taro-runtime/src/dom/node.ts
@@ -7,6 +7,7 @@ import { Shortcuts, ensure } from '@tarojs/shared'
 import { hydrate, HydratedData } from '../hydrate'
 import { TaroElement } from './element'
 import { setInnerHTML } from './html/html'
+import { parser } from './html/parser'
 import { CurrentReconciler } from '../reconciler'
 import { document } from '../bom/document'
 
@@ -216,7 +217,41 @@ export class TaroNode extends TaroEventTarget {
     return ''
   }
 
-  protected findIndex (childeNodes: TaroNode[], refChild: TaroNode) {
+  public insertAdjacentHTML (
+    position: 'beforebegin' | 'afterbegin' | 'beforeend' | 'afterend',
+    html: string
+  ) {
+    const parsedNodes = parser(html)
+
+    switch (position) {
+      case 'beforebegin':
+        for (const n of parsedNodes) {
+          this.parentNode.insertBefore(n, this)
+        }
+        break
+      case 'afterbegin':
+        for (const n of parsedNodes) {
+          if (this.hasChildNodes()) {
+            this.childNodes[0].insertBefore(n)
+          } else {
+           this.appendChild(n)
+          }
+        }
+        break
+      case 'beforeend':
+        for (const n of parsedNodes) {
+          this.appendChild(n)
+        }
+        break
+      case 'afterend':
+        for (const n of parsedNodes) {
+          this.parentNode?.appendChild(n)
+        }
+        break
+    }
+  }
+
+  protected findIndex(childeNodes: TaroNode[], refChild: TaroNode) {
     const index = childeNodes.indexOf(refChild)
     ensure(index !== -1, 'The node to be replaced is not a child of this node.')
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
`vue@3.1.2` 对静态内容插入逻辑进行了[更改](https://github.com/vuejs/vue-next/commit/4de5d24aa72f6bc68da967ead330147032983e30)，其中使用了 Taro Runtime 尚未支持的 `insertAdjacentHTML` 方法。

本 PR 为 `TaroNode` 新增了 `insertAdjacentHTML` 方法，以适配 `vue@^3.1.2`。  


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #9595
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
