### PR TITLE
fix(2.x): 微信小程序父子组件`render props`编译后事件名称不一致

### DIFF
--- a/packages/taro-transformer-wx/src/render-props.ts
+++ b/packages/taro-transformer-wx/src/render-props.ts
@@ -9,12 +9,15 @@ const renderPropsMap = new Map<string, string>()
 const RENDER_PROPS_EVENTS = '$$renderPropsEvents'
 
 export function injectRenderPropsListener (attrPath: NodePath<t.JSXAttribute>, attrName: string, attrExpr: t.ArrowFunctionExpression, componentName: string) {
-  const randomLetters = createRandomLetters(5)
-  const renderClosureFuncName = attrName + randomLetters
+  let renderClosureFuncName = renderPropsMap.get(componentName + '_' + attrName);
+  if (!renderClosureFuncName) {
+    const randomLetters = createRandomLetters(5);
+    renderClosureFuncName = attrName + randomLetters;
+    renderPropsMap.set(componentName + '_' + attrName, renderClosureFuncName);
+  }
   const jsxDecl = buildConstVariableDeclaration(renderClosureFuncName, attrExpr)
   const block = buildBlockElement([], true)
   const renderPropsArgs = t.memberExpression(t.thisExpression(), t.identifier(renderClosureFuncName))
-  renderPropsMap.set(componentName + '_' + attrName, renderClosureFuncName)
   block.children = [
     t.jSXExpressionContainer(t.callExpression(t.identifier(renderClosureFuncName), [renderPropsArgs]))
   ]


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

### 非常感谢 `taro2.x` 开源框架强大的编译能力，能够让开发者轻松的使用 `react` 语法开发微信小程序。
### 问题描述：
在使用 `render props` 这一特性的时候，发现获取的参数值常常为 `undefined` ，偶尔又能正常获取值。观察编译后的小程序代码发现是父组件所 `listen` 和子组件 `emit` 的事件名称不一致导致，父组件修改了部分代码，热更新后更加明显的观察到这一问题。假如多个父组件使用同一子组件的 `render props` ，事件名称也会出现不一致。
### 如何解决：
在父组件注入监听事件时，先查询 `renderPropsMap` 中以**子组件名称+属性名称**为 `key` 的事件名称是否存在，假如已存在不再重新生成，保证每次编译父子组件事件名称保持一致。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [X] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
