### PR TITLE
chore(release): publish 3.3.15

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.3.14",
+  "version": "3.3.15",
   "npmClient": "yarn",
   "command": {
     "create": {

--- a/packages/babel-plugin-transform-react-jsx-to-rn-stylesheet/package.json
+++ b/packages/babel-plugin-transform-react-jsx-to-rn-stylesheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-transform-react-jsx-to-rn-stylesheet",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Transform stylesheet selector to style in JSX Elements.",
   "license": "MIT",
   "main": "dist/index.js",
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "camelize": "^1.0.0",
-    "taro-css-to-react-native": "3.3.14"
+    "taro-css-to-react-native": "3.3.15"
   },
   "devDependencies": {
     "@types/babel__core": "^7.1.14"

--- a/packages/babel-plugin-transform-taroapi/package.json
+++ b/packages/babel-plugin-transform-taroapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-transform-taroapi",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc"

--- a/packages/babel-preset-taro/package.json
+++ b/packages/babel-preset-taro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-taro",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "> TODO: description",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/babel-preset-taro#readme",
@@ -34,21 +34,21 @@
     "@babel/preset-typescript": "7.12.17",
     "@babel/runtime": "^7.11.2",
     "@babel/runtime-corejs3": "^7.14.8",
-    "@tarojs/helper": "3.3.14",
-    "@tarojs/taro-h5": "3.3.14",
+    "@tarojs/helper": "3.3.15",
+    "@tarojs/taro-h5": "3.3.15",
     "@vue/babel-plugin-jsx": "^1.0.6",
     "@vue/babel-preset-jsx": "^1.2.4",
     "babel-plugin-dynamic-import-node": "^2.3.3",
     "babel-plugin-global-define": "^1.0.3",
     "babel-plugin-jsx-attributes-array-to-object": "^0.3.0",
     "babel-plugin-transform-imports-api": "^1.0.0",
-    "babel-plugin-transform-react-jsx-to-rn-stylesheet": "3.3.14",
-    "babel-plugin-transform-taroapi": "3.3.14",
+    "babel-plugin-transform-react-jsx-to-rn-stylesheet": "3.3.15",
+    "babel-plugin-transform-taroapi": "3.3.15",
     "core-js": "^3.6.5",
     "metro-react-native-babel-preset": "^0.66.2",
     "react-refresh": "0.9.0"
   },
   "devDependencies": {
-    "@tarojs/taro-rn": "3.3.14"
+    "@tarojs/taro-rn": "3.3.15"
   }
 }

