### PR TITLE
fix(swan): 修复 input 光标跳动问题

### DIFF
--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/swan.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/swan.spec.ts.snap
@@ -1669,11 +1669,11 @@ require(\\"./taro\\");
 </template>
 
 <template name=\\"tmpl_0_input_focus\\">
-  <input value=\\"{= i.value =}\\" type=\\"{{ xs.b(i.type,'') }}\\" password=\\"{{ xs.b(i.password,false) }}\\" placeholder=\\"{{ i.placeholder }}\\" placeholder-style=\\"{{ i.placeholderStyle }}\\" placeholder-class=\\"{{ xs.b(i.placeholderClass,'input-placeholder') }}\\" disabled=\\"{{ i.disabled }}\\" maxlength=\\"{{ xs.b(i.maxlength,140) }}\\" cursor-spacing=\\"{{ xs.b(i.cursorSpacing,0) }}\\" focus=\\"{{ xs.b(i.focus,false) }}\\" confirm-type=\\"{{ xs.b(i.confirmType,'done') }}\\" confirm-hold=\\"{{ xs.b(i.confirmHold,false) }}\\" cursor=\\"{{ xs.b(i.cursor,i.value.length) }}\\" selection-start=\\"{{ xs.b(i.selectionStart,-1) }}\\" selection-end=\\"{{ xs.b(i.selectionEnd,-1) }}\\" bindinput=\\"eh\\" bindfocus=\\"eh\\" bindblur=\\"eh\\" bindconfirm=\\"eh\\" name=\\"{{ i.name }}\\" style=\\"{{ i.st }}\\" class=\\"{{ i.cl }}\\" bindtap=\\"eh\\" id=\\"{{xs.f(i.uid)}}\\"></input>
+  <input value=\\"{= i.value =}\\" type=\\"{{ xs.b(i.type,'') }}\\" password=\\"{{ xs.b(i.password,false) }}\\" placeholder=\\"{{ i.placeholder }}\\" placeholder-style=\\"{{ i.placeholderStyle }}\\" placeholder-class=\\"{{ xs.b(i.placeholderClass,'input-placeholder') }}\\" disabled=\\"{{ i.disabled }}\\" maxlength=\\"{{ xs.b(i.maxlength,140) }}\\" cursor-spacing=\\"{{ xs.b(i.cursorSpacing,0) }}\\" focus=\\"{{ xs.b(i.focus,false) }}\\" confirm-type=\\"{{ xs.b(i.confirmType,'done') }}\\" confirm-hold=\\"{{ xs.b(i.confirmHold,false) }}\\" cursor=\\"{{ xs.b(i.cursor,i.value.length) }}\\" selection-start=\\"{{ xs.b(i.selectionStart,-1) }}\\" selection-end=\\"{{ xs.b(i.selectionEnd,-1) }}\\" bindinput=\\"eh\\" bindfocus=\\"eh\\" bindblur=\\"eh\\" bindconfirm=\\"eh\\" name=\\"{{ i.name }}\\" style=\\"{{ i.st }}\\" class=\\"{{ i.cl }}\\" bindtap=\\"eh\\"  id=\\"{{i.uid}}\\"></input>
 </template>
 
 <template name=\\"tmpl_0_input_blur\\">
