### PR TITLE
fix(components): 修复Vue2的输入框input事件回调错误问题

### DIFF
--- a/packages/taro-components/h5/vue/createFormsComponent.js
+++ b/packages/taro-components/h5/vue/createFormsComponent.js
@@ -21,11 +21,11 @@ export default function createFormsComponent (name, event, modelValue = 'value',
     methods: {
       input (e) {
         this.$emit('input', e)
-        this.$emit('model', e.target.value)
+        this.$emit('model', e.detail.value)
       },
       change (e) {
         this.$emit('change', e)
-        this.$emit('model', e.target.value)
+        this.$emit('model', e.detail.value)
       }
     },
     render (createElement) {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复vue2的input输入框input事件回调和change事件回调回调错误的问题
`e.target.value`获取到的值不是输入框最新的值，需要使用`e.detail.value`


**这个 PR 是什么类型?** (至少选择一个)

- [X] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [X] Web 平台（H5）
- [ ] 移动端（React-Native）
