### PR TITLE
fix: 修复跳转mini.debugReact链接错误

### DIFF
--- a/docs/react-overall.md
+++ b/docs/react-overall.md
@@ -271,7 +271,7 @@ export default class Test extends React.Component {
 
 因为 development 版本的 React 体积较大，为了减少小程序体积，方便开发时真机预览。Taro 在构建小程序时默认使用 production 版本的 React 相关依赖。
 
-但是 production 版本的 React 出错时不会展示报错堆栈的信息。因此当你遇到类似这种报错时：【Error: Minified React error #152】。可以修改编译配置中的 [mini.debugReact](http://localhost:3000/taro/docs/next/config-detail#minidebugreact) 选项，然后重新开启编译。这样 Taro 会使用 development 版本的 React，从而输出报错堆栈。
+但是 production 版本的 React 出错时不会展示报错堆栈的信息。因此当你遇到类似这种报错时：【Error: Minified React error #152】。可以修改编译配置中的 [mini.debugReact](./config-detail#minidebugreact) 选项，然后重新开启编译。这样 Taro 会使用 development 版本的 React，从而输出报错堆栈。
 
 #### Error: Minified React error #152 报错
 

--- a/versioned_docs/version-3.x/react-overall.md
+++ b/versioned_docs/version-3.x/react-overall.md
@@ -263,7 +263,7 @@ export default class Test extends React.Component {
 
 因为 development 版本的 React 体积较大，为了减少小程序体积，方便开发时真机预览。Taro 在构建小程序时默认使用 production 版本的 React 相关依赖。
 
-但是 production 版本的 React 出错时不会展示报错堆栈的信息。因此当你遇到类似这种报错时：【Error: Minified React error #152】。可以修改编译配置中的 [mini.debugReact](http://localhost:3000/taro/docs/next/config-detail#minidebugreact) 选项，然后重新开启编译。这样 Taro 会使用 development 版本的 React，从而输出报错堆栈。
+但是 production 版本的 React 出错时不会展示报错堆栈的信息。因此当你遇到类似这种报错时：【Error: Minified React error #152】。可以修改编译配置中的 [mini.debugReact](./config-detail#minidebugreact) 选项，然后重新开启编译。这样 Taro 会使用 development 版本的 React，从而输出报错堆栈。
 
 #### Error: Minified React error #152 报错
 


### PR DESCRIPTION
**这个 PR 做了什么?**

修复文档中跳转 mini.debugReact 配置项的链接错误

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [x] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
