### PR TITLE
feat(runtime): 属性选择器里可以带空格

### DIFF
--- a/packages/taro-runtime/src/__tests__/html.spec.js
+++ b/packages/taro-runtime/src/__tests__/html.spec.js
@@ -108,6 +108,28 @@ describe('html with <style>', () => {
     expect(el1.style.cssText).toBe('font-size: 10;')
   })
 
+  it('attributes selector with space', () => {
+    const html = `
+      <style>
+        [name = "title"]   {
+          color: red;
+        }
+        [name = "body"][content = 'hello-world'] {
+          font-size: 10;
+        }
+      </style>
+      <div>
+        <div name="title"></div>
+        <div name="body" content="hello-world"></div>
+      </div>
+    `
+    const res = parser(html)
+    const el0 = res[0].children[0]
+    const el1 = res[0].children[1]
+    expect(el0.style.cssText).toBe('color: red;')
+    expect(el1.style.cssText).toBe('font-size: 10;')
+  })
+
   it('combination', () => {
     const html = `
       <style>

--- a/packages/taro-runtime/src/dom/html/style.ts
+++ b/packages/taro-runtime/src/dom/html/style.ts
@@ -70,8 +70,12 @@ export default class StyleTagParser {
   }
 
   parseSelector (src: string) {
-    // todo: 属性选择器里可以带空格：[a = "b"]，这里的 split(' ') 需要作兼容
-    const list = src.trim().replace(/ *([>~+]) */g, ' $1').replace(/ +/g, ' ').split(' ')
+    const list = src
+      .trim()
+      .replace(/ *([>~+]) */g, ' $1')
+      .replace(/ +/g, ' ')
+      .replace(/\[([^\[\]=\s]+)\s*=\s*([^\[\]=\s]+)\]/g, '[$1=$2]')
+      .split(' ')
     const selectors = list.map(item => {
       const firstChar = item.charAt(0)
       const selector: ISelector = {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
feat(runtime): 属性选择器里可以带空格


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
