### PR TITLE
fix: 在React Taro项目下，会安装vue3，从而导致JSX.Element 类型不兼容问题

### DIFF
--- a/packages/taro-plugin-vue3/package.json
+++ b/packages/taro-plugin-vue3/package.json
@@ -31,9 +31,6 @@
     "@tarojs/shared": "3.4.4",
     "webpack": "4.46.0"
   },
-  "peerDependencies": {
-    "vue": "^3.0.0"
-  },
   "devDependencies": {
     "@tarojs/service": "3.4.4",
     "@tarojs/taro": "3.4.4",


### PR DESCRIPTION
remove vue peer dependence

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
因为此依赖的vue peerDependence，在React Taro项目下，会安装vue3，从而导致JSX.Element 类型不兼容问题


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #11474
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
