### PR TITLE
fix(harmony): input组件用作radio时，同一group的item，name必须相同，这里使用groupId作为name

### DIFF
--- a/packages/taro-harmony/src/components/components-harmony/radio/index.hml
+++ b/packages/taro-harmony/src/components/components-harmony/radio/index.hml
@@ -2,7 +2,7 @@
   id="{{ id }}"
   value="{{ value }}"
   type="radio"
-  name="{{ groupId }}"
+  name="{{ nameValue }}"
   disabled="{{disabled}}"
   checked="{{ checked }}"
   @change="onChange"

--- a/packages/taro-harmony/src/components/components-harmony/radio/index.hml
+++ b/packages/taro-harmony/src/components/components-harmony/radio/index.hml
@@ -2,7 +2,7 @@
   id="{{ id }}"
   value="{{ value }}"
   type="radio"
-  name="{{ name }}"
+  name="{{ groupId }}"
   disabled="{{disabled}}"
   checked="{{ checked }}"
   @change="onChange"

--- a/packages/taro-harmony/src/components/components-harmony/radio/index.js
+++ b/packages/taro-harmony/src/components/components-harmony/radio/index.js
@@ -1,11 +1,22 @@
 export default {
   props: [
     'id',
+    'name',
     'groupId',
     'value',
     'checked',
     'disabled'
   ],
+
+  computed: {
+    nameValue () {
+      let name = this.name
+      if (this.groupId) {
+        name = this.groupId
+      }
+      return name
+    }
+  },
 
   onChange (e) {
     if (e.checked) {

--- a/packages/taro-harmony/src/components/components-harmony/radio/index.js
+++ b/packages/taro-harmony/src/components/components-harmony/radio/index.js
@@ -1,7 +1,6 @@
 export default {
   props: [
     'id',
-    'name',
     'groupId',
     'value',
     'checked',


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复harmony  radio组件无法切换问题

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [x] 鸿蒙