--- a/packages/css-to-react-native/package.json
+++ b/packages/css-to-react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "taro-css-to-react-native",
   "description": "Convert CSS text to a React Native stylesheet object",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "main": "dist/index.js",
   "license": "MIT",
   "dependencies": {

--- a/packages/eslint-config-taro/package.json
+++ b/packages/eslint-config-taro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-taro",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Taro specific linting rules for ESLint",
   "main": "index.js",
   "files": [

--- a/packages/eslint-plugin-taro/package.json
+++ b/packages/eslint-plugin-taro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-taro",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Taro specific linting plugin for ESLint",
   "main": "index.js",
   "files": [

--- a/packages/postcss-html-transform/package.json
+++ b/packages/postcss-html-transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-html-transform",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "transform html tag name selector",
   "main": "index.js",
   "author": "drchan",

--- a/packages/postcss-plugin-constparse/package.json
+++ b/packages/postcss-plugin-constparse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-plugin-constparse",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "parse constants defined in config",
   "main": "index.js",
   "author": "Simba",

--- a/packages/postcss-pxtransform/package.json
+++ b/packages/postcss-pxtransform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-pxtransform",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "PostCSS plugin px 转小程序 rpx及h5 rem 单位",
   "keywords": [
     "postcss",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/shared",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "> TODO: description",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/shared#readme",

--- a/packages/stylelint-config-taro-rn/package.json
+++ b/packages/stylelint-config-taro-rn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-taro-rn",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Shareable stylelint config for React Native CSS modules",
   "main": "index.js",
   "files": [

--- a/packages/stylelint-taro-rn/package.json
+++ b/packages/stylelint-taro-rn/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stylelint-taro-rn",
   "description": "A collection of React Native specific rules for stylelint",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/packages/taro-alipay/package.json
+++ b/packages/taro-alipay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-alipay",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "支付宝小程序平台插件",
   "author": "Chen-jj",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-alipay#readme",
@@ -27,8 +27,8 @@
     "url": "https://github.com/NervJS/taro/issues"
   },
   "dependencies": {
-    "@tarojs/components": "3.3.14",
-    "@tarojs/service": "3.3.14",
-    "@tarojs/shared": "3.3.14"
+    "@tarojs/components": "3.3.15",
+    "@tarojs/service": "3.3.15",
+    "@tarojs/shared": "3.3.15"
   }
 }

--- a/packages/taro-api/package.json
+++ b/packages/taro-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/api",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Taro common API",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/api#readme",
@@ -30,6 +30,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "@tarojs/runtime": "3.3.14"
+    "@tarojs/runtime": "3.3.15"
   }
 }

--- a/packages/taro-cli/package.json
+++ b/packages/taro-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/cli",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "cli tool for taro",
   "main": "index.js",
   "scripts": {
@@ -44,17 +44,17 @@
   "license": "MIT",
   "dependencies": {
     "@hapi/joi": "17.1.1",
-    "@tarojs/helper": "3.3.14",
-    "@tarojs/plugin-platform-alipay": "3.3.14",
-    "@tarojs/plugin-platform-jd": "3.3.14",
-    "@tarojs/plugin-platform-qq": "3.3.14",
-    "@tarojs/plugin-platform-swan": "3.3.14",
-    "@tarojs/plugin-platform-tt": "3.3.14",
-    "@tarojs/plugin-platform-weapp": "3.3.14",
-    "@tarojs/service": "3.3.14",
-    "@tarojs/shared": "3.3.14",
-    "@tarojs/taro": "3.3.14",
-    "@tarojs/taroize": "3.3.14",
+    "@tarojs/helper": "3.3.15",
+    "@tarojs/plugin-platform-alipay": "3.3.15",
+    "@tarojs/plugin-platform-jd": "3.3.15",
+    "@tarojs/plugin-platform-qq": "3.3.15",
+    "@tarojs/plugin-platform-swan": "3.3.15",
+    "@tarojs/plugin-platform-tt": "3.3.15",
+    "@tarojs/plugin-platform-weapp": "3.3.15",
+    "@tarojs/service": "3.3.15",
+    "@tarojs/shared": "3.3.15",
+    "@tarojs/taro": "3.3.15",
+    "@tarojs/taroize": "3.3.15",
     "@tarojs/transformer-wx": "^2.0.4",
     "@types/request": "^2.48.1",
     "@typescript-eslint/parser": "^4.15.1",
@@ -79,11 +79,11 @@
     "ejs": "^2.6.1",
     "envinfo": "^6.0.1",
     "eslint": "^6.1.0",
-    "eslint-config-taro": "3.3.14",
+    "eslint-config-taro": "3.3.15",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-react": "^7.4.0",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "eslint-plugin-taro": "3.3.14",
+    "eslint-plugin-taro": "3.3.15",
     "eslint-plugin-vue": "^6.2.2",
     "fbjs": "^1.0.0",
     "fs-extra": "^5.0.0",
@@ -105,7 +105,7 @@
     "postcss-modules-resolve-imports": "^1.3.0",
     "postcss-modules-scope": "^1.1.0",
     "postcss-modules-values": "^1.3.0",
-    "postcss-pxtransform": "3.3.14",
+    "postcss-pxtransform": "3.3.15",
     "postcss-reporter": "^6.0.1",
     "postcss-taro-unit-transform": "1.2.15",
     "postcss-url": "^7.3.2",
@@ -126,7 +126,7 @@
     "xxhashjs": "^0.2.2"
   },
   "devDependencies": {
-    "@tarojs/mini-runner": "3.3.14",
-    "@tarojs/webpack-runner": "3.3.14"
+    "@tarojs/mini-runner": "3.3.15",
+    "@tarojs/webpack-runner": "3.3.15"
   }
 }

--- a/packages/taro-components-react/package.json
+++ b/packages/taro-components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/components-react",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "",
   "main:h5": "src/index.js",
   "main": "dist/index.js",
@@ -24,8 +24,8 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.13.10",
-    "@tarojs/taro": "3.3.14",
-    "@tarojs/taro-h5": "3.3.14",
+    "@tarojs/taro": "3.3.15",
+    "@tarojs/taro-h5": "3.3.15",
     "better-scroll": "^1.14.1",
     "classnames": "^2.2.5",
     "intersection-observer": "^0.7.0",

--- a/packages/taro-components-rn/package.json
+++ b/packages/taro-components-rn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/components-rn",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "多端解决方案基础组件（RN）",
   "main": "./dist/index.js",
   "scripts": {
@@ -42,7 +42,7 @@
     "unimodules-permissions-interface": "~5.3.0"
   },
   "devDependencies": {
-    "@tarojs/components": "3.3.14",
+    "@tarojs/components": "3.3.15",
     "@types/react-native": "0.66.5",
     "@types/sinon": "^9.0.8",
     "cpy-cli": "^3.1.1",

--- a/packages/taro-components/package.json
+++ b/packages/taro-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/components",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "",
   "main:h5": "src/index.js",
   "main": "dist/index.js",
@@ -38,7 +38,7 @@
   "license": "MIT",
   "dependencies": {
     "@stencil/core": "2.9.0",
-    "@tarojs/taro": "3.3.14",
+    "@tarojs/taro": "3.3.15",
     "better-scroll": "^1.14.1",
     "classnames": "^2.2.5",
     "intersection-observer": "^0.7.0",

--- a/packages/taro-extend/package.json
+++ b/packages/taro-extend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/extend",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Taro extend functionality",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-extend#readme",

--- a/packages/taro-h5/package.json
+++ b/packages/taro-h5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taro-h5",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Taro h5 framework",
   "main:h5": "src/index.js",
   "main": "dist/index.cjs.js",
@@ -33,9 +33,9 @@
   "author": "O2Team",
   "license": "MIT",
   "dependencies": {
-    "@tarojs/api": "3.3.14",
-    "@tarojs/router": "3.3.14",
-    "@tarojs/runtime": "3.3.14",
+    "@tarojs/api": "3.3.15",
+    "@tarojs/router": "3.3.15",
+    "@tarojs/runtime": "3.3.15",
     "base64-js": "^1.3.0",
     "jsonp-retry": "^1.0.3",
     "mobile-detect": "^1.4.2",

--- a/packages/taro-helper/package.json
+++ b/packages/taro-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/helper",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Taro Helper",
   "main": "index.js",
   "types": "types/index.d.ts",
@@ -41,7 +41,7 @@
     "@babel/preset-typescript": "7.12.17",
     "@babel/register": "7.14.5",
     "@babel/runtime": "^7.9.2",
-    "@tarojs/taro": "3.3.14",
+    "@tarojs/taro": "3.3.15",
     "chalk": "3.0.0",
     "chokidar": "3.3.1",
     "cross-spawn": "7.0.3",

--- a/packages/taro-jd/package.json
+++ b/packages/taro-jd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-jd",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "京东小程序平台插件",
   "author": "Chen-jj",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-jd#readme",
@@ -27,7 +27,7 @@
     "url": "https://github.com/NervJS/taro/issues"
   },
   "dependencies": {
-    "@tarojs/service": "3.3.14",
-    "@tarojs/shared": "3.3.14"
+    "@tarojs/service": "3.3.15",
+    "@tarojs/shared": "3.3.15"
   }
 }

--- a/packages/taro-loader/package.json
+++ b/packages/taro-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taro-loader",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "> TODO: description",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-loader#readme",
@@ -26,7 +26,7 @@
     "url": "https://github.com/NervJS/taro/issues"
   },
   "dependencies": {
-    "@tarojs/helper": "3.3.14",
+    "@tarojs/helper": "3.3.15",
     "acorn": "^8.0.4",
     "acorn-walk": "^8.0.0",
     "loader-utils": "^1.2.3"
@@ -35,6 +35,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@tarojs/taro": "3.3.14"
+    "@tarojs/taro": "3.3.15"
   }
 }

