### PR TITLE
修复关闭scalable value 有多个单位时只有第一个值不转换成 scalePx2dp

### DIFF
--- a/packages/css-to-react-native/__tests__/index.spec.js
+++ b/packages/css-to-react-native/__tests__/index.spec.js
@@ -3452,6 +3452,23 @@ describe('ICSS :export pseudo-selector', () => {
     })
   })
 
+  it('does not transform value to scalePx2dp when option scalable false', () => {
+    expect(
+      transform(`
+      .foo {
+        padding: 10px 20px;
+      }
+    `, { scalable: false })
+    ).toEqual({
+      foo: {
+        paddingTop: 10,
+        paddingRight: 20,
+        paddingBottom: 10,
+        paddingLeft: 20
+      }
+    })
+  })
+
   it('should throw an error if exportedKey has the same name as a class and is defined twice', () => {
     expect(() =>
       transform(`

--- a/packages/css-to-react-native/src/index.js
+++ b/packages/css-to-react-native/src/index.js
@@ -57,7 +57,7 @@ const transformDecls = (styles, declarations, result, options = {}) => {
       !options.scalable &&
       /(\d+)px/.test(value)
     ) {
-      value = value.replace(/(\d+)px/, '$1PX')
+      value = value.replace(/(\d+)px/g, '$1PX')
     }
 
     if (shorthandBorderProps.indexOf(property) > -1) {

--- a/packages/css-to-react-native/src/index.js
+++ b/packages/css-to-react-native/src/index.js
@@ -52,7 +52,6 @@ const transformDecls = (styles, declarations, result, options = {}) => {
     // scalable option, when it is false, transform single value 'px' unit to 'PX'
     // do not be wrapped by scalePx2dp function
     if (
-      isLengthUnit &&
       typeof options.scalable === 'boolean' &&
       !options.scalable &&
       /(\d+)px/.test(value)


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
1. 修复关闭scalable value 有多个单位时只有第一个值不转换成 scalePx2dp


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
