### PR TITLE
fix(vue-devtools/service): 修复 vue devtools 失效的问题，fix #11095

### DIFF
--- a/packages/taro-plugin-vue-devtools/src/index.ts
+++ b/packages/taro-plugin-vue-devtools/src/index.ts
@@ -43,6 +43,7 @@ export default function (ctx: IPluginContext, options: IOptions) {
         const config = args[0]
         config.__VUE_DEVTOOLS_PORT__ = port
         config.ENABLE_SIZE_APIS = true
+        config.ENABLE_CONTAINS = true
         return args
       })
 

--- a/packages/taro-service/package.json
+++ b/packages/taro-service/package.json
@@ -40,6 +40,7 @@
     "fs-extra": "^8.0.1",
     "lodash": "^4.17.21",
     "resolve": "^1.6.0",
-    "tapable": "^1.1.3"
+    "tapable": "^1.1.3",
+    "webpack-merge": "^4.2.2"
   }
 }

--- a/packages/taro-service/src/Config.ts
+++ b/packages/taro-service/src/Config.ts
@@ -1,7 +1,7 @@
 import * as path from 'path'
 import * as fs from 'fs-extra'
 
-import { merge } from 'lodash'
+import * as merge from 'webpack-merge'
 import { IProjectConfig } from '@tarojs/taro/types/compile'
 import {
   SOURCE_DIR,


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复 Vue DevTools 失效的问题，fix #11095

- 使用 `webpack-merge` 代替 `lodash merge` 去合并用户的 webpack 配置，在对数组的合并上（如 merge([B,C], [A]) ），前者是 [B,C,A]，后者是 [A,C]
- Vue DevTools 需要用到 `node.contains` 方法

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #11095 
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