--- a/packages/taro-mini-runner/package.json
+++ b/packages/taro-mini-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/mini-runner",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Mini app runner for taro",
   "main": "index.js",
   "scripts": {
@@ -36,18 +36,18 @@
   "homepage": "https://github.com/NervJS/taro#readme",
   "dependencies": {
     "@babel/core": "^7.11.1",
-    "@tarojs/helper": "3.3.14",
-    "@tarojs/plugin-platform-alipay": "3.3.14",
-    "@tarojs/plugin-platform-jd": "3.3.14",
-    "@tarojs/plugin-platform-qq": "3.3.14",
-    "@tarojs/plugin-platform-swan": "3.3.14",
-    "@tarojs/plugin-platform-tt": "3.3.14",
-    "@tarojs/plugin-platform-weapp": "3.3.14",
-    "@tarojs/runner-utils": "3.3.14",
-    "@tarojs/runtime": "3.3.14",
-    "@tarojs/shared": "3.3.14",
-    "@tarojs/taro": "3.3.14",
-    "@tarojs/taro-loader": "3.3.14",
+    "@tarojs/helper": "3.3.15",
+    "@tarojs/plugin-platform-alipay": "3.3.15",
+    "@tarojs/plugin-platform-jd": "3.3.15",
+    "@tarojs/plugin-platform-qq": "3.3.15",
+    "@tarojs/plugin-platform-swan": "3.3.15",
+    "@tarojs/plugin-platform-tt": "3.3.15",
+    "@tarojs/plugin-platform-weapp": "3.3.15",
+    "@tarojs/runner-utils": "3.3.15",
+    "@tarojs/runtime": "3.3.15",
+    "@tarojs/shared": "3.3.15",
+    "@tarojs/taro": "3.3.15",
+    "@tarojs/taro-loader": "3.3.15",
     "babel-loader": "8.2.1",
     "copy-webpack-plugin": "5.1.2",
     "css": "2.2.4",
@@ -68,10 +68,10 @@
     "mkdirp": "^1.0.4",
     "ora": "^3.4.0",
     "postcss": "8.3.5",
-    "postcss-html-transform": "3.3.14",
+    "postcss-html-transform": "3.3.15",
     "postcss-import": "12.0.1",
     "postcss-loader": "4.3.0",
-    "postcss-pxtransform": "3.3.14",
+    "postcss-pxtransform": "3.3.15",
     "postcss-url": "8.0.0",
     "regenerator-runtime": "0.11",
     "request": "^2.88.0",
@@ -94,8 +94,8 @@
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "7.10.4",
     "@babel/preset-env": "^7.11.0",
-    "@tarojs/components": "3.3.14",
-    "@tarojs/react": "3.3.14",
-    "babel-preset-taro": "3.3.14"
+    "@tarojs/components": "3.3.15",
+    "@tarojs/react": "3.3.15",
+    "babel-preset-taro": "3.3.15"
   }
 }

