### PR TITLE
refactor(rn): replace deprecated keyboard api

### DIFF
--- a/packages/taro-rn/src/lib/keyboard.ts
+++ b/packages/taro-rn/src/lib/keyboard.ts
@@ -6,19 +6,20 @@ const hideKeyboard = (opts: Taro.hideKeyboard.Option = {}): void => {
   try {
     Keyboard.dismiss()
     const res = { errMsg: 'hideKeyboard:ok' }
-    success && success(res)
-    complete && complete(res)
+    success?.(res)
+    complete?.(res)
   } catch (err) {
     const res = { errMsg: err.message }
-    fail && fail(res)
-    complete && complete(res)
+    fail?.(res)
+    complete?.(res)
   }
 }
 
-const callbackManager = createCallbackManager()
+const _cbManager = createCallbackManager()
+let _hasListener = false
 
 const keyboardHeightListener = (e) => {
-  callbackManager.trigger(e.endCoordinates.height)
+  _cbManager.trigger({ height: e.endCoordinates.height })
 }
 
 /**
@@ -26,10 +27,11 @@ const keyboardHeightListener = (e) => {
  * @param {(height: number) => void} callback 键盘高度变化事件的回调函数
  */
 const onKeyboardHeightChange = (callback: Taro.onKeyboardHeightChange.Callback): void => {
-  callbackManager.add(callback)
-  if (callbackManager.count() === 1) {
-    Keyboard.addListener('keyboardDidShow', keyboardHeightListener)
-    Keyboard.addListener('keyboardDidHide', keyboardHeightListener)
+  _cbManager.add(callback)
+  if (!_hasListener) {
+    Keyboard.addListener("keyboardDidShow", keyboardHeightListener)
+    Keyboard.addListener("keyboardDidHide", keyboardHeightListener)
+    _hasListener = true
   }
 }
 
@@ -37,11 +39,18 @@ const onKeyboardHeightChange = (callback: Taro.onKeyboardHeightChange.Callback):
  * 取消监听键盘高度变化事件
  * @param {(height: number) => void} callback 键盘高度变化事件的回调函数
  */
-const offKeyboardHeightChange = (callback: Taro.onKeyboardHeightChange.Callback): void => {
-  callbackManager.remove(callback)
-  if (callbackManager.count() === 0) {
-    Keyboard.removeListener('keyboardDidShow', keyboardHeightListener)
-    Keyboard.removeListener('keyboardDidHide', keyboardHeightListener)
+const offKeyboardHeightChange = (callback?: Taro.onKeyboardHeightChange.Callback): void => {
+  if (callback && typeof callback === 'function') {
+    _cbManager.remove(callback)
+  } else if (callback === undefined) {
+    _cbManager.clear()
+  } else {
+    console.warn('offKeyboardHeightChange failed')
+  }
+  if (_cbManager.count() === 0) {
+    Keyboard.removeAllListeners('keyboardDidShow')
+    Keyboard.removeAllListeners('keyboardDidHide')
+    _hasListener = false
   }
 }
 

--- a/packages/taro/types/api/ui/keyboard.d.ts
+++ b/packages/taro/types/api/ui/keyboard.d.ts
@@ -11,7 +11,7 @@ declare namespace Taro {
   }
 
   /** 在input、textarea等focus拉起键盘之后，手动调用此接口收起键盘
-   * @supported weapp
+   * @supported weapp, rn
    * @example
    * ```tsx
    * Taro.hideKeyboard({
@@ -68,7 +68,7 @@ declare namespace Taro {
   }
 
   /** 监听键盘高度变化
-   * @supported weapp
+   * @supported weapp, rn
    * @example
    * ```tsx
    * Taro.onKeyboardHeightChange(res => {
@@ -78,4 +78,14 @@ declare namespace Taro {
    * @see https://developers.weixin.qq.com/miniprogram/dev/api/ui/keyboard/wx.onKeyboardHeightChange.html
    */
   function onKeyboardHeightChange(callback: onKeyboardHeightChange.Callback): void
+
+  /**
+   * 取消监听键盘高度变化事件。
+   * @supported weapp, rn
+   * @see https://developers.weixin.qq.com/miniprogram/dev/api/ui/keyboard/wx.offKeyboardHeightChange.html
+   */
+  function offKeyboardHeightChange(
+    /** 键盘高度变化事件的回调函数 */
+    callback?: (...args: any[]) => any,
+  ): void
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

1、`Keyboard.removeListener` 已废弃，故改为 `removeAllListeners` 实现;
2、修改 `Keyboard` 相应的类型文件；

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [x] 代码重构(Refactor)
- [x] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
