### PR TITLE
fix(h5): 修复 h5 下 createAnimation 创建的样式权重过低的问题，fix #10245

### DIFF
--- a/packages/taro-h5/src/api/createAnimation/index.js
+++ b/packages/taro-h5/src/api/createAnimation/index.js
@@ -295,8 +295,8 @@ class Animation {
     // 生成一条 transition 动画
     this.steps.push(
       [
-        this.rules.join(';'),
-        this.transform.join(' '),
+        this.rules.map(rule => `${rule}!important`).join(';'),
+        `${this.transform.join(' ')}!important`,
         `${TRANSFORM}-origin: ${transformOrigin}`,
         `transition: all ${duration}ms ${timingFunction} ${delay}ms`
       ]


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

### 问题描述

微信小程序下 createAnimation 样式权重是 行内style
h5下 createAnimation 样式权重是 属性选择器
h5下权重过低，无法覆盖初始样式

### 解决方案
在生成的样式后增加 `!important`

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #10245
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
