### PR TITLE
fix(h5):修复安卓系统下罗盘API获取的方向不是绝对方向的问题

### DIFF
--- a/packages/taro-h5/src/api/device/compass.ts
+++ b/packages/taro-h5/src/api/device/compass.ts
@@ -1,8 +1,21 @@
 import Taro from '@tarojs/api'
 import { CallbackManager, MethodHandler } from '../utils/handler'
-
+import { getDeviceInfo } from '../../api/base/system'
 const callbackManager = new CallbackManager()
-let compassListener
+
+/**
+ * 按系统类型获取对应绝对orientation事件名，因为安卓系统中
+ * 直接监听deviceorientation事件得到的不是绝对orientation
+ */
+const getDeviceorientationAbsoluteEventNameByOS = () => {
+  if(getDeviceInfo().system==='AndroidOS')
+  {
+    return "deviceorientationabsolute"
+  }
+  else{
+    return "deviceorientation"
+  }
+}
 
 /**
  * 停止监听罗盘数据
@@ -10,7 +23,7 @@ let compassListener
 export const stopCompass: typeof Taro.stopCompass = ({ success, fail, complete } = {}) => {
   const handle = new MethodHandler({ name: 'stopCompass', success, fail, complete })
   try {
-    window.removeEventListener('deviceorientation', compassListener, true)
+    window.removeEventListener(getDeviceorientationAbsoluteEventNameByOS(), compassListener, true)
     return handle.success()
   } catch (e) {
     return handle.fail({ errMsg: e.message })
@@ -42,7 +55,7 @@ export const startCompass: typeof Taro.startCompass = ({ success, fail, complete
         stopCompass()
       }
       compassListener = getDeviceOrientationListener(200)
-      window.addEventListener('deviceorientation', compassListener, true)
+      window.addEventListener(getDeviceorientationAbsoluteEventNameByOS(), compassListener, true)
     } else {
       throw new Error('compass is not supported')
     }


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

修复安卓系统的浏览器中调用罗盘API无法获得绝对方向的问题

（因为安卓系统中直接监听deviceorientation事件得到的不是绝对orientation）

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
