### PR TITLE
fix: 兼容现有的其他平台插件

### DIFF
--- a/packages/taro-cli/src/cli.ts
+++ b/packages/taro-cli/src/cli.ts
@@ -77,14 +77,19 @@ export default class CLI {
             case 'tt':
             case 'qq':
             case 'jd':
-              kernel.optsPlugins = [
-                ...kernel.optsPlugins,
-                `@tarojs/plugin-platform-${platform}`,
-                path.resolve(filesPath, 'writeFileToDist.js'),
-                path.resolve(filesPath, 'generateProjectConfig.js'),
-                path.resolve(filesPath, 'generateFrameworkInfo.js')
-              ]
-              break
+                kernel.optsPlugins.push(`@tarojs/plugin-platform-${platform}`);
+            case 'kwai':
+            case 'xhs':
+            case 'lark':
+            case 'qywx':
+            case 'dd':
+            case 'iot':
+                kernel.optsPlugins.push(
+                  path.resolve(filesPath, 'writeFileToDist.js'),
+                  path.resolve(filesPath, 'generateProjectConfig.js'),
+                  path.resolve(filesPath, 'generateFrameworkInfo.js')
+                );
+                break;
             default: {
               // h5, rn
               const platformPlugins = fs.readdirSync(platformsPath)


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
在cli 参数入口增加如下平台的判断:
- kuai(快手)
- xhs(小红书)
- lark(飞书)
- qywx(企业微信)
- dd(钉钉)
- iot(支付宝iot)

适配现有外置小程序平台插件.避免打包时候提示缺少`this.ctx.generateProjectConfig`和`this.ctx.writeFileToDist`方法


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #11644
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
