### PR TITLE
fix: 配置文件中 outputRoot 为绝对路径时打包输出的路径错误

### DIFF
--- a/packages/taro-mini-runner/src/prerender/prerender.ts
+++ b/packages/taro-mini-runner/src/prerender/prerender.ts
@@ -4,7 +4,7 @@ import { NodeVM } from 'vm2'
 import { omitBy } from 'lodash'
 import * as webpack from 'webpack'
 import * as fs from 'fs'
-import { join } from 'path'
+import { resolve } from 'path'
 import { IBuildConfig } from '../utils/types'
 import { printPrerenderSuccess, printPrerenderFail } from '../utils/logHelper'
 
@@ -169,7 +169,7 @@ export class Prerender {
   }
 
   private getRealPath (path: string, ext = '.js') {
-    return join(this.outputPath, path + ext).replace(/\\/g, '\\\\')
+    return resolve(this.outputPath, path + ext).replace(/\\/g, '\\\\')
   }
 
   private buildSandbox () {

--- a/packages/taro-mini-runner/src/webpack/build.conf.ts
+++ b/packages/taro-mini-runner/src/webpack/build.conf.ts
@@ -92,13 +92,13 @@ export default (appPath: string, mode, config: Partial<IBuildConfig>): any => {
   const plugin: any = {}
   const minimizer: any[] = []
   const sourceDir = path.join(appPath, sourceRoot)
-  const outputDir = path.join(appPath, outputRoot)
+  const outputDir = path.resolve(appPath, outputRoot)
   const taroBaseReg = /@tarojs[\\/][a-z]+/
   if (isBuildPlugin) {
     const patterns = copy ? copy.patterns : []
     patterns.push({
       from: path.join(sourceRoot, 'plugin', 'doc'),
-      to: path.join(outputRoot, 'doc')
+      to: path.resolve(outputRoot, 'doc')
     })
     copy = Object.assign({}, copy, { patterns })
   }

--- a/packages/taro-mini-runner/src/webpack/chain.ts
+++ b/packages/taro-mini-runner/src/webpack/chain.ts
@@ -516,7 +516,7 @@ export const getEntry = ({
 
 export function getOutput (appPath: string, [{ outputRoot, publicPath, globalObject }, customOutput]) {
   return {
-    path: path.join(appPath, outputRoot),
+    path: path.resolve(appPath, outputRoot),
     publicPath,
     filename: '[name].js',
     chunkFilename: '[name].js',

--- a/packages/taro-rn-runner/src/index.ts
+++ b/packages/taro-rn-runner/src/index.ts
@@ -16,7 +16,7 @@ import saveAssets from '@react-native-community/cli/build/commands/bundle/saveAs
 import * as outputBundle from 'metro/src/shared/output/bundle'
 
 function concatOutputFileName (config: any): string {
-  let output = path.join(config.outputRoot, 'index.bundle')
+  let output = path.resolve(config.outputRoot, 'index.bundle')
   if (config.output) {
     const outputType = typeof config.output
     if (outputType === 'string') {
@@ -30,7 +30,7 @@ function concatOutputFileName (config: any): string {
       console.error(`invalid value for 'rn.output' configuration: ${JSON.stringify(config.output)}`)
     }
   }
-  const res = path.isAbsolute(output) ? output : path.join('.', output)
+  const res = path.isAbsolute(output) ? output : path.resolve('.', output)
   fse.ensureDirSync(path.dirname(res))
   return res
 }
@@ -41,7 +41,7 @@ function concatOutputAssetsDest (config: any): string | undefined {
   }
   const assetDest = config.deviceType === 'ios' ? config.output.iosAssetsDest : config.output.androidAssetsDest
   if (!assetDest) return undefined
-  const res = path.isAbsolute(assetDest) ? assetDest : path.join('.', assetDest)
+  const res = path.isAbsolute(assetDest) ? assetDest : path.resolve('.', assetDest)
   fse.ensureDirSync(path.dirname(res))
   return res
 }

--- a/packages/taro-webpack-runner/src/config/dev.conf.ts
+++ b/packages/taro-webpack-runner/src/config/dev.conf.ts
@@ -61,7 +61,7 @@ export default function (appPath: string, config: Partial<BuildConfig>): any {
     postcss = emptyObj
   } = config
   const sourceDir = path.join(appPath, sourceRoot)
-  const outputDir = path.join(appPath, outputRoot)
+  const outputDir = path.resolve(appPath, outputRoot)
   const plugin = {} as any
 
   const isMultiRouterMode = get(router, 'mode') === 'multi'

--- a/packages/taro-webpack-runner/src/config/prod.conf.ts
+++ b/packages/taro-webpack-runner/src/config/prod.conf.ts
@@ -63,7 +63,7 @@ export default function (appPath: string, config: Partial<BuildConfig>): any {
     terser
   } = config
   const sourceDir = path.join(appPath, sourceRoot)
-  const outputDir = path.join(appPath, outputRoot)
+  const outputDir = path.resolve(appPath, outputRoot)
   const isMultiRouterMode = get(router, 'mode') === 'multi'
 
   const plugin: any = {}

--- a/packages/taro-webpack-runner/src/index.ts
+++ b/packages/taro-webpack-runner/src/index.ts
@@ -72,7 +72,7 @@ const buildDev = async (appPath: string, config: BuildConfig): Promise<any> => {
   const routerMode = routerConfig.mode || 'hash'
   const routerBasename = routerConfig.basename || '/'
   const publicPath = conf.publicPath ? addLeadingSlash(addTrailingSlash(conf.publicPath)) : '/'
-  const outputPath = path.join(appPath, conf.outputRoot as string)
+  const outputPath = path.resolve(appPath, conf.outputRoot as string)
   const customDevServerOption = config.devServer || {}
   const webpackChain = devConf(appPath, config)
   const onBuildFinish = config.onBuildFinish

--- a/packages/taro-webpack-runner/src/util/chain.ts
+++ b/packages/taro-webpack-runner/src/util/chain.ts
@@ -9,7 +9,6 @@ import * as HtmlWebpackPlugin from 'html-webpack-plugin'
 import { partial } from 'lodash'
 import { mapKeys, pipe } from 'lodash/fp'
 import * as MiniCssExtractPlugin from 'mini-css-extract-plugin'
-import { join, resolve } from 'path'
 import * as TerserPlugin from 'terser-webpack-plugin'
 import * as webpack from 'webpack'
 import { PostcssOption, IPostcssOption, ICopyOptions } from '@tarojs/taro/types/compile'
@@ -216,7 +215,7 @@ export const getCopyWebpackPlugin = ({ copy, appPath }: { copy: ICopyOptions; ap
     copy.patterns.map(({ from, to, ...extra }) => {
       return {
         from,
-        to: resolve(appPath, to),
+        to: path.resolve(appPath, to),
         context: appPath,
         ...extra
       }
@@ -550,7 +549,7 @@ export const getModule = (appPath: string, {
 
 export const getOutput = (appPath: string, [{ outputRoot, publicPath, chunkDirectory }, customOutput]) => {
   return {
-    path: join(appPath, outputRoot),
+    path: path.resolve(appPath, outputRoot),
     filename: 'js/[name].js',
     chunkFilename: `${chunkDirectory}/[name].js`,
     publicPath,


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
#9606 修复配置文件中 outputRoot 为绝对路径时打包输出的路径错误


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 字节跳动小程序
- [x] QQ 轻应用
- [x] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）

快应用平台与移动端应该也存在这个问题，但未实际测试。