### PR TITLE
fix(h5): 修复 Vue3 在 H5 下 onPullDownRefresh 不触发的问题，fix #10103

### DIFF
--- a/packages/taro-router/src/router.ts
+++ b/packages/taro-router/src/router.ts
@@ -81,9 +81,10 @@ function loadPage (page: PageInstance | null, pageConfig: Route | undefined, sta
     if (pageEl) {
       pageEl.style.display = 'block'
     } else {
-      page.onLoad(qs(stacksIndex))
-      pageEl = document.getElementById(page.path!)
-      pageOnReady(pageEl, page)
+      page.onLoad(qs(stacksIndex), function () {
+        pageEl = document.getElementById(page.path!)
+        pageOnReady(pageEl, page)
+      })
     }
     stacks.push(page)
     page.onShow!()

--- a/packages/taro-runtime/src/dsl/common.ts
+++ b/packages/taro-runtime/src/dsl/common.ts
@@ -129,6 +129,8 @@ export function createPageConfig (component: any, pageName?: string, data?: Reco
           if (!isBrowser) {
             pageElement.ctx = this
             pageElement.performUpdate(true, cb)
+          } else {
+            isFunction(cb) && cb()
           }
         })
       }

--- a/packages/taro-runtime/src/dsl/instance.ts
+++ b/packages/taro-runtime/src/dsl/instance.ts
@@ -2,7 +2,7 @@ import type { Component, ComponentClass } from 'react'
 import VueCtor, { ComponentOptions, VNode } from 'vue'
 import type { Component as Vue3Component } from '@vue/runtime-core'
 import type { CombinedVueInstance } from 'vue/types/vue'
-import type { MpEvent } from '../interface'
+import type { Func, MpEvent } from '../interface'
 import type { TaroElement } from '../dom/element'
 
 export interface Instance<T = Record<string, any>> extends Component<T>, Show, PageInstance {
@@ -55,7 +55,7 @@ export interface PageLifeCycle extends Show {
   onShareTimeline?(): void
   onAddToFavorites?(): void
   eh?(event: MpEvent): void
-  onLoad(options: Record<string, unknown>): void
+  onLoad(options: Record<string, unknown>, cb?: Func): void
   onUnload(): void
 }
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复 Vue3 在 H5 下 `onPullDownRefresh` 不触发的问题，fix #10103

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #10103 
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
