### PR TITLE
refactor(rn): 重构网络状态回调机制

### DIFF
--- a/packages/taro-rn/src/lib/network.ts
+++ b/packages/taro-rn/src/lib/network.ts
@@ -1,8 +1,10 @@
 import NetInfo from '@react-native-community/netinfo'
 
-let unsubscribe: any = null
+let _unsubscribe: any = null
 
-export function getNetworkType (opts: Taro.getNetworkType.Option = {}): Promise<Taro.getNetworkType.SuccessCallbackResult> {
+let _callbacks: Set<Function> = new Set()
+
+export function getNetworkType(opts: Taro.getNetworkType.Option = {}): Promise<Taro.getNetworkType.SuccessCallbackResult> {
   const { success, fail, complete } = opts
   const res: any = {}
 
@@ -25,18 +27,26 @@ export function getNetworkType (opts: Taro.getNetworkType.Option = {}): Promise<
   })
 }
 
-export function onNetworkStatusChange (onNetworkStatusChange: Taro.onNetworkStatusChange.Callback): void {
-  function changeCallback (connectionInfo) {
-    const { type, isConnected } = connectionInfo
-    onNetworkStatusChange && onNetworkStatusChange({
-      isConnected,
-      networkType: type
+export function onNetworkStatusChange(fnc: Taro.onNetworkStatusChange.Callback): void {
+  _callbacks.add(fnc)
+  if (!_unsubscribe) {
+    _unsubscribe = NetInfo.addEventListener((connectionInfo) => {
+      _callbacks.forEach(cb => {
+        const { type, isConnected } = connectionInfo
+        cb?.({ isConnected, networkType: type })
+      })
     })
   }
-  unsubscribe = NetInfo.addEventListener(changeCallback)
 }
 
-export function offNetworkStatusChange (): void {
-  unsubscribe()
-  unsubscribe = null
+export function offNetworkStatusChange(fnc?: Taro.onNetworkStatusChange.Callback): void {
+  if (fnc && typeof fnc === 'function') {
+    _callbacks.delete(fnc)
+  } else if (fnc === undefined) {
+    _callbacks.clear()
+    _unsubscribe?.()
+    _unsubscribe = null
+  } else {
+    console.warn('offNetworkStatusChange failed')
+  }
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

问题：`Taro.onNetworkStatusChange` 和 `Taro.offNetworkStatusChange` 表现形式与文档不一致，且 `Taro.offNetworkStatusChange` 无效。
解决：对事件回调机制进行了重构。

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [x] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