--- a/packages/taro-plugin-html/package.json
+++ b/packages/taro-plugin-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-html",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Taro 小程序端支持使用 HTML 标签的插件",
   "main": "index.js",
   "scripts": {
@@ -29,10 +29,10 @@
   },
   "homepage": "https://github.com/NervJS/taro#readme",
   "devDependencies": {
-    "@tarojs/runtime": "3.3.14",
-    "@tarojs/service": "3.3.14"
+    "@tarojs/runtime": "3.3.15",
+    "@tarojs/service": "3.3.15"
   },
   "dependencies": {
-    "@tarojs/shared": "3.3.14"
+    "@tarojs/shared": "3.3.15"
   }
 }

--- a/packages/taro-plugin-mini-ci/package.json
+++ b/packages/taro-plugin-mini-ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-mini-ci",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Taro 小程序端构建后支持CI（持续集成）的插件",
   "keywords": [
     "Taro",
@@ -37,6 +37,6 @@
     "tt-ide-cli": "^0.0.24"
   },
   "devDependencies": {
-    "@tarojs/service": "3.3.14"
+    "@tarojs/service": "3.3.15"
   }
 }

--- a/packages/taro-plugin-react-devtools/package.json
+++ b/packages/taro-plugin-react-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-react-devtools",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Taro 小程序端支持使用 React DevTools 的插件",
   "main": "index.js",
   "scripts": {
@@ -28,12 +28,12 @@
   },
   "homepage": "https://github.com/NervJS/taro#readme",
   "devDependencies": {
-    "@tarojs/service": "3.3.14"
+    "@tarojs/service": "3.3.15"
   },
   "dependencies": {
-    "@tarojs/helper": "3.3.14",
-    "@tarojs/shared": "3.3.14",
-    "@tarojs/taro": "3.3.14",
+    "@tarojs/helper": "3.3.15",
+    "@tarojs/shared": "3.3.15",
+    "@tarojs/taro": "3.3.15",
     "cross-spawn": "^7.0.3",
     "detect-port": "^1.3.0",
     "react-devtools": "4.14.0"

--- a/packages/taro-plugin-vue-devtools/package.json
+++ b/packages/taro-plugin-vue-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-vue-devtools",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Taro 小程序端支持使用 Vue DevTools 的插件",
   "main": "index.js",
   "scripts": {
@@ -28,12 +28,12 @@
   },
   "homepage": "https://github.com/NervJS/taro#readme",
   "devDependencies": {
-    "@tarojs/service": "3.3.14"
+    "@tarojs/service": "3.3.15"
   },
   "dependencies": {
-    "@tarojs/helper": "3.3.14",
-    "@tarojs/shared": "3.3.14",
-    "@tarojs/taro": "3.3.14",
+    "@tarojs/helper": "3.3.15",
+    "@tarojs/shared": "3.3.15",
+    "@tarojs/taro": "3.3.15",
     "@vue/devtools": "6.0.0-beta.15",
     "cross-spawn": "^7.0.3",
     "detect-port": "^1.3.0"

--- a/packages/taro-qq/package.json
+++ b/packages/taro-qq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-qq",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "QQ 小程序平台插件",
   "author": "Chen-jj",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-qq#readme",
@@ -26,8 +26,8 @@
     "url": "https://github.com/NervJS/taro/issues"
   },
   "dependencies": {
-    "@tarojs/plugin-platform-weapp": "3.3.14",
-    "@tarojs/service": "3.3.14",
-    "@tarojs/shared": "3.3.14"
+    "@tarojs/plugin-platform-weapp": "3.3.15",
+    "@tarojs/service": "3.3.15",
+    "@tarojs/shared": "3.3.15"
   }
 }

