### PR TITLE
fix(rn-style-transformer): 修复样式文件不能引入以 npm 包形式引入问题

### DIFF
--- a/packages/taro-rn-style-transformer/__tests__/index.spec.js
+++ b/packages/taro-rn-style-transformer/__tests__/index.spec.js
@@ -181,6 +181,17 @@ describe('style transform', () => {
 }`))
   })
 
+  it('.less tranform node_modules file import', async () => {
+    const css = await run(`
+      @import 'less/test/browser/css/global-vars/simple.css';
+    `, './__tests__/styles/a.less')
+    expect(css).toEqual(getWrapedCSS(`{
+  "test": {
+    "color": "red"
+  }
+}`))
+  })
+
   it('.less import source omit extension', async () => {
     const css = await run(`
       @import './b';

--- a/packages/taro-rn-style-transformer/src/transforms/sass.ts
+++ b/packages/taro-rn-style-transformer/src/transforms/sass.ts
@@ -29,7 +29,7 @@ function makeURL (resource: string, rootDir: string) {
 function makeImportStatement (filePath: string, resource: string, rootDir: string) {
   const url = makeURL(resource, rootDir)
   const relativePath = path.relative(filePath, url).replace(/\\/g, '/') // fix window path error
-  return `@import '${relativePath}'`
+  return `@import './${relativePath}'`
 }
 
 function getGlobalResource (filename: string, config: SassGlobalConfig) {

--- a/packages/taro-rn-style-transformer/src/utils/lessImport.ts
+++ b/packages/taro-rn-style-transformer/src/utils/lessImport.ts
@@ -1,47 +1,46 @@
-import path from 'path'
+import less from 'less'
 import { resolveStyle } from './index'
-import { LogLevelEnum } from '../types'
 
-class Importer {
+class Importer extends less.FileManager {
+  platform: 'android' | 'ios'
+  alias: Record<string, string> = {}
+
   constructor (opt) {
+    super()
     this.platform = opt.platform
     this.alias = opt.alias
   }
 
-  platform: 'android' | 'ios'
+  supports () {
+    return true
+  }
 
-  alias: Record<string, string> = {}
+  supportsSync () {
+    return false
+  }
 
-  process (src: string, options: Less.PreProcessorExtraInfo) {
-    const { fileInfo } = options
-    const { filename, currentDirectory: basedir } = fileInfo
-
-    if (!basedir) {
-      return src
-    }
-
+  async loadFile (
+    filename: string,
+    currentDirectory: string,
+    options: any,
+    environment: any
+  ) {
     const resolveOpts = {
-      basedir,
+      basedir: currentDirectory,
       alias: this.alias,
       platform: this.platform,
-      logLevel: LogLevelEnum.WARNING,
-      defaultExt: path.extname(filename)
+      defaultExt: '.less'
     }
+    const rewriteFilename = resolveStyle(filename, resolveOpts)
 
-    // 解析 @import "a.less" 字符串里面的内容
-    src = src.replace(/@import\s+['"]([^'|"]*)['"]/gi, (_, id) => {
-      const relativePath = path.relative(basedir, resolveStyle(id.trim(), resolveOpts)).replace(/\\/g, '/')
-      return `@import '${relativePath}';`
-    })
-
-    return src
+    return super.loadFile(rewriteFilename, currentDirectory, options, environment)
   }
 }
 
 function makeLessImport (options) {
   return {
     install: (_, pluginManager) => {
-      pluginManager.addPreProcessor(new Importer(options))
+      pluginManager.addFileManager(new Importer(options))
     },
     minVersion: [2, 7, 1]
   }


### PR DESCRIPTION
fix(rn-style-transformer): 修复样式文件不能引入以 npm 包形式引入问题

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
1. 解决样式文件里面引入 npm 包文件失效问题
2. less importer 插件重写，更合理的给 less 文件 import url 变基


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
