### PR TITLE
feat(babel-plugin-transform-react-jsx-to-rn-stylesheet): 当style为array，需要转换为object #11476

### DIFF
--- a/packages/babel-plugin-transform-react-jsx-to-rn-stylesheet/__tests__/index.spec.js
+++ b/packages/babel-plugin-transform-react-jsx-to-rn-stylesheet/__tests__/index.spec.js
@@ -1,6 +1,6 @@
 import { transform } from '@babel/core'
 import syntaxJSX from 'babel-plugin-syntax-jsx'
-import jSXStylePlugin from '../src/index'
+import jSXStylePlugin from '../dist/index'
 
 const mergeStylesFunctionTemplate = `function _mergeStyles() {
   var newTarget = {};
@@ -48,6 +48,10 @@ const getStyleFunctionTemplete = `function _getStyle(classNameExpression) {
   var style = {};
   classNameArr.reduce((sty, cls) => Object.assign(sty, _styleSheet[cls.trim()]), style);
   return style;
+}`
+
+const mergeEleStylesFunctionTemplate = `function _mergeEleStyles() {
+  return [].concat.apply([], arguments).reduce((pre, cur) => Object.assign(pre, cur), {});
 }`
 
 describe('jsx style plugin', () => {
@@ -116,11 +120,14 @@ class App extends Component {
   }
 }`)).toBe(`import { createElement, Component } from 'rax';
 import appCssStyleSheet from "./app.css";
+
+${mergeEleStylesFunctionTemplate}
+
 var _styleSheet = appCssStyleSheet;
 
 class App extends Component {
   render() {
-    return <div style={[_styleSheet["header1"], _styleSheet["header2"]]} />;
+    return <div style={_mergeEleStyles(_styleSheet["header1"], _styleSheet["header2"])} />;
   }
 
 }`)
@@ -179,13 +186,15 @@ class App extends Component {
 import app1CssStyleSheet from "./app1.css";
 import app2CssStyleSheet from "./app2.css";
 
+${mergeEleStylesFunctionTemplate}
+
 ${mergeStylesFunctionTemplate}
 
 var _styleSheet = _mergeStyles(app1CssStyleSheet, app2CssStyleSheet);
 
 class App extends Component {
   render() {
-    return <div style={[_styleSheet["header1"], _styleSheet["header2"]]} />;
+    return <div style={_mergeEleStyles(_styleSheet["header1"], _styleSheet["header2"])} />;
   }
 
 }`)
@@ -204,13 +213,15 @@ class App extends Component {
 import appCssStyleSheet from "./app.css";
 import appCssStyleSheet1 from "../app.css";
 
+${mergeEleStylesFunctionTemplate}
+
 ${mergeStylesFunctionTemplate}
 
 var _styleSheet = _mergeStyles(appCssStyleSheet, appCssStyleSheet1);
 
 class App extends Component {
   render() {
-    return <div style={[_styleSheet["header1"], _styleSheet["header2"]]} />;
+    return <div style={_mergeEleStyles(_styleSheet["header1"], _styleSheet["header2"])} />;
   }
 
 }`)
@@ -229,13 +240,15 @@ class App extends Component {
 import appCssStyleSheet from "./app.css";
 import style from "./style.css";
 
+${mergeEleStylesFunctionTemplate}
+
 ${mergeStylesFunctionTemplate}
 
 var _styleSheet = _mergeStyles(appCssStyleSheet, style);
 
 class App extends Component {
   render() {
-    return <div style={[_styleSheet["header2"], style.header1]} />;
+    return <div style={_mergeEleStyles(_styleSheet["header2"], style.header1)} />;
   }
 
 }`)
@@ -254,13 +267,16 @@ class App extends Component {
   }
 }`)).toBe(`import { createElement, Component } from 'rax';
 import appCssStyleSheet from "./app.css";
+
+${mergeEleStylesFunctionTemplate}
+
 var _styleSheet = appCssStyleSheet;
 
 class App extends Component {
   render() {
-    return <div style={[_styleSheet["header"], {
+    return <div style={_mergeEleStyles(_styleSheet["header"], {
       height: 100
-    }]} />;
+    })} />;
   }\n
 }`)
   })
@@ -279,13 +295,15 @@ class App extends Component {
 import appCssStyleSheet from "./app.css";
 import style from "./style.css";
 
+${mergeEleStylesFunctionTemplate}
+
 ${mergeStylesFunctionTemplate}
 
 var _styleSheet = _mergeStyles(appCssStyleSheet, style);
 
 class App extends Component {
   render() {
-    return <div style={[_styleSheet["header2"], style.header1, style.header3]} />;
+    return <div style={_mergeEleStyles(_styleSheet["header2"], style.header1, style.header3)} />;
   }\n
 }`)
   })
@@ -407,11 +425,14 @@ import './app.less';
 render(<div className="header" style={{width: 100, height: 100}} />);
 `)).toBe(`import { createElement, render } from 'rax';
 import appLessStyleSheet from "./app.less";
+
+${mergeEleStylesFunctionTemplate}
+
 var _styleSheet = appLessStyleSheet;
-render(<div style={[_styleSheet["header"], {
+render(<div style={_mergeEleStyles(_styleSheet["header"], {
   width: 100,
   height: 100
-}]} />);`)
+})} />);`)
   })
   it('transform styleAttribute inline string', () => {
     expect(getTransfromCode(`
