### PR TITLE
fix: swiper 1 itme & input padding

### DIFF
--- a/packages/taro-components-rn/src/components/Input/index.tsx
+++ b/packages/taro-components-rn/src/components/Input/index.tsx
@@ -250,7 +250,10 @@ class _Input extends React.Component<InputProps, InputState> {
         multiline={!!_multiline}
         onContentSizeChange={this.onContentSizeChange}
         underlineColorAndroid="rgba(0,0,0,0)"
-        style={[style, _multiline && _autoHeight && { height: Math.max(35, this.state.height) }]}
+        style={[{
+          paddingBottom: 0,
+          paddingTop: 0
+        }, style, _multiline && _autoHeight && { height: Math.max(35, this.state.height) }]}
       />
     )
   }

--- a/packages/taro-components-rn/src/components/Input/index.tsx
+++ b/packages/taro-components-rn/src/components/Input/index.tsx
@@ -251,8 +251,8 @@ class _Input extends React.Component<InputProps, InputState> {
         onContentSizeChange={this.onContentSizeChange}
         underlineColorAndroid="rgba(0,0,0,0)"
         style={[{
-          paddingBottom: 0,
-          paddingTop: 0
+          padding: 0,
+          height: 22.4,
         }, style, _multiline && _autoHeight && { height: Math.max(35, this.state.height) }]}
       />
     )

--- a/packages/taro-components-rn/src/components/Input/index.tsx
+++ b/packages/taro-components-rn/src/components/Input/index.tsx
@@ -252,7 +252,6 @@ class _Input extends React.Component<InputProps, InputState> {
         underlineColorAndroid="rgba(0,0,0,0)"
         style={[{
           padding: 0,
-          height: 22.4,
         }, style, _multiline && _autoHeight && { height: Math.max(35, this.state.height) }]}
       />
     )

--- a/packages/taro-components-rn/src/components/Swiper/PropsType.tsx
+++ b/packages/taro-components-rn/src/components/Swiper/PropsType.tsx
@@ -49,4 +49,5 @@ export interface CarouselProps {
   dotActiveStyle?: StyleProp<ViewStyle>;
   pagination?: (props: PaginationProps) => React.ReactNode;
   afterChange?: (index: number) => void;
+  children?: React.ReactNode;
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

0. Android input default padding 0
1. swiper 1 item bug
2. swiper current > count -1 bug

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
