### PR TITLE
fix(h5): 去除block组件多余的渲染节点

### DIFF
--- a/packages/taro-components/src/components/block/block.tsx
+++ b/packages/taro-components/src/components/block/block.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { Component, h, Host, ComponentInterface } from '@stencil/core'
+import { Component, h, Fragment, ComponentInterface } from '@stencil/core'
 
 @Component({
   tag: 'taro-block-core'
@@ -7,7 +7,7 @@ import { Component, h, Host, ComponentInterface } from '@stencil/core'
 export class Block implements ComponentInterface {
   render () {
     return (
-      <Host />
+      <Fragment />
     )
   }
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
block组件在小程序中是一个空元素，转换成h5后，当前的方式会有多余节点插入，改为使用Fragment，避免多余节点


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
