### PR TITLE
fix(mini-runner): 修复external module导致的错误 (#9862)

### DIFF
--- a/packages/taro-mini-runner/src/__tests__/fixtures/mini-split-chunks/src/packageA/detail/index.jsx
+++ b/packages/taro-mini-runner/src/__tests__/fixtures/mini-split-chunks/src/packageA/detail/index.jsx
@@ -8,6 +8,7 @@ import '../../css/sub-vendors.css'
 import '../../css/sub-common.css'
 import subCommonStyles from '../../css/sub-common.module.css'
 import vendorsStyles from '../../css/sub-vendors.module.css'
+import _ from 'lodash'
 
 export default class Detail extends Component {
   componentDidMount() {

--- a/packages/taro-mini-runner/src/__tests__/fixtures/mini-split-chunks/src/packageB/list/index.jsx
+++ b/packages/taro-mini-runner/src/__tests__/fixtures/mini-split-chunks/src/packageB/list/index.jsx
@@ -5,6 +5,7 @@ import consoleLogSubCommon from '../../utils/consoleLogSubCommon'
 import testExcludeFunction from '../../utils/testExcludeFunction'
 import '../../css/sub-common.css'
 import subCommonStyles from '../../css/sub-common.module.css'
+import _ from 'lodash'
 
 export default class My extends Component {
   componentDidMount () {

--- a/packages/taro-mini-runner/src/__tests__/mini-split-chunks.spec.ts
+++ b/packages/taro-mini-runner/src/__tests__/mini-split-chunks.spec.ts
@@ -20,6 +20,13 @@ describe('mini-split-chunks', () => {
   test('should process mini-split-chunks', async () => {
     const appName = 'mini-split-chunks'
     const { stats, config } = await compile(appName, {
+      webpackChain (chain) {
+        chain.merge({
+          externals: [
+            'lodash'
+          ]
+        })
+      },
       optimizeMainPackage: {
         enable: true,
         exclude: [

--- a/packages/taro-mini-runner/src/plugins/MiniSplitChunksPlugin.ts
+++ b/packages/taro-mini-runner/src/plugins/MiniSplitChunksPlugin.ts
@@ -74,6 +74,10 @@ export default class MiniSplitChunksPlugin extends SplitChunksPlugin {
 
     compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation: any) => {
       compilation.hooks.optimizeChunks.tap(PLUGIN_NAME, (chunks: webpack.compilation.Chunk[]) => {
+        const splitChunksOriginConfig = {
+          ...compiler?.options?.optimization?.splitChunks
+        }
+
         this.subCommonDeps = new Map()
         this.chunkSubCommons = new Map()
         this.subPackagesVendors = new Map()
@@ -84,6 +88,7 @@ export default class MiniSplitChunksPlugin extends SplitChunksPlugin {
         const subChunks = chunks.filter(chunk => this.isSubChunk(chunk))
 
         if (subChunks.length === 0) {
+          this.options = SplitChunksPlugin.normalizeOptions(splitChunksOriginConfig)
           return
         }
 
@@ -149,9 +154,9 @@ export default class MiniSplitChunksPlugin extends SplitChunksPlugin {
          * 用新的option配置生成新的cacheGroups配置
          */
         this.options = SplitChunksPlugin.normalizeOptions({
-          ...compiler?.options?.optimization?.splitChunks,
+          ...splitChunksOriginConfig,
           cacheGroups: {
-            ...compiler?.options?.optimization?.splitChunks?.cacheGroups,
+            ...splitChunksOriginConfig?.cacheGroups,
             ...this.getSubPackageVendorsCacheGroup(),
             ...this.getSubCommonCacheGroup()
           }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

1、分包提取插件不处理external module
2、修复没有分包配置时报'getCacheGroups' of null的错误
3、格式化path使用helper内的normalizePath方法

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
