### PR TITLE
feat: 添加百度 onInit 支持

### DIFF
--- a/packages/taro-runtime/src/dsl/instance.ts
+++ b/packages/taro-runtime/src/dsl/instance.ts
@@ -56,6 +56,7 @@ export interface PageLifeCycle extends Show {
   onAddToFavorites?(): void
   eh?(event: MpEvent): void
   onLoad(options: Record<string, unknown>): void
+  onInit?(options: Record<string, unknown>): void
   onUnload(): void
 }
 

--- a/packages/taro/types/taro.config.d.ts
+++ b/packages/taro/types/taro.config.d.ts
@@ -83,6 +83,16 @@ declare namespace Taro {
      * @default false
      */
     enableShareTimeline?: boolean
+    /**
+     * 是否在百度端启用onInit,不支持全局设置
+     * 
+     * 启用此项会将 onLoad 中的taro初始化提前到 onInit,提升页面加载速度
+     * 
+     * 需要百度基础库 > 3.160.12 
+     * 
+     * https://smartprogram.baidu.com/docs/develop/performance/performance_oninit
+    */
+     taroSwanUsePageOnInit?:boolean
   }
 
   interface WindowConfig extends CommonPageConfig {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
react 添加了百度 onInit 生命周期,在百度 onInit 中挂载taro 性能有提升明显
https://smartprogram.baidu.com/docs/develop/performance/performance_oninit/

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [x] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
