### PR TITLE
fix(rn): image picker loading on android 11

### DIFF
--- a/packages/taro-rn/package.json
+++ b/packages/taro-rn/package.json
@@ -57,7 +57,7 @@
     "react-native-root-toast": "^3.0.1",
     "react-native-safe-area-context": "~3.3.2",
     "react-native-stylekit": "^1.0.0",
-    "react-native-syan-image-picker": "0.4.10",
+    "react-native-syan-image-picker": "0.5.3",
     "react-native-unimodules": "~0.14.10"
   },
   "devDependencies": {
@@ -87,7 +87,7 @@
     "react-native-device-info": "~8.4.8",
     "react-native-image-resizer": "~1.4.5",
     "react-native-safe-area-context": "~3.3.2",
-    "react-native-syan-image-picker": "0.4.10",
+    "react-native-syan-image-picker": "0.5.3",
     "react-native-unimodules": "~0.14.10"
   },
   "resolutions": {

--- a/packages/taro-rn/src/lib/chooseImage/index.ts
+++ b/packages/taro-rn/src/lib/chooseImage/index.ts
@@ -26,7 +26,9 @@ function getRes(images) {
 function openCamera(options: Taro.chooseImage.Option): Promise<Taro.chooseImage.SuccessCallbackResult> {
   const { success, fail, complete } = options
   return new Promise((resolve, reject) => {
-    SYImagePicker.openCamera({}, (err, photo: any) => {
+    SYImagePicker.openCamera({
+      compressFocusAlpha: true
+    }, (err, photo: any) => {
       if (err) {
         const res = {
           errMsg: err
@@ -55,6 +57,7 @@ function openPicker(options: Taro.chooseImage.Option): Promise<Taro.chooseImage.
   return new Promise((resolve, reject) => {
     // NOTE：react-native-syan-image-picker 暂不支持 Android 端压缩
     SYImagePicker.showImagePicker({
+      compressFocusAlpha: true,
       imageCount,
       quality: sizeType[0] === 'compressed' ? 70 : 90,
     }, (err, photos: any) => {

--- a/packages/taro-rn/src/lib/previewImage/index.tsx
+++ b/packages/taro-rn/src/lib/previewImage/index.tsx
@@ -7,6 +7,7 @@ import { downloadFile } from '../file'
 
 const styles = StyleSheet.create({
   mask: {
+    elevation: 1,
     position: 'absolute',
     backgroundColor: '#000000',
     top: 0,

--- a/packages/taro-router-rn/src/router.ts
+++ b/packages/taro-router-rn/src/router.ts
@@ -142,6 +142,7 @@ function getStackOptions (config: RouterConfig) {
     },
     headerTintColor: headColor,
     cardStyleInterpolator: CardStyleInterpolators.forHorizontalIOS,
+    cardStyle: { elevation: 1 },
     headerBackTitleVisible: false,
     headerPressColorAndroid: 'rgba(255,255,255,0)',
     headerTitleAlign,

--- a/yarn.lock
+++ b/yarn.lock
@@ -26963,10 +26963,10 @@ react-native-svg@~12.1.1:
     css-select "^2.1.0"
     css-tree "^1.0.0-alpha.39"
 
-react-native-syan-image-picker@0.4.10:
-  version "0.4.10"
-  resolved "https://registry.yarnpkg.com/react-native-syan-image-picker/-/react-native-syan-image-picker-0.4.10.tgz#aefeef40842cddfdf43a9ab7ef76787e8f630dcf"
-  integrity sha512-iwo6v/+801R5mPWgIr0WP0jELfr+NZg1qiFDmdqTLObBd3x9rezV60lP331fRaJTmfYMK0IU04Hiu0WOSmAZ7w==
+react-native-syan-image-picker@0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/react-native-syan-image-picker/-/react-native-syan-image-picker-0.5.3.tgz#4d1f164449abac11f60cde337ad1ac22ef554b19"
+  integrity sha512-jDHKiv6jPrC3Dslhq2tDjqYC27HE0sNRzpthOY1//THgQpJ0Ht7B6EHvllWVaMw0V41kFVMixLxVQTMu/V7RSw==
 
 react-native-unimodules@~0.14.10:
   version "0.14.10"


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复android 11加载相册一直loading

closes #11167

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #11167
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
