### PR TITLE
fix: 解决 `ENABLE_INNER_HTML is not defined`

### DIFF
--- a/packages/taro-runtime/src/dom-external/index.ts
+++ b/packages/taro-runtime/src/dom-external/index.ts
@@ -11,13 +11,13 @@ declare const ENABLE_SIZE_APIS: boolean
 
 const domExternal = new ContainerModule(bind => {
   if (process.env.TARO_ENV !== 'h5') {
-    if (ENABLE_INNER_HTML) {
+    if (typeof ENABLE_INNER_HTML !== 'undefined' && ENABLE_INNER_HTML) {
       bind(SERVICE_IDENTIFIER.InnerHTMLImpl).toFunction(setInnerHTML)
-      if (ENABLE_ADJACENT_HTML) {
+      if (typeof ENABLE_ADJACENT_HTML !== 'undefined' && ENABLE_ADJACENT_HTML) {
         bind(SERVICE_IDENTIFIER.insertAdjacentHTMLImpl).toFunction(insertAdjacentHTMLImpl)
       }
     }
-    if (ENABLE_SIZE_APIS) {
+    if (typeof ENABLE_SIZE_APIS !== 'undefined' && ENABLE_SIZE_APIS) {
       bind(SERVICE_IDENTIFIER.getBoundingClientRectImpl).toFunction(getBoundingClientRectImpl)
     }
   }


### PR DESCRIPTION

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

自定义包依赖 `@tarojs/components` `3.3+`，
运行 jest 测试时提示
`ReferenceError: ENABLE_INNER_HTML is not defined`

需自行加上全局变量配置

```json
"jest": {
  "globals": {
    "ENABLE_INNER_HTML": true,
    "ENABLE_ADJACENT_HTML": true,
    "ENABLE_SIZE_APIS": true
  }
},
```

或者由 taro 做兼容

---

参考例子

增加配置前，提示错误
https://github.com/miaoxing/mxjs-m-ret/runs/3044454333?check_suite_focus=true

增加配置后，运行成功
https://github.com/miaoxing/mxjs-m-ret/runs/3045186096?check_suite_focus=true


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
