### PR TITLE
解决开发环境下小程序包体积过大无法进行预览上传的问题

### DIFF
--- a/versioned_docs/version-3.x/compile-optimized.mdx
+++ b/versioned_docs/version-3.x/compile-optimized.mdx
@@ -39,3 +39,29 @@ config = {
 ## 解决包体积过大无法进行预览的问题
 
 智行小程序团队通过在开发环境下配置压缩指定文件，解决了小程序端包体积过大无法进行预览的问题。详情请阅读文章[《编写插件，将 Taro 编译打包耗时缩短至三分之一》](https://mp.weixin.qq.com/s/Z79QhAlP8tBQn3mXQ11byQ)。
+
+## 通过webpackChain配置解决开发环境下小程序包体积过大无法进行预览上传的问题(不影响devtools的使用)
+```js
+// config/dev.sj
+module.exports = {
+ mini: {
+    webpackChain: (chain, webpack) => {
+      chain.merge({
+        plugin: {
+          install: {
+            plugin: require('terser-webpack-plugin'),
+            args: [{
+              terserOptions: {
+                compress: true, // 默认使用terser压缩
+                // mangle: false,
+                keep_classnames: true, // 不改变class名称
+                keep_fnames: true // 不改变函数名称
+              }
+            }]
+          }
+        }
+      })
+    }
+  }
+}
+```


### PR DESCRIPTION
通过webpackChain配置解决开发环境下小程序包体积过大无法进行预览上传的问题(不影响devtools的使用)

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)



**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ *] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [* ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
