### PR TITLE
fix: 解决h5中reLaunch未清空已有路由，与小程序效果不一致问题

### DIFF
--- a/packages/taro-components/src/components/tabbar/tabbar.tsx
+++ b/packages/taro-components/src/components/tabbar/tabbar.tsx
@@ -148,7 +148,7 @@ export class Tabbar implements ComponentInterface {
 
   switchTab = (index: number) => {
     this.selectedIndex = index
-    Taro.navigateTo({
+    Taro.reLaunch({
       url: this.list[index].pagePath
     })
   }

--- a/packages/taro-router/src/api.ts
+++ b/packages/taro-router/src/api.ts
@@ -81,7 +81,13 @@ export function switchTab (option: Option) {
   return navigateTo(option)
 }
 
-export function reLaunch (option: Option) {
+export async function reLaunch (option: Option) {
+  // 模拟小程序reLaunch效果，清空已有路由
+  if (stacks.length > 1) {
+    navigateBack({delta: stacks.length - 1});
+    // 如果不添加延时会导致redirectTo时还是在当前路由操作
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
   return redirectTo(option)
 }
 

--- a/packages/taro-router/src/api.ts
+++ b/packages/taro-router/src/api.ts
@@ -78,7 +78,7 @@ export function navigateBack (options: NavigateBackOption = { delta: 1 }) {
 }
 
 export function switchTab (option: Option) {
-  return navigateTo(option)
+  return reLaunch(option)
 }
 
 export async function reLaunch (option: Option) {

--- a/packages/taro-router/src/api.ts
+++ b/packages/taro-router/src/api.ts
@@ -84,9 +84,9 @@ export function switchTab (option: Option) {
 export async function reLaunch (option: Option) {
   // 模拟小程序reLaunch效果，清空已有路由
   if (stacks.length > 1) {
-    navigateBack({delta: stacks.length - 1});
+    navigateBack({ delta: stacks.length - 1 })
     // 如果不添加延时会导致redirectTo时还是在当前路由操作
-    await new Promise(resolve => setTimeout(resolve, 10));
+    await new Promise(resolve => setTimeout(resolve, 10))
   }
   return redirectTo(option)
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)



**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue [#8347]
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
