### PR TITLE
fix: 修复事件调用 preventDefault 后 defaultPrevented 值不存在的问题

### DIFF
--- a/packages/taro-alipay/src/create-component.js
+++ b/packages/taro-alipay/src/create-component.js
@@ -64,7 +64,12 @@ function processEvent (eventHandlerName, obj) {
       // 将支付宝的 event 事件对象的字段，对齐微信小程序的
       event = processEventTarget(event)
     }
-    event.preventDefault = function () {}
+    event.preventDefault = function () {
+      Object.defineProperty(event, 'defaultPrevented', {
+        value: true,
+        writable: false
+      })
+    }
     event.stopPropagation = function () {}
     event.currentTarget = event.currentTarget || event.target || {}
     if (event.target) {

--- a/packages/taro-jd/src/create-component.js
+++ b/packages/taro-jd/src/create-component.js
@@ -115,7 +115,12 @@ function processEvent (eventHandlerName, obj) {
 
   obj[eventHandlerName] = function (event) {
     if (event) {
-      event.preventDefault = function () {}
+      event.preventDefault = function () {
+        Object.defineProperty(event, 'defaultPrevented', {
+          value: true,
+          writable: false
+        })
+      }
       event.stopPropagation = function () {}
       event.currentTarget = event.currentTarget || event.target || {}
       if (event.target) {

--- a/packages/taro-qq/src/create-component.js
+++ b/packages/taro-qq/src/create-component.js
@@ -99,7 +99,12 @@ function processEvent (eventHandlerName, obj) {
 
   obj[eventHandlerName] = function (event) {
     if (event) {
-      event.preventDefault = function () {}
+      event.preventDefault = function () {
+        Object.defineProperty(event, 'defaultPrevented', {
+          value: true,
+          writable: false
+        })
+      }
       event.stopPropagation = function () {}
       event.currentTarget = event.currentTarget || event.target || {}
       if (event.target) {

--- a/packages/taro-quickapp/src/create-component.js
+++ b/packages/taro-quickapp/src/create-component.js
@@ -114,7 +114,12 @@ function processEvent (eventHandlerName, obj) {
       }
       if (!event.preventDefault) {
         Object.defineProperty(event, 'preventDefault', {
-          value: () => {}
+          value: () => {
+            Object.defineProperty(event, 'defaultPrevented', {
+              value: true,
+              writable: false
+            })
+          }
         })
       }
     }

--- a/packages/taro-swan/src/create-component.js
+++ b/packages/taro-swan/src/create-component.js
@@ -66,7 +66,12 @@ function processEvent (eventHandlerName, obj) {
 
   obj[eventHandlerName] = function (event) {
     if (event) {
-      event.preventDefault = function () {}
+      event.preventDefault = function () {
+        Object.defineProperty(event, 'defaultPrevented', {
+          value: true,
+          writable: false
+        })
+      }
       event.stopPropagation = function () {}
       event.currentTarget = event.currentTarget || event.target || {}
       if (event.target) {

--- a/packages/taro-tt/src/create-component.js
+++ b/packages/taro-tt/src/create-component.js
@@ -76,7 +76,12 @@ function processEvent (eventHandlerName, obj) {
 
   obj[eventHandlerName] = function (event) {
     if (event) {
-      event.preventDefault = function () {}
+      event.preventDefault = function () {
+        Object.defineProperty(event, 'defaultPrevented', {
+          value: true,
+          writable: false
+        })
+      }
       event.stopPropagation = function () {}
       event.currentTarget = event.currentTarget || event.target || {}
       if (event.target) {

--- a/packages/taro-weapp/src/create-component.js
+++ b/packages/taro-weapp/src/create-component.js
@@ -115,7 +115,12 @@ function processEvent (eventHandlerName, obj) {
 
   obj[eventHandlerName] = function (event) {
     if (event) {
-      event.preventDefault = function () {}
+      event.preventDefault = function () {
+        Object.defineProperty(event, 'defaultPrevented', {
+          value: true,
+          writable: false
+        })
+      }
       event.stopPropagation = function () {}
       event.currentTarget = event.currentTarget || event.target || {}
       if (event.target) {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复事件回调中调用 `preventDefault` 后 `defaultPrevented` 值不存在的问题。

事件处理中模拟了 `preventDefault` 方法，但实现仅仅是一个空方法，在此基础上增加了对 `defaultPrevented` 的模拟，让其更符合规范。虽然实质上不会发生什么（小程序还不支持默认行为的阻止），但自定义组件的封装能基于 `defaultPrevented` 来决定自定义默认行为的调用。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 字节跳动小程序
- [x] QQ 轻应用
- [x] 京东小程序
- [x] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
