### PR TITLE
chore: add error icon type for toast

### DIFF
--- a/packages/taro/types/api/ui/interaction.d.ts
+++ b/packages/taro/types/api/ui/interaction.d.ts
@@ -15,9 +15,10 @@ declare module '../../index' {
        *
        * 可选值：
        * - 'success': 显示成功图标，此时 title 文本最多显示 7 个汉字长度;
+       * - 'error': 显示失败图标，此时 title 文本最多显示 7 个汉字长度;
        * - 'loading': 显示加载图标，此时 title 文本最多显示 7 个汉字长度;
        * - 'none': 不显示图标，此时 title 文本最多可显示两行 */
-      icon?: 'success' | 'loading' | 'none'
+      icon?: 'success' | 'error' | 'loading' | 'none'
       /** 自定义图标的本地路径，image 的优先级高于 icon */
       image?: string
       /** 是否显示透明蒙层，防止触摸穿透 */


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

微信小程序的 Toast 新增了 [error 类型](https://developers.weixin.qq.com/miniprogram/dev/api/ui/interaction/wx.showToast.html)，可以在类型定义中加上此类型，以防在编写代码时出现 ts error。

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
