### PR TITLE
fix(webpack-runner): 修复h5编译时报错 ENABLE_INNER_HTML is not defined

### DIFF
--- a/packages/taro-webpack-runner/src/config/dev.conf.ts
+++ b/packages/taro-webpack-runner/src/config/dev.conf.ts
@@ -12,7 +12,8 @@ import {
   getFastRefreshPlugin,
   getModule,
   getOutput,
-  processEnvOption
+  processEnvOption,
+  getRuntimeConstants
 } from '../util/chain'
 import { BuildConfig } from '../util/types'
 import getBaseChain from './base.conf'
@@ -105,7 +106,9 @@ export default function (appPath: string, config: Partial<BuildConfig>): any {
       template: path.join(appPath, sourceRoot, 'index.html')
     }])
   }
-  plugin.definePlugin = getDefinePlugin([processEnvOption(env), defineConstants])
+
+  const runtimeConstants = getRuntimeConstants()
+  plugin.definePlugin = getDefinePlugin([processEnvOption(env), defineConstants, runtimeConstants])
 
   if (config.framework === FRAMEWORK_MAP.REACT && config.devServer?.hot !== false) {
     // 默认开启 fast-refresh

--- a/packages/taro-webpack-runner/src/config/prod.conf.ts
+++ b/packages/taro-webpack-runner/src/config/prod.conf.ts
@@ -13,7 +13,8 @@ import {
   getModule,
   getOutput,
   getTerserPlugin,
-  processEnvOption
+  processEnvOption,
+  getRuntimeConstants
 } from '../util/chain'
 import { BuildConfig } from '../util/types'
 import getBaseChain from './base.conf'
@@ -108,7 +109,8 @@ export default function (appPath: string, config: Partial<BuildConfig>): any {
     }])
   }
 
-  plugin.definePlugin = getDefinePlugin([processEnvOption(env), defineConstants])
+  const runtimeConstants = getRuntimeConstants()
+  plugin.definePlugin = getDefinePlugin([processEnvOption(env), defineConstants, runtimeConstants])
 
   const isCssoEnabled = !(csso && csso.enable === false)
 

--- a/packages/taro-webpack-runner/src/util/chain.ts
+++ b/packages/taro-webpack-runner/src/util/chain.ts
@@ -562,3 +562,15 @@ export const getOutput = (appPath: string, [{ outputRoot, publicPath, chunkDirec
 export const getDevtool = ({ enableSourceMap, sourceMapType = 'cheap-module-eval-source-map' }) => {
   return enableSourceMap ? sourceMapType : 'none'
 }
+
+export function getRuntimeConstants () {
+  const constants = {
+    ENABLE_INNER_HTML: true,
+    ENABLE_ADJACENT_HTML: true,
+    ENABLE_TEMPLATE_CONTENT: true,
+    ENABLE_CLONE_NODE: true,
+    ENABLE_SIZE_APIS: false
+  }
+
+  return constants
+}


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
因为web平台的webpack设置未添加相应constants导致编译时runtime中出现undefined


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) #10124
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
