### PR TITLE
fixed(selector filter): fix postcss * test rule

### DIFF
--- a/packages/postcss-html-transform/src/index.ts
+++ b/packages/postcss-html-transform/src/index.ts
@@ -9,7 +9,7 @@ const reg = new RegExp(`(^| |\\+|,|~|>|\\n)(${tagsCombine})\\b(?=$| |\\.|\\+|,|~
 function plugin (_opts) {
   return function (root) {
     root.walkRules(function (rule) {
-      if (/(^| )\*(?![=/*])/.test(rule)) {
+      if (/(^| )\*(?![=/*])/.test(rule.selector)) {
         rule.remove()
         return
       }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

`postcss-html-transform`插件过滤通配符:

比如在样式中书写:
```less
.test {
    --size: 9px;
   font-size: calc(var(--size) * 2);
}
```
会被命中并移除。

看起来这个插件只是想移除通配符相关的。所以改为直接匹配选择器感。

简单测试了一下。没有什么问题。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
