### PR TITLE
refactor(rn): 实现 rn 端 input 组件中 placeholder color 的设置

### DIFF
--- a/packages/taro-components-rn/src/components/Input/PropsType.tsx
+++ b/packages/taro-components-rn/src/components/Input/PropsType.tsx
@@ -34,6 +34,8 @@ export interface InputProps extends FormItemProps{
   cursor?: number;
   selectionStart: number;
   selectionEnd: number;
+  placeholderStyle?: string;
+  placeholderTextColor?: string;
   onInput?: (evt: Event) => void;
   onChange?: (evt: Event) => void;
   onFocus?: (evt: Event) => void;

--- a/packages/taro-components-rn/src/components/Input/index.tsx
+++ b/packages/taro-components-rn/src/components/Input/index.tsx
@@ -33,7 +33,7 @@ import {
   TextInputContentSizeChangeEventData,
   KeyboardTypeOptions
 } from 'react-native'
-import { noop, omit } from '../../utils'
+import { noop, omit, parseStyles } from '../../utils'
 import { InputProps, InputState } from './PropsType'
 
 const keyboardTypeMap: { [key: string]: string } = {
@@ -193,8 +193,8 @@ class _Input extends React.Component<InputProps, InputState> {
       _autoHeight,
       autoFocus,
       focus,
+      placeholderStyle,
     } = this.props
-
     const keyboardType: KeyboardTypeOptions = keyboardTypeMap[type] as KeyboardTypeOptions
 
     const selection = (() => {
@@ -210,30 +210,36 @@ class _Input extends React.Component<InputProps, InputState> {
     // fix: https://reactnative.dev/docs/textinput#multiline
     const textAlignVertical = _multiline ? 'top' : 'auto'
 
+    const placeholderTextColor = this.props.placeholderTextColor || parseStyles(placeholderStyle)?.color
+
+    const props = omit(this.props, [
+      'style',
+      'value',
+      'type',
+      'password',
+      'placeholder',
+      'disabled',
+      'maxlength',
+      'confirmType',
+      'confirmHold',
+      'cursor',
+      'selectionStart',
+      'selectionEnd',
+      'onInput',
+      'onFocus',
+      'onBlur',
+      'onKeyDown',
+      'onConfirm',
+      '_multiline',
+      '_autoHeight',
+      '_onLineChange',
+      'placeholderStyle',
+      'placeholderTextColor',
+    ])
+
     return (
       <TextInput
-        {...omit(this.props, [
-          'style',
-          'value',
-          'type',
-          'password',
-          'placeholder',
-          'disabled',
-          'maxlength',
-          'confirmType',
-          'confirmHold',
-          'cursor',
-          'selectionStart',
-          'selectionEnd',
-          'onInput',
-          'onFocus',
-          'onBlur',
-          'onKeyDown',
-          'onConfirm',
-          '_multiline',
-          '_autoHeight',
-          '_onLineChange'
-        ])}
+        {...props}
         defaultValue={value}
         keyboardType={keyboardType}
         secureTextEntry={!!password}
@@ -255,9 +261,14 @@ class _Input extends React.Component<InputProps, InputState> {
         textAlignVertical={textAlignVertical}
         onContentSizeChange={this.onContentSizeChange}
         underlineColorAndroid="rgba(0,0,0,0)"
-        style={[{
-          padding: 0,
-        }, style, _multiline && _autoHeight && { height: Math.max(35, this.state.height) }]}
+        placeholderTextColor={placeholderTextColor}
+        style={[
+          {
+            padding: 0
+          },
+          style,
+          _multiline && _autoHeight && { height: Math.max(35, this.state.height) }
+        ]}
       />
     )
   }

--- a/packages/taro-components/types/Input.d.ts
+++ b/packages/taro-components/types/Input.d.ts
@@ -35,6 +35,10 @@ interface InputProps extends StandardProps, FormItemProps {
    */
   placeholderClass?: string
 
+  /** 指定 placeholder 文字的颜色
+   * @supported rn
+   */
+  placeholderTextColor?: string
   /** 是否禁用
    * @supported weapp, h5, rn
    */


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
1. 处理 input 组件 ts 错误
2. 完善 input 组件 placeholder Color 属性设置，支持 `placeholderTextColor` 和 `placeholderStyle` 两种方式


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #11562
- [ ] 新功能(Feature)
- [x] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [x] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
