### PR TITLE
fix(runtime): 修复 Vue3 生命周期触发问题，fix #9614

### DIFF
--- a/packages/taro-runtime/src/dsl/vue3.ts
+++ b/packages/taro-runtime/src/dsl/vue3.ts
@@ -22,6 +22,7 @@ function createVue3Page (h: typeof createElement, id: string) {
       props: {
         tid: String
       },
+      mixins: [component],
       created () {
         injectPageInstance(this, id)
         // vue3 组件 created 时机比小程序页面 onShow 慢，因此在 created 后再手动触发一次 onShow。
@@ -29,20 +30,6 @@ function createVue3Page (h: typeof createElement, id: string) {
           safeExecute(id, 'onShow')
         })
       }
-    }
-
-    if (isArray(component.mixins)) {
-      const mixins = component.mixins
-      const idx = mixins.length - 1
-      if (!mixins[idx].props?.tid) {
-        // mixins 里还没注入过，直接推入数组
-        component.mixins.push(inject)
-      } else {
-        // mixins 里已经注入过，代替前者
-        component.mixins[idx] = inject
-      }
-    } else {
-      component.mixins = [inject]
     }
 
     return h(
@@ -53,7 +40,7 @@ function createVue3Page (h: typeof createElement, id: string) {
         class: isBrowser ? 'taro_page' : ''
       },
       [
-        h(component, {
+        h(inject, {
           tid: id
         })
       ]


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复 Vue3 生命周期触发问题，fix #9614

Vue3 `resolveMergedOptions` 函数里有 cache 逻辑，用户编写的页面对象的 mixins 只会被 merge 一次。

因此反过来，每次打开新页面时，使用新对象进行渲染，用户编写的页面对象作为 mixin。

虽然 Vue3 使用 WeakMap 实现 cache，还需要关注是否会导致内存泄漏。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #9614 

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
