### PR TITLE
fix(h5): getImageInfo missing path value

### DIFF
--- a/packages/taro-h5/src/api/media/image/getImageInfo.ts
+++ b/packages/taro-h5/src/api/media/image/getImageInfo.ts
@@ -15,14 +15,29 @@ export const getImageInfo: typeof Taro.getImageInfo = (options) => {
     return Promise.reject(res)
   }
 
+  const getBase64Image = (image: HTMLImageElement) => {
+    try {
+      const canvas = document.createElement('canvas')
+      canvas.width = image.width
+      canvas.height = image.height
+      const ctx = canvas.getContext('2d')
+      ctx?.drawImage(image, 0, 0, image.width, image.height)
+      return canvas.toDataURL('image/png')
+    } catch (e) {
+      console.error('getImageInfo:get base64 fail', e)
+    }
+  }
+
   const { src, success, fail, complete } = options
   const handle = new MethodHandler({ name: 'getImageInfo', success, fail, complete })
   return new Promise((resolve, reject) => {
     const image = new Image()
+    image.crossOrigin = ''
     image.onload = () => {
       handle.success({
         width: image.naturalWidth,
-        height: image.naturalHeight
+        height: image.naturalHeight,
+        path: getBase64Image(image) || src
       }, resolve)
     }
     image.onerror = (e: any) => {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修正getImageInfo未返回path属性的问题


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