@@ -436,15 +457,18 @@ import './app.less';
 render(<div className="header" style="width:100px;height:100px;background-color:rgba(0, 0, 0, 0.5);border: 1px solid;" />);
 `)).toBe(`import { createElement, render } from 'rax';
 import appLessStyleSheet from "./app.less";
+
+${mergeEleStylesFunctionTemplate}
+
 var _styleSheet = appLessStyleSheet;
-render(<div style={[_styleSheet["header"], {
+render(<div style={_mergeEleStyles(_styleSheet["header"], {
   "width": 100,
   "height": 100,
   "backgroundColor": "rgba(0, 0, 0, 0.5)",
   "borderWidth": 1,
   "borderStyle": "solid",
   "borderColor": "black"
-}]} />);`)
+})} />);`)
   })
 
   it('ignore merge stylesheet when css module enable', () => {
@@ -460,11 +484,14 @@ class App extends Component {
 }`, false, { enableCSSModule: true })).toBe(`import { createElement, Component } from 'rax';
 import appScssStyleSheet from "./app.scss";
 import styleSheet from './app.module.scss';
+
+${mergeEleStylesFunctionTemplate}
+
 var _styleSheet = appScssStyleSheet;
 
 class App extends Component {
   render() {
-    return <div style={[_styleSheet["header"], styleSheet.red]} />;
+    return <div style={_mergeEleStyles(_styleSheet["header"], styleSheet.red)} />;
   }\n
 }`)
   })
@@ -585,13 +612,15 @@ class App extends Component {
 import appScssStyleSheet from "./app.scss";
 import styleSheet from "./app.module.scss";
 
+${mergeEleStylesFunctionTemplate}
+
 ${mergeStylesFunctionTemplate}
 
 var _styleSheet = _mergeStyles(appScssStyleSheet, styleSheet);
 
 class App extends Component {
   render() {
-    return <div style={[_styleSheet["header"], styleSheet.red]} />;
+    return <div style={_mergeEleStyles(_styleSheet["header"], styleSheet.red)} />;
   }\n
 }`)
   })
@@ -649,15 +678,18 @@ class App extends Component {
   }
 }`, false, { enableMultipleClassName: true })).toBe(`import { createElement, Component } from 'rax';
 import appCssStyleSheet from "./app.css";
