### PR TITLE
fix(components): 修复 Vue3 使用 input 组件时 v-model 失效的问题，fix #9775

### DIFF
--- a/packages/taro-components/h5/vue3/createFormsComponent.js
+++ b/packages/taro-components/h5/vue3/createFormsComponent.js
@@ -1,4 +1,4 @@
-import { h } from 'vue'
+import { h, toRefs, computed } from 'vue'
 
 export default function createFormsComponent (name, eventName, modelValue = 'value', classNames = []) {
   const props = {
@@ -12,25 +12,30 @@ export default function createFormsComponent (name, eventName, modelValue = 'val
     emits: ['tap', 'update:modelValue'],
     props,
     setup (props, { slots, emit }) {
-      const attrs = {
-        [modelValue]: props.modelValue
-      }
+      const { modelValue: model, focus } = toRefs(props)
 
-      if (name === 'taro-input') {
-        attrs['auto-focus'] = props.focus
-      }
+      const attrs = computed(() => {
+        return name === 'taro-input'
+          ? {
+            [modelValue]: model.value,
+            'auto-focus': focus.value
+          }
+          : {
+            [modelValue]: model.value
+          }
+      })
 
       return () => (
         h(
           `${name}-core`,
           {
             class: ['hydrated', ...classNames],
-            ...attrs,
+            ...attrs.value,
             onClick (e) {
               emit('tap', e)
             },
             [`on${eventName}`] (e) {
-              emit('update:modelValue', e.target.value)
+              emit('update:modelValue', e.detail.value)
             }
           },
           slots

--- a/packages/taro-components/src/components/input/input.tsx
+++ b/packages/taro-components/src/components/input/input.tsx
@@ -1,4 +1,4 @@
-import { Component, h, ComponentInterface, Prop, Event, EventEmitter, Element } from '@stencil/core'
+import { Component, h, ComponentInterface, Prop, Event, EventEmitter, Element, State, Watch } from '@stencil/core'
 import { EventHandler, TaroEvent } from '../../../types'
 
 function getTrueType (type: string | undefined, confirmType: string, password: boolean) {
@@ -39,7 +39,16 @@ export class Input implements ComponentInterface {
   @Prop() confirmType = 'done'
   @Prop() name: string
 
+  @State() _value: string
+
   @Element() el: HTMLElement
+
+  @Watch('value')
+  watchHandler(newValue: string, oldValue: string) {
+    if (newValue !== oldValue) {
+      this._value = newValue
+    }
+  }
 
   @Event({
     eventName: 'input'
@@ -65,6 +74,10 @@ export class Input implements ComponentInterface {
     eventName: 'keydown'
   }) onKeyDown: EventEmitter
 
+  componentWillLoad () {
+    this._value = this.value
+  }
+
   componentDidLoad () {
     if (this.type === 'file') {
       this.fileListener = () => {
@@ -78,7 +91,9 @@ export class Input implements ComponentInterface {
 
     Object.defineProperty(this.el, 'value', {
       get: () => this.inputRef.value,
-      set: value => (this.value = value),
+      set: value => {
+        this._value = value
+      },
       configurable: true
     })
   }
@@ -117,6 +132,8 @@ export class Input implements ComponentInterface {
       //     }
       //   )
       // }
+
+      this._value = value
 
       this.onInput.emit({
         value,
@@ -168,7 +185,7 @@ export class Input implements ComponentInterface {
 
   render () {
     const {
-      value,
+      _value,
       type,
       password,
       placeholder,
@@ -186,7 +203,7 @@ export class Input implements ComponentInterface {
           autoFocus && input?.focus()
         }}
         class='weui-input'
-        value={fixControlledValue(value)}
+        value={fixControlledValue(_value)}
         type={getTrueType(type, confirmType, password)}
         placeholder={placeholder}
         disabled={disabled}


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复 Vue3 使用 `input` 组件时 `v-model` 失效的问题，fix #9775

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #9775 
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
