### PR TITLE
fix(rn): swiper selectIndex updated when props change

### DIFF
--- a/packages/taro-components-rn/src/components/Swiper/carousel.tsx
+++ b/packages/taro-components-rn/src/components/Swiper/carousel.tsx
@@ -75,6 +75,7 @@ class Carousel extends React.Component<CarouselProps, CarouselState> {
   // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(props: CarouselProps): void {
     const { selectedIndex, infinite } = props
+    if (selectedIndex === this.props.selectedIndex && infinite === this.props.infinite) return
     const index = this.getVirtualIndex(selectedIndex as number, infinite)
     if (index !== this.state.selectedIndex) {
       this.goTo(index)


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

父组件导致组件重新渲染，导致UNSAFE_componentWillReceiveProps 被调用，进而导致swiper调回初始化位置

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