+
+${mergeEleStylesFunctionTemplate}
+
 var _styleSheet = appCssStyleSheet;
 
 class App extends Component {
   render() {
-    return <div style={[_styleSheet["container"], {
+    return <div style={_mergeEleStyles(_styleSheet["container"], {
       color: "red"
-    }]} headerStyle={[_styleSheet["header"], {
+    })} headerStyle={_mergeEleStyles(_styleSheet["header"], {
       color: "green"
-    }]} />;
+    })} />;
   }
 
 }`)

--- a/packages/babel-plugin-transform-react-jsx-to-rn-stylesheet/__tests__/index.spec.js
+++ b/packages/babel-plugin-transform-react-jsx-to-rn-stylesheet/__tests__/index.spec.js
@@ -1,6 +1,6 @@
 import { transform } from '@babel/core'
 import syntaxJSX from 'babel-plugin-syntax-jsx'
-import jSXStylePlugin from '../dist/index'
+import jSXStylePlugin from '../src/index'
 
 const mergeStylesFunctionTemplate = `function _mergeStyles() {
   var newTarget = {};

--- a/packages/babel-plugin-transform-react-jsx-to-rn-stylesheet/src/index.ts
+++ b/packages/babel-plugin-transform-react-jsx-to-rn-stylesheet/src/index.ts
@@ -7,6 +7,8 @@ import { ConvertPluginPass as PluginPass } from './types'
 const STYLE_SHEET_NAME = '_styleSheet'
 const GET_STYLE_FUNC_NAME = '_getStyle'
 const MERGE_STYLES_FUNC_NAME = '_mergeStyles'
+const MERGE_ELE_STYLES_FUNC_NAME = '_mergeEleStyles'
+
 const GET_CLS_NAME_FUNC_NAME = '_getClassName'
 const NAME_SUFFIX = 'styleSheet'
 const RN_CSS_EXT = ['.css', '.scss', '.sass', '.less', '.styl', '.stylus']
@@ -23,7 +25,7 @@ const string2Object = str => {
   const entries = str.replace(/;+$/g, '')
     .split(';')
     .map(l => {
-      const arr = l.split(':')
+      const arr = l.split(':').map(it => it.trim())
       arr[1] = arr[1]?.replace(/px/g, 'PX')
       return arr
     })
@@ -97,6 +99,12 @@ function ${GET_CLS_NAME_FUNC_NAME}() {
   return className.join(' ').trim();
 }
 `
+// like: `[[styles.header, styles.header1], styles.header2]`
+const getMergeEleStyleFunction = `
+function ${MERGE_ELE_STYLES_FUNC_NAME}() {
+  return [].concat.apply([], arguments).reduce((pre, cur) => Object.assign(pre, cur), {})
+}
+`
 const getStyleFunction = `
 function ${GET_STYLE_FUNC_NAME}(classNameExpression) {
   var className = ${GET_CLS_NAME_FUNC_NAME}(classNameExpression);
@@ -113,10 +121,11 @@ export default function (babel: {
 }): PluginObj {
   const { types: t, template } = babel
 
-  const getClassNameFunctionTemplate = template(getClassNameFunction)
-  const getStyleFunctionTemplete = template(getStyleFunction)
-  const getClassNameFunctionStmt = getClassNameFunctionTemplate()
-  const getStyleFunctionStmt = getStyleFunctionTemplete()
+  const getClassNameFunctionStmt = template(getClassNameFunction)()
+
+  const getStyleFunctionStmt = template(getStyleFunction)()
+
+  const getMergeEleStyleFunctionStmt = template(getMergeEleStyleFunction)()
 
   function getMap (str) {
     return str.split(/\s+/).map((className) => {
@@ -273,13 +282,16 @@ export default function (babel: {
           const node = astPath.node
           const injectGetStyle = file.get('injectGetStyle')
           // 从最后一个import 开始插入表达式，后续插入的表达式追加在后面
-          const lastImportIndex = findLastImportIndex(node.body)
-
+          let lastImportIndex = findLastImportIndex(node.body)
           if (injectGetStyle) {
             // @ts-ignore
-            node.body.splice(lastImportIndex + 1, 0, getClassNameFunctionStmt)
+            node.body.splice(++lastImportIndex, 0, getClassNameFunctionStmt)
             // @ts-ignore
-            node.body.splice(lastImportIndex + 2, 0, getStyleFunctionStmt)
+            node.body.splice(++lastImportIndex, 0, getStyleFunctionStmt)
+          }
+          if (file.get('hasMultiStyle')) {
+            // @ts-ignore
+            node.body.splice(++lastImportIndex, 0, getMergeEleStyleFunctionStmt)
           }
           existStyleImport = false
         }
@@ -339,7 +351,12 @@ export default function (babel: {
               return
             }
 
+            if (arrayExpression.length > 1) {
+              file.set('hasMultiStyle', true)
+            }
+
             if (hasStyleAttribute && styleAttribute.value) {
+              file.set('hasMultiStyle', true)
               let expression
               // 支持 行内 style 转成oject：style="width:100;height:100;" => style={{width:'100',height:'100'}}
               if (t.isStringLiteral(styleAttribute.value)) {
@@ -350,9 +367,11 @@ export default function (babel: {
               }
               const expressionType = expression.type
 
+              let _arrayExpression
+              // 非rn场景，style不支持数组，因此需要将数组转换为对象
               // style={[styles.a, styles.b]} ArrayExpression
               if (expressionType === 'ArrayExpression') {
-                expression.elements = arrayExpression.concat(expression.elements)
+                _arrayExpression = arrayExpression.concat(expression.elements)
                 // style={styles.a} MemberExpression
                 // style={{ height: 100 }} ObjectExpression
                 // style={{ ...custom }} ObjectExpression
@@ -361,10 +380,13 @@ export default function (babel: {
                 // style={this.props.useCustom ? custom : null} ConditionalExpression
                 // style={custom || other} LogicalExpression
               } else {
-                styleAttribute.value = t.jSXExpressionContainer(t.arrayExpression(arrayExpression.concat(expression)))
+                _arrayExpression = arrayExpression.concat(expression)
               }
+              styleAttribute.value = t.jSXExpressionContainer(t.callExpression(t.identifier(MERGE_ELE_STYLES_FUNC_NAME), _arrayExpression))
             } else {
-              const expression = arrayExpression.length === 1 ? arrayExpression[0] : t.arrayExpression(arrayExpression)
+              const expression = arrayExpression.length > 1
+                ? t.callExpression(t.identifier(MERGE_ELE_STYLES_FUNC_NAME), arrayExpression)
+                : arrayExpression[0]
               attributes.push(t.jSXAttribute(t.jSXIdentifier(key === DEFAULT_STYLE_KEY ? key : (key + 'Style')), t.jSXExpressionContainer(expression)))
             }
           } else if (hasStyleAttribute) {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
在rn端的babel-plugin-transform-react-jsx-to-rn-stylesheet中， 会将className解析为style，在某些场景下可能产生问题。
例如：
```typescript
function demo () {
    return <ChildComp className="header1 header2" style={{color: ‘black’}}/>
}
function ChildComp ({ style }) {
    // 在rn端style为array类型，解构操作会导致样式失效。
    return <View style={{...style, color:  'red'}}/>
}
```
当子组件需要操作父组件传递的style时， 在rn端中style的类型为array，其他端中为object，如果不对rn做单独处理会导致样式失效。（较难排查）
该变更将style转为object，保持各端操作的一致性。



**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
