### PR TITLE
fix(h5): query 不进行 decode

### DIFF
--- a/packages/taro-router/src/router/page.ts
+++ b/packages/taro-router/src/router/page.ts
@@ -104,7 +104,7 @@ export default class PageHandler {
   getQuery (stamp = 0, search = '', options: Record<string, unknown> = {}) {
     search = search ? `${search}&${this.search}` : this.search
     const query = search
-      ? queryString.parse(search)
+      ? queryString.parse(search, { decode: false })
       : {}
 
     query.stamp = stamp.toString()


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

- [query-string](https://github.com/sindresorhus/query-string#decode) 这个库 decode 默认是 true，H5 不进行 decode 与小程序的 query 保持一致

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
