### PR TITLE
test(h5): 解决 `config.routes` 内容多了一层数组

### DIFF
--- a/packages/taro-h5/__tests__/ui/tab-bar.test.tsx
+++ b/packages/taro-h5/__tests__/ui/tab-bar.test.tsx
@@ -53,7 +53,7 @@ describe('tabbar', () => {
         return this.props.children
       }
     }
-    config.routes = config.pages?.map(path => ({ path, load: () => null }));
+    config.routes = config.pages?.map(path => ({ path, load: () => null }))
     const inst = createReactApp(App, React, ReactDOM, config)
     createRouter(inst, config, 'React')
   })

--- a/packages/taro-h5/__tests__/ui/tab-bar.test.tsx
+++ b/packages/taro-h5/__tests__/ui/tab-bar.test.tsx
@@ -53,9 +53,7 @@ describe('tabbar', () => {
         return this.props.children
       }
     }
-    config.routes = [
-      config.pages?.map(path => ({ path, load: () => null }))
-    ]
+    config.routes = config.pages?.map(path => ({ path, load: () => null }));
     const inst = createReactApp(App, React, ReactDOM, config)
     createRouter(inst, config, 'React')
   })


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

参考这个例子写测试时，发现 `config.routes` 内容多了一层数组，导致后续操作 404

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [x] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