--- a/packages/taro-react/package.json
+++ b/packages/taro-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/react",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "like react-dom, but for mini apps.",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-react#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/NervJS/taro/issues"
   },
   "dependencies": {
-    "@tarojs/runtime": "3.3.14",
-    "@tarojs/shared": "3.3.14",
+    "@tarojs/runtime": "3.3.15",
+    "@tarojs/shared": "3.3.15",
     "react-reconciler": "0.26.1",
     "scheduler": "^0.20.1"
   },

--- a/packages/taro-rn-runner/package.json
+++ b/packages/taro-rn-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/rn-runner",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "ReactNative build tool for taro",
   "main": "index.js",
   "repository": {
@@ -32,10 +32,10 @@
   "dependencies": {
     "@react-native-community/cli": "^5.0.1",
     "@react-native-community/cli-server-api": "^5.0.1",
-    "@tarojs/helper": "3.3.14",
-    "@tarojs/rn-style-transformer": "3.3.14",
-    "@tarojs/rn-supporter": "3.3.14",
-    "@tarojs/rn-transformer": "3.3.14",
+    "@tarojs/helper": "3.3.15",
+    "@tarojs/rn-style-transformer": "3.3.15",
+    "@tarojs/rn-supporter": "3.3.15",
+    "@tarojs/rn-transformer": "3.3.15",
     "fs-extra": "^9.0.1",
     "lodash": "^4.17.4",
     "metro": "^0.66.2",

--- a/packages/taro-rn-style-transformer/package.json
+++ b/packages/taro-rn-style-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/rn-style-transformer",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "提供Taro RN 统一处理样式文件能力",
   "main": "dist/index.js",
   "scripts": {
@@ -23,20 +23,20 @@
     "npm": ">=6.0.0"
   },
   "dependencies": {
-    "@tarojs/helper": "3.3.14",
+    "@tarojs/helper": "3.3.15",
     "fbjs": "^2.0.0",
     "less": "^3.12.2",
     "postcss": "^7.0.35",
     "postcss-import": "^12.0.1",
-    "postcss-pxtransform": "3.3.14",
+    "postcss-pxtransform": "3.3.15",
     "postcss-reporter": "^6.0.1",
     "prop-types": "^15.7.2",
     "sass": "^1.34.1",
     "stylelint": "^13.8.0",
-    "stylelint-config-taro-rn": "3.3.14",
-    "stylelint-taro-rn": "3.3.14",
+    "stylelint-config-taro-rn": "3.3.15",
+    "stylelint-taro-rn": "3.3.15",
     "stylus": "^0.54.8",
-    "taro-css-to-react-native": "3.3.14"
+    "taro-css-to-react-native": "3.3.15"
   },
   "devDependencies": {
     "@types/less": "^3.0.2",

--- a/packages/taro-rn-supporter/package.json
+++ b/packages/taro-rn-supporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/rn-supporter",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Taro rn supporter",
   "main": "dist/index.js",
   "scripts": {
@@ -31,8 +31,8 @@
     "npm": ">=6.0.0"
   },
   "dependencies": {
-    "@tarojs/helper": "3.3.14",
-    "@tarojs/rn-style-transformer": "3.3.14",
+    "@tarojs/helper": "3.3.15",
+    "@tarojs/rn-style-transformer": "3.3.15",
     "lodash": "^4.17.20",
     "metro": "^0.66.2",
     "metro-react-native-babel-transformer": "^0.66.2",

--- a/packages/taro-rn-transformer/package.json
+++ b/packages/taro-rn-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/rn-transformer",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Taro RN 入口文件处理",
   "main": "dist/index.js",
   "types": "./src/types/index.d.ts",
@@ -32,7 +32,7 @@
     "npm": ">=6.0.0"
   },
   "devDependencies": {
-    "@tarojs/helper": "3.3.14",
+    "@tarojs/helper": "3.3.15",
     "lodash": "^4.17.20"
   }
 }

--- a/packages/taro-rn/package.json
+++ b/packages/taro-rn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taro-rn",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Taro RN framework",
   "main": "dist/index.js",
   "typings": "types/index.d.ts",
@@ -37,7 +37,7 @@
     "@react-native-community/clipboard": "~1.5.1",
     "@react-native-community/geolocation": "~2.0.2",
     "@react-native-community/netinfo": "~7.1.2",
-    "@tarojs/runtime-rn": "3.3.14",
+    "@tarojs/runtime-rn": "3.3.15",
     "babel-preset-expo": "~8.5.1",
     "base64-js": "^1.3.0",
     "expo-av": "~9.2.3",
@@ -61,7 +61,7 @@
     "react-native-unimodules": "~0.14.10"
   },
   "devDependencies": {
-    "@tarojs/taro": "3.3.14",
+    "@tarojs/taro": "3.3.15",
     "@types/react-native": "0.66.5",
     "babel-plugin-jest-hoist": "^26.6.2",
     "cpy-cli": "^3.1.1",

--- a/packages/taro-router-rn/package.json
+++ b/packages/taro-router-rn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/router-rn",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Taro-router-rn",
   "main": "dist/index.js",
   "typings": "src/index.ts",

--- a/packages/taro-router/package.json
+++ b/packages/taro-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/router",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Taro-router",
   "main:h5": "dist/router.esm.js",
   "main": "dist/index.js",
@@ -27,7 +27,7 @@
   "author": "O2Team",
   "license": "MIT",
   "dependencies": {
-    "@tarojs/runtime": "3.3.14",
+    "@tarojs/runtime": "3.3.15",
     "history": "^5.1.0",
     "query-string": "^6.13.8",
     "universal-router": "^8.3.0",

--- a/packages/taro-runner-utils/package.json
+++ b/packages/taro-runner-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/runner-utils",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Taro runner utilities.",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -22,7 +22,7 @@
   "author": "garfield550",
   "license": "MIT",
   "dependencies": {
-    "@tarojs/helper": "3.3.14",
+    "@tarojs/helper": "3.3.15",
     "scss-bundle": "^3.0.2"
   }
 }

--- a/packages/taro-runtime-rn/package.json
+++ b/packages/taro-runtime-rn/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarojs/runtime-rn",
-    "version": "3.3.14",
+    "version": "3.3.15",
     "description": "taro-runtime-rn",
     "main": "dist/index.js",
     "types": "./src/index.ts",
@@ -28,8 +28,8 @@
         "url": "https://github.com/NervJS/taro/issues"
     },
     "dependencies": {
-        "@tarojs/components-rn": "3.3.14",
-        "@tarojs/router-rn": "3.3.14"
+        "@tarojs/components-rn": "3.3.15",
+        "@tarojs/router-rn": "3.3.15"
     },
     "resolutions": {
         "@types/react": "17.0.11"

--- a/packages/taro-runtime/package.json
+++ b/packages/taro-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/runtime",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "taro runtime for mini apps.",
   "main": "dist/runtime.esm.js",
   "module": "dist/runtime.esm.js",
@@ -24,12 +24,12 @@
     "access": "public"
   },
   "dependencies": {
-    "@tarojs/shared": "3.3.14",
+    "@tarojs/shared": "3.3.15",
     "inversify": "5.1.1",
     "lodash-es": "4.17.15",
     "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {
-    "@tarojs/taro": "3.3.14"
+    "@tarojs/taro": "3.3.15"
   }
 }

