### PR TITLE
fix(swiper): 修复轮播销毁时的报错问题

### DIFF
--- a/packages/taro-components-react/src/components/swiper/index.tsx
+++ b/packages/taro-components-react/src/components/swiper/index.tsx
@@ -257,7 +257,7 @@ class Swiper extends React.Component<SwiperProps, Record<string, unknown>> {
   }
 
   handleSwiperLoop = debounce(() => {
-    if (this.mySwiper && this.props.circular) {
+    if (this.mySwiper && this.mySwiper.$wrapperEl && this.props.circular) {
       // @ts-ignore
       this.mySwiper.loopDestroy()
       // @ts-ignore


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复轮播销毁时的报错问题
Uncaught TypeError: Cannot read properties of undefined (reading 'children')
    at Swiper.swiper_loopDestroy [as loopDestroy]

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
