### PR TITLE
feat: add global config option: subpackages support plugins config

### DIFF
--- a/packages/taro/types/taro.config.d.ts
+++ b/packages/taro/types/taro.config.d.ts
@@ -174,6 +174,8 @@ declare module './index' {
     name?: string
     /** 分包是否是独立分包 */
     independent?: boolean
+    /** 分包支持引用独立的插件 */
+    plugins?: Plugins
   }
 
   interface Plugins {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
目前最新版本的微信小程序的`subPackages`配置项是支持`plugins`选项，而目前taro的全局配置类型文件是没有给`subPackages`配置加`plugins`属性，导致在ts环境下配置会提示类型错误，这个pr解决了这个问题，加上了这个选项类型声明


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [x] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