--- a/packages/taro-service/package.json
+++ b/packages/taro-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/service",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Taro Service",
   "main": "index.js",
   "types": "types/index.d.ts",
@@ -34,9 +34,9 @@
   "homepage": "https://github.com/NervJS/taro#readme",
   "dependencies": {
     "@hapi/joi": "17.1.1",
-    "@tarojs/helper": "3.3.14",
-    "@tarojs/shared": "3.3.14",
-    "@tarojs/taro": "3.3.14",
+    "@tarojs/helper": "3.3.15",
+    "@tarojs/shared": "3.3.15",
+    "@tarojs/taro": "3.3.15",
     "fs-extra": "8.1.0",
     "lodash": "4.17.21",
     "resolve": "1.15.1",

--- a/packages/taro-swan/package.json
+++ b/packages/taro-swan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-swan",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "百度小程序平台插件",
   "author": "Chen-jj",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-swan#readme",
@@ -27,8 +27,8 @@
     "url": "https://github.com/NervJS/taro/issues"
   },
   "dependencies": {
-    "@tarojs/components": "3.3.14",
-    "@tarojs/service": "3.3.14",
-    "@tarojs/shared": "3.3.14"
+    "@tarojs/components": "3.3.15",
+    "@tarojs/service": "3.3.15",
+    "@tarojs/shared": "3.3.15"
   }
 }

