### PR TITLE
fix(mini-runner): 修复独立分包场景下 jsonpFunction 配置和 base.wxml 引用路径问题

### DIFF
--- a/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
+++ b/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
@@ -776,7 +776,8 @@ export default class TaroMiniPlugin {
     if (independentPackages.size) {
       independentPackages.forEach((pages, name) => {
         const childCompiler = compilation.createChildCompiler(PLUGIN_NAME, {
-          path: `${compiler.options.output}/${name}`
+          path: `${compiler.options.output.path}/${name}`,
+          jsonpFunction: `${compiler.options.output.jsonpFunction}/${name}`
         })
         const compPath = path.resolve(__dirname, '..', 'template/comp')
         childCompiler.inputFileSystem = compiler.inputFileSystem
@@ -971,7 +972,7 @@ export default class TaroMiniPlugin {
       }
     })
     this.pages.forEach(page => {
-      const importBaseTemplatePath = promoteRelativePath(path.relative(page.path, path.join(sourceDir, this.getTemplatePath(baseTemplateName))))
+      let importBaseTemplatePath = promoteRelativePath(path.relative(page.path, path.join(sourceDir, this.getTemplatePath(baseTemplateName))))
       const config = this.filesConfig[this.getConfigFilePath(page.name)]
       let isIndependent = false
       let independentName = ''
@@ -979,6 +980,7 @@ export default class TaroMiniPlugin {
         if (pages.includes(page.path)) {
           isIndependent = true
           independentName = name
+          importBaseTemplatePath = promoteRelativePath(path.relative(page.path, path.join(sourceDir, name, this.getTemplatePath(baseTemplateName))))
         }
       })
       if (config) {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
问题：
1、独立分包页面的 page构造器 被重复调用（分别被主包和子包的 runtime.js 调用），报页面重复注册异常
2、独立分包页面 base.wxml 依赖引用异常

问题场景：小程序独立分包

问题原因：
1、独立分包和主包配置了相同的 jsonpFunction ，存在命名冲突，导致独立分包页面初始化 Page() 重复执行
2、独立分包页面的 base.wxml  依赖错误引用主包的 base.wxml 路径，而独立分包无法引用主包资源

问题修复：
1、独立分包的 jsonpFunction 增加包名标识
2、base.wxml  依赖路径修正为引用独立分包内的 base.wxml

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
