### PR TITLE
feat(babel-preset-taro/jsx-to-rn): add option for transform style att…

### DIFF
--- a/packages/babel-plugin-transform-react-jsx-to-rn-stylesheet/__tests__/index.spec.js
+++ b/packages/babel-plugin-transform-react-jsx-to-rn-stylesheet/__tests__/index.spec.js
@@ -60,9 +60,9 @@ const getStyleFunctionTemplete = `function _getStyle(classNameExpression) {
 
 describe('jsx style plugin', () => {
   function getTransfromCode (source, debug = false, options = {}) {
-    const { isCSSModule, enableMultipleClassName = false } = options
+    const { enableCSSModule, enableMultipleClassName = false } = options
     const code = transform(source, {
-      plugins: [[jSXStylePlugin, { isCSSModule, enableMultipleClassName }], syntaxJSX],
+      plugins: [[jSXStylePlugin, { enableCSSModule, enableMultipleClassName }], syntaxJSX],
       configFile: false
     }).code
     if (debug) {
@@ -465,7 +465,7 @@ class App extends Component {
   render() {
     return <div className="header" style={styleSheet.red} />;
   }
-}`, false, { isCSSModule: true })).toBe(`import { createElement, Component } from 'rax';
+}`, false, { enableCSSModule: true })).toBe(`import { createElement, Component } from 'rax';
 import appScssStyleSheet from "./app.scss";
 import styleSheet from './app.module.scss';
 var _styleSheet = appScssStyleSheet;
@@ -489,7 +489,7 @@ class App extends Component {
       <div className="red" />
     </div>;
   }
-}`, false, { isCSSModule: true })).toBe(`import { createElement, Component } from 'rax';
+}`, false, { enableCSSModule: true })).toBe(`import { createElement, Component } from 'rax';
 import styleSheet from './app.module.scss';
 var _styleSheet = {};
 
@@ -514,7 +514,7 @@ class App extends Component {
     const a = styleSheet.red
     return <div className={a} />;
   }
-}`, false, { isCSSModule: true })).toBe(`import { createElement, Component } from 'rax';
+}`, false, { enableCSSModule: true })).toBe(`import { createElement, Component } from 'rax';
 import appScssStyleSheet from "./app.scss";
 import styleSheet from './app.module.scss';
 var _styleSheet = appScssStyleSheet;
@@ -539,7 +539,7 @@ class App extends Component {
     const b = a;
     return <div className={{ ...b }} />;
   }
-}`, false, { isCSSModule: true })).toBe(`import { createElement, Component } from 'rax';
+}`, false, { enableCSSModule: true })).toBe(`import { createElement, Component } from 'rax';
 import appScssStyleSheet from "./app.scss";
 import styleSheet from './app.module.scss';
 var _styleSheet = appScssStyleSheet;

--- a/packages/babel-plugin-transform-react-jsx-to-rn-stylesheet/src/index.ts
+++ b/packages/babel-plugin-transform-react-jsx-to-rn-stylesheet/src/index.ts
@@ -383,7 +383,7 @@ function importDeclaration (astPath, state, t) {
   const ext = path.extname(sourceValue)
   const styleSheetIdentifiers = file.get('styleSheetIdentifiers') || []
   const cssModuleStylesheets = file.get('cssModuleStylesheets') || []
-  const isCSSModule = state.opts?.isCSSModule
+  const enableCSSModule = state.opts?.enableCSSModule
 
   // 是样式文件但不是 css module
   if (isStyle(sourceValue)) {
@@ -394,7 +394,7 @@ function importDeclaration (astPath, state, t) {
       styleSheetName = specifiers[0].local.name
     }
 
-    if (isModuleSource(sourceValue) && isCSSModule) {
+    if (isModuleSource(sourceValue) && enableCSSModule) {
       if (styleSheetName) {
         cssModuleStylesheets.push(styleSheetName)
       }

--- a/packages/babel-plugin-transform-react-jsx-to-rn-stylesheet/src/types.ts
+++ b/packages/babel-plugin-transform-react-jsx-to-rn-stylesheet/src/types.ts
@@ -1,7 +1,7 @@
 import { PluginPass } from 'babel__core'
 
 export interface PluginOptions {
-  isCSSModule?: boolean
+  enableCSSModule?: boolean
   /* 是否开启多类名转换 */
   enableMultipleClassName?: boolean
 }

--- a/packages/babel-preset-taro/package.json
+++ b/packages/babel-preset-taro/package.json
@@ -40,6 +40,7 @@
     "@vue/babel-preset-jsx": "^1.2.4",
     "babel-plugin-dynamic-import-node": "^2.3.3",
     "babel-plugin-global-define": "^1.0.3",
+    "babel-plugin-jsx-attributes-array-to-object": "^0.3.0",
     "babel-plugin-transform-imports-api": "^1.0.0",
     "babel-plugin-transform-react-jsx-to-rn-stylesheet": "3.3.3",
     "babel-plugin-transform-taroapi": "3.3.3",

--- a/packages/babel-preset-taro/rn/index.js
+++ b/packages/babel-preset-taro/rn/index.js
@@ -116,7 +116,7 @@ module.exports = (_, options = {}) => {
   const defineConstants = getDefineConstants()
   const presets = []
   const plugins = []
-  const { enableMultipleClassName = false } = getRNConfig()
+  const { enableMultipleClassName = false, enableMergeStyle = false } = getRNConfig()
 
   presets.push(reactNativeBabelPreset(_, options))
   plugins.push(
@@ -124,7 +124,12 @@ module.exports = (_, options = {}) => {
     [require('@babel/plugin-transform-react-jsx'), {
       runtime: options.reactJsxRuntime || 'automatic'
     }],
-    [require('babel-plugin-transform-react-jsx-to-rn-stylesheet'), { isCSSModule: getCSSModule(), enableMultipleClassName }],
+    [require('babel-plugin-transform-react-jsx-to-rn-stylesheet'), { enableCSSModule: getCSSModule(), enableMultipleClassName }]
+  )
+  if (enableMergeStyle) {
+    plugins.push([require('babel-plugin-jsx-attributes-array-to-object'), { attributes: ['style'] }])
+  }
+  plugins.push(
     [require('babel-plugin-transform-imports-api').default, {
       packagesApis: new Map([
         ['@tarojs/taro', new Set(nativeInterfaces)],

--- a/packages/babel-preset-taro/yarn.lock
+++ b/packages/babel-preset-taro/yarn.lock
@@ -1168,6 +1168,11 @@ babel-plugin-global-define@^1.0.3:
   resolved "https://registry.yarnpkg.com/babel-plugin-global-define/-/babel-plugin-global-define-1.0.3.tgz#262c528f0c26bf318f4ccc77cf21df43a0fa6308"
   integrity sha512-M8Sby4wRLuLr+9UB8V31knVRf/rl0xkk51A7um6hUCvVPyOvLtI0u0k1OPiMgE2d7CwmeSa33NzGpaALHPQCPg==
 
+babel-plugin-jsx-attributes-array-to-object@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jsx-attributes-array-to-object/-/babel-plugin-jsx-attributes-array-to-object-0.3.0.tgz#ac7b551a2407750ac899460fe5e38b1dceaebed1"
+  integrity sha512-XvbCsBFo/y4n2DzRtICQ60Kb3FWPIK359YsUkDPjC4UBCF/FMENKYzxarEhAD1GnrAuui5wOUvli89yqF1IzdA==
+
 babel-plugin-polyfill-corejs2@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.2.tgz#e9124785e6fd94f94b618a7954e5693053bf5327"


### PR DESCRIPTION
…r arr to obj&rename isCSSModule

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
1. 增加 rn enableMergeStyle 选项对 jsx 标签 style 属性数组(Array<Object>)转换为对象(Object)


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