--- a/packages/taro-tt/package.json
+++ b/packages/taro-tt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-tt",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "头条小程序平台插件",
   "author": "Chen-jj",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-tt#readme",
@@ -27,7 +27,7 @@
     "url": "https://github.com/NervJS/taro/issues"
   },
   "dependencies": {
-    "@tarojs/service": "3.3.14",
-    "@tarojs/shared": "3.3.14"
+    "@tarojs/service": "3.3.15",
+    "@tarojs/shared": "3.3.15"
   }
 }

--- a/packages/taro-weapp/package.json
+++ b/packages/taro-weapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-weapp",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "微信小程序平台插件",
   "author": "drchan",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-weapp#readme",
@@ -27,8 +27,8 @@
     "url": "https://github.com/NervJS/taro/issues"
   },
   "dependencies": {
-    "@tarojs/components": "3.3.14",
-    "@tarojs/service": "3.3.14",
-    "@tarojs/shared": "3.3.14"
+    "@tarojs/components": "3.3.15",
+    "@tarojs/service": "3.3.15",
+    "@tarojs/shared": "3.3.15"
   }
 }

--- a/packages/taro-webpack-runner/package.json
+++ b/packages/taro-webpack-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/webpack-runner",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "webpack runner for taro",
   "main": "index.js",
   "scripts": {
@@ -32,11 +32,11 @@
   "dependencies": {
     "@babel/core": "^7.11.1",
     "@pmmmwh/react-refresh-webpack-plugin": "0.4.3",
-    "@tarojs/helper": "3.3.14",
-    "@tarojs/runner-utils": "3.3.14",
-    "@tarojs/runtime": "3.3.14",
-    "@tarojs/shared": "3.3.14",
-    "@tarojs/taro-loader": "3.3.14",
+    "@tarojs/helper": "3.3.15",
+    "@tarojs/runner-utils": "3.3.15",
+    "@tarojs/runtime": "3.3.15",
+    "@tarojs/shared": "3.3.15",
+    "@tarojs/taro-loader": "3.3.15",
     "autoprefixer": "9.7.4",
     "babel-loader": "8.2.1",
     "copy-webpack-plugin": "5.1.1",
@@ -55,8 +55,8 @@
     "ora": "4.0.3",
     "postcss": "8.3.5",
     "postcss-loader": "4.3.0",
-    "postcss-plugin-constparse": "3.3.14",
-    "postcss-pxtransform": "3.3.14",
+    "postcss-plugin-constparse": "3.3.15",
+    "postcss-pxtransform": "3.3.15",
     "react-refresh": "0.9.0",
     "resolve": "1.15.1",
     "resolve-url-loader": "3.1.3",
@@ -73,9 +73,9 @@
     "webpack-format-messages": "^2.0.5"
   },
   "devDependencies": {
-    "@tarojs/components": "3.3.14",
-    "@tarojs/taro": "3.3.14",
-    "babel-plugin-transform-taroapi": "3.3.14",
-    "babel-preset-taro": "3.3.14"
+    "@tarojs/components": "3.3.15",
+    "@tarojs/taro": "3.3.15",
+    "babel-plugin-transform-taroapi": "3.3.15",
+    "babel-preset-taro": "3.3.15"
   }
 }