-  <input value=\\"{= i.value =}\\" type=\\"{{ xs.b(i.type,'') }}\\" password=\\"{{ xs.b(i.password,false) }}\\" placeholder=\\"{{ i.placeholder }}\\" placeholder-style=\\"{{ i.placeholderStyle }}\\" placeholder-class=\\"{{ xs.b(i.placeholderClass,'input-placeholder') }}\\" disabled=\\"{{ i.disabled }}\\" maxlength=\\"{{ xs.b(i.maxlength,140) }}\\" cursor-spacing=\\"{{ xs.b(i.cursorSpacing,0) }}\\" confirm-type=\\"{{ xs.b(i.confirmType,'done') }}\\" confirm-hold=\\"{{ xs.b(i.confirmHold,false) }}\\" cursor=\\"{{ xs.b(i.cursor,i.value.length) }}\\" selection-start=\\"{{ xs.b(i.selectionStart,-1) }}\\" selection-end=\\"{{ xs.b(i.selectionEnd,-1) }}\\" bindinput=\\"eh\\" bindfocus=\\"eh\\" bindblur=\\"eh\\" bindconfirm=\\"eh\\" name=\\"{{ i.name }}\\" style=\\"{{ i.st }}\\" class=\\"{{ i.cl }}\\" bindtap=\\"eh\\" id=\\"{{xs.f(i.uid)}}\\"></input>
+  <input value=\\"{= i.value =}\\" type=\\"{{ xs.b(i.type,'') }}\\" password=\\"{{ xs.b(i.password,false) }}\\" placeholder=\\"{{ i.placeholder }}\\" placeholder-style=\\"{{ i.placeholderStyle }}\\" placeholder-class=\\"{{ xs.b(i.placeholderClass,'input-placeholder') }}\\" disabled=\\"{{ i.disabled }}\\" maxlength=\\"{{ xs.b(i.maxlength,140) }}\\" cursor-spacing=\\"{{ xs.b(i.cursorSpacing,0) }}\\" confirm-type=\\"{{ xs.b(i.confirmType,'done') }}\\" confirm-hold=\\"{{ xs.b(i.confirmHold,false) }}\\" cursor=\\"{{ xs.b(i.cursor,i.value.length) }}\\" selection-start=\\"{{ xs.b(i.selectionStart,-1) }}\\" selection-end=\\"{{ xs.b(i.selectionEnd,-1) }}\\" bindinput=\\"eh\\" bindfocus=\\"eh\\" bindblur=\\"eh\\" bindconfirm=\\"eh\\" name=\\"{{ i.name }}\\" style=\\"{{ i.st }}\\" class=\\"{{ i.cl }}\\" bindtap=\\"eh\\"  id=\\"{{i.uid}}\\"></input>
 </template>
 
 <template name=\\"tmpl_0_textarea\\">
@@ -2528,9 +2528,7 @@ module.exports = {
   e: function (n) {
     return 'tmpl_' + n + '_container'
   },
-  f: function (s) {
-    return s[0] === '_' ? s.slice(1) : s
-  }
+  
 }
 
 /** filePath: dist/vendors.js **/

--- a/packages/taro-swan/src/program.ts
+++ b/packages/taro-swan/src/program.ts
@@ -45,5 +45,8 @@ export default class Swan extends TaroPlatformBase {
    */
   modifyComponents () {
     this.template.mergeComponents(this.ctx, components)
+    delete this.template.internalComponents.Input.cursor
+    delete this.template.internalComponents.Input['selection-start']
+    delete this.template.internalComponents.Input['selection-end']
   }
 }

--- a/packages/taro-swan/src/template.ts
+++ b/packages/taro-swan/src/template.ts
@@ -56,15 +56,6 @@ export class Template extends RecursiveTemplate {
 
   modifyTemplateResult = (res: string, nodeName: string) => {
     if (nodeName === 'picker-view-column') return ''
-    if (nodeName === 'input') {
-      return res.replace(/ id="{{i.uid}}"/g, 'id="{{xs.f(i.uid)}}"')
-    }
     return res
-  }
-
-  buildXSTmpExtra () {
-    return `f: function (s) {
-    return s[0] === '_' ? s.slice(1) : s
-  }`
   }
 }

--- a/packages/taro-swan/types/template.d.ts
+++ b/packages/taro-swan/types/template.d.ts
@@ -17,5 +17,4 @@ export declare class Template extends RecursiveTemplate {
     getAttrValue(value: string, key: string, nodeName: string): string;
     modifyLoopBody: (child: string, nodeName: string) => string;
     modifyTemplateResult: (res: string, nodeName: string) => string;
-    buildXSTmpExtra(): string;
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

暂时移除 `<input>` 的 `cursor`、`section-start`、`section-end` 属性

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) 
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [x] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
