### PR TITLE
fix(h5): textarea caculate content height bug

### DIFF
--- a/packages/taro-components/src/components/textarea/textarea.tsx
+++ b/packages/taro-components/src/components/textarea/textarea.tsx
@@ -102,7 +102,9 @@ export class Textarea implements ComponentInterface {
     let origHeight = ta.style.height,
       height = ta.offsetHeight,
       scrollHeight = ta.scrollHeight,
-      overflow = ta.style.overflow
+      overflow = ta.style.overflow,
+      originMinHeight = ta.style.minHeight || null
+
     /// only bother if the ta is bigger than content
     if (height >= scrollHeight) {
       ta.style.minHeight = 0
@@ -126,7 +128,7 @@ export class Textarea implements ComponentInterface {
         ta.style.height = origHeight
         /// put the overflow back
         ta.style.overflow = overflow
-        ta.style.minHeight = null
+        ta.style.minHeight = originMinHeight
         return height
       }
     } else {

--- a/packages/taro-components/src/components/textarea/textarea.tsx
+++ b/packages/taro-components/src/components/textarea/textarea.tsx
@@ -105,6 +105,7 @@ export class Textarea implements ComponentInterface {
       overflow = ta.style.overflow
     /// only bother if the ta is bigger than content
     if (height >= scrollHeight) {
+      ta.style.minHeight = 0
       /// check that our browser supports changing dimension
       /// calculations mid-way through a function call...
       ta.style.height = height + scanAmount + 'px'
@@ -125,6 +126,7 @@ export class Textarea implements ComponentInterface {
         ta.style.height = origHeight
         /// put the overflow back
         ta.style.overflow = overflow
+        ta.style.minHeight = null
         return height
       }
     } else {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

textarea 设置了min-height在caculateContentHeight时会陷入死循环

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #11335
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
