### PR TITLE
fix(rn): 修复 pxTransform api 计算值与小程序端不统一

### DIFF
--- a/packages/taro-runtime-rn/src/compute.ts
+++ b/packages/taro-runtime-rn/src/compute.ts
@@ -18,6 +18,6 @@ export function pxTransform (size: number): number {
     throw new Error(`deviceRatio 配置中不存在 ${designWidth} 的设置！`)
   }
   const formatSize = ~~size
-  const rateSize = formatSize / (deviceRatio[designWidth] * 2)
+  const rateSize = formatSize * deviceRatio[designWidth]
   return rateSize * deviceWidthDp / uiWidthPx
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
1. pxTransform 计算值与小程序端保持统一，https://github.com/NervJS/taro/blob/37075f081e55481347bd0bbd606d367d2215e842/packages/postcss-pxtransform/index.js#L52


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
