### PR TITLE
chore(deps): [security] bump react-native-webview from 10.10.2 to 11.6.4

### DIFF
--- a/packages/taro-components-rn/package.json
+++ b/packages/taro-components-rn/package.json
@@ -38,7 +38,7 @@
     "expo-camera": "~9.0.0",
     "prop-types": "^15.6.2",
     "react-native-maps": "^0.25.0",
-    "react-native-webview": "^10.10.2",
+    "react-native-webview": "^11.6.4",
     "unimodules-permissions-interface": "~5.3.0"
   },
   "devDependencies": {
@@ -66,7 +66,7 @@
     "expo-camera": "~9.0.0",
     "react": "*",
     "react-native": "*",
-    "react-native-webview": "^10.10.2"
+    "react-native-webview": "^11.6.4"
   },
   "resolutions": {
     "@types/react": "17.0.11",

--- a/packages/taro-components-rn/yarn.lock
+++ b/packages/taro-components-rn/yarn.lock
@@ -6497,10 +6497,10 @@ react-native-swipeout@^2.3.6:
     prop-types "^15.5.10"
     react-tween-state "^0.1.5"
 
-react-native-webview@^10.10.2:
-  version "10.10.2"
-  resolved "https://registry.nlark.com/react-native-webview/download/react-native-webview-10.10.2.tgz?cache=0&sync_timestamp=1621859915767&other_urls=https%3A%2F%2Fregistry.nlark.com%2Freact-native-webview%2Fdownload%2Freact-native-webview-10.10.2.tgz#13208aef17c9ccfd28355363688f4cbe2143f10a"
-  integrity sha1-EyCK7xfJzP0oNVNjaI9MviFD8Qo=
+react-native-webview@^11.6.4:
+  version "11.6.4"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.6.4.tgz#bd2d072ea0157b3fcb10961b5d1866470b22c3c3"
+  integrity sha512-ahW9KL/iBooDRdQwBgPEWOl5Awjwvmo5FtV83WzbgUpQxDJ+ZRzZDpbmwcjLtd6R67yWg6dk1inqKQTrmkWiXQ==
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

0. 安全升级

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
