### PR TITLE
feat(rn): add auto width & height for RichText

### DIFF
--- a/packages/taro-components-rn/__tests__/__snapshots__/richText.spec.tsx.snap
+++ b/packages/taro-components-rn/__tests__/__snapshots__/richText.spec.tsx.snap
@@ -1,7 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RichText RichText render 1`] = `
-<View>
+<View
+  style={
+    Object {
+      "height": 0,
+      "width": "100%",
+    }
+  }
+>
   <View
     style={
       Array [
@@ -20,12 +27,12 @@ exports[`RichText RichText render 1`] = `
             document.documentElement.style.margin = 0;
             document.body.style.padding = 0;
             document.body.style.margin = 0;
-            true;
+            window.ReactNativeWebView.postMessage(document.body.scrollHeight);
           "
       injectedJavaScriptBeforeContentLoadedForMainFrameOnly={true}
       injectedJavaScriptForMainFrameOnly={true}
       javaScriptEnabled={true}
-      messagingEnabled={false}
+      messagingEnabled={true}
       onContentProcessDidTerminate={[Function]}
       onHttpError={[Function]}
       onLoadingError={[Function]}
@@ -37,7 +44,7 @@ exports[`RichText RichText render 1`] = `
       scalesPageToFit={false}
       source={
         Object {
-          "html": "<div class=\\"div_class\\" style=\\"line-height:60px;color:white;font-size:60px\\"><span>Hello World!</span></div>",
+          "html": "<meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1, maximum-scale=1\\"/><div class=\\"div_class\\" style=\\"line-height:60px;color:white;font-size:60px\\"><span>Hello World!</span></div>",
         }
       }
       style={

--- a/packages/taro-components-rn/src/components/RichText/PropsType.tsx
+++ b/packages/taro-components-rn/src/components/RichText/PropsType.tsx
@@ -12,3 +12,7 @@ export interface RichTextProps {
   style?: StyleProp<ViewStyle>;
   nodes: Node[] | string;
 }
+
+export interface RichTextState {
+  webViewHeight?: number,
+}


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

RichText 组件默认为自适应宽高
并默认添加viewport，与小程序和h5一致
```html
<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>
```

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #10768
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
