### PR TITLE
fix(h5):修改packages的scripts下copy:assets 中的copy到copy-cli，修复其与windows中的c…

### DIFF
--- a/packages/taro-h5/package.json
+++ b/packages/taro-h5/package.json
@@ -16,7 +16,7 @@
     "test:ci": "jest -i --coverage false",
     "test:dev": "jest --watch",
     "test:coverage": "jest --coverage",
-    "copy:assets": "copy src/**/*.css dist",
+    "copy:assets": "copy-cli src/**/*.css dist",
     "build": "rollup -c && tsc",
     "dev": "tsc -w",
     "prebuild": "npm run copy:assets",


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

npm下的copy命令与windows下的copy命令同名，默认构建会报”命令语法不正确”。，只要改成npm下的copy-cli就可以了

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
