### PR TITLE
fix(vue3): 修复 Vue3 使用原生组件时事件触发失败的问题，#9794

### DIFF
--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/vue3.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/vue3.spec.ts.snap
@@ -515,14 +515,10 @@ require(\\"./taro\\");
             }, options);
         }
         function setReconciler() {
-            var _a;
             var hooks = taro_runtime[\\"container\\"].get(taro_runtime[\\"SERVICE_IDENTIFIER\\"].Hooks);
             hooks.getLifecycle = function(instance, lifecycle) {
                 return instance.$options[lifecycle];
             };
-            (_a = hooks.modifyMpEventImpls) === null || _a === void 0 ? void 0 : _a.push((function(event) {
-                event.type = event.type.replace(/-/g, \\"\\");
-            }));
             if (false) {}
         }
         function createVue3Page(h, id) {

--- a/packages/taro-plugin-vue3/src/runtime/connect.ts
+++ b/packages/taro-plugin-vue3/src/runtime/connect.ts
@@ -26,10 +26,6 @@ function setReconciler () {
     return instance.$options[lifecycle]
   }
 
-  hooks.modifyMpEventImpls?.push(function (event) {
-    event.type = event.type.replace(/-/g, '')
-  })
-
   if (process.env.TARO_ENV === 'h5') {
     hooks.createPullDownComponent = (component, path, h: typeof createElement) => {
       const inject = {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复 Vue3 使用原生组件时事件触发失败的问题，#9794

examples: `<com type='primary' @my-event='handleClick'></com>`

Vue3 会 `addEventListener('my-event')`，因此触发时不需要去掉小程序 e.type 中的 `-`

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #9794
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