--- a/packages/taro-with-weapp/package.json
+++ b/packages/taro-with-weapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/with-weapp",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "taroize 之后的运行时",
   "main": "index.js",
   "scripts": {
@@ -23,8 +23,8 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@tarojs/runtime": "3.3.14",
-    "@tarojs/taro": "3.3.14",
+    "@tarojs/runtime": "3.3.15",
+    "@tarojs/taro": "3.3.15",
     "lodash": "^4.17.11"
   }
 }

--- a/packages/taro/package.json
+++ b/packages/taro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taro",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Taro framework",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro#readme",
   "main": "index.js",
@@ -26,8 +26,8 @@
   "author": "O2Team",
   "license": "MIT",
   "dependencies": {
-    "@tarojs/api": "3.3.14",
-    "@tarojs/runtime": "3.3.14",
-    "@tarojs/taro-h5": "3.3.14"
+    "@tarojs/api": "3.3.15",
+    "@tarojs/runtime": "3.3.15",
+    "@tarojs/taro-h5": "3.3.15"
   }
 }

--- a/packages/taroize/package.json
+++ b/packages/taroize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taroize",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "转换原生微信小程序代码为 Taro 代码",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## 特性

### H5

- 支持 `CoverView`、`CoverImage` 组件

### RN

- 优化依赖，包括升级 `react-native-netinfo` ，删除 `expo-location` 依赖等，#10690

## 修复

### 小程序

- 增加对 `getLocalIPAddress` API 的支持，#10631 
- 修复 Vue3 `Input` 组件设置自动聚焦失败的问题，#10579 
- 修复使用 `recoil` 报错的问题，fix #10119 

### H5

- 支持使用**相对路径**地址跳转到新页面，by @baosiqing 
- 优化 `Input` 组件设置 `focus` 的时机，by @baosiqing 
- 修复浏览器多级后退造成的错误，#10616 
- 修复快速切换 TabBar 时，页面展示错误的问题，#10426
- 修复 `showTabBarRedDot`、`showTabBarBadge`、`setTabBarItem`、`setTabBarStyle` 等 `TabBar` 相关的 API，#9397 #8580 #8175
- 修复 Vue2 的组件使用 `nativeProps` 失效的问题，#10689 
- 修复 `Textarea` 组件 `onLineChange`、`autoHeight` 属性无效的问题，#7997 #8003 

### RN

- 修复 Windows 通过模板初始化 RN 报错的问题，#10485 
- 把 `networkType` 返回内容与小程序对齐

### 其它

- 增加对 **nodejs 16 和 17** 的支持

## Typings

- 优化类型实体写法，#10652
- 补充 `offMemoryWarning` API 的类型