### PR TITLE
feat(vue3): 允许用户对vue-loader传入配置项

### DIFF
--- a/packages/taro-plugin-vue3/src/index.ts
+++ b/packages/taro-plugin-vue3/src/index.ts
@@ -32,7 +32,7 @@ export default (ctx: IPluginContext, config: IConfig = {}) => {
 
     if (process.env.TARO_ENV === 'h5') {
       // H5
-      modifyH5WebpackChain(ctx, chain, data, config)
+      modifyH5WebpackChain(ctx, chain, config)
     } else {
       // 小程序
       modifyMiniWebpackChain(ctx, chain, data, config)

--- a/packages/taro-plugin-vue3/src/index.ts
+++ b/packages/taro-plugin-vue3/src/index.ts
@@ -4,15 +4,20 @@ import { modifyH5WebpackChain } from './webpack.h5'
 
 import type { IPluginContext } from '@tarojs/service'
 
+type CompilerOptions = {
+  isCustomElement: (tag: string) => boolean
+  whitespace: 'condense' | 'preserve'
+  delimiters: string[]
+  comments: boolean
+  nodeTransforms: ((...args: any) => void)[]
+}
 export interface IConfig {
   mini?: {
-    compilerOptions: {
-      isCustomElement: (tag: string) => boolean
-      whitespace: 'condense' | 'preserve'
-      delimiters: string[]
-      comments: boolean
-      nodeTransforms: ((...args: any) => void)[]
-    }
+    compilerOptions: CompilerOptions
+  },
+  vueLoaderOption?: {
+    compilerOptions: CompilerOptions
+    [key: string]: any
   }
 }
 
@@ -27,10 +32,10 @@ export default (ctx: IPluginContext, config: IConfig = {}) => {
 
     if (process.env.TARO_ENV === 'h5') {
       // H5
-      modifyH5WebpackChain(ctx, chain)
+      modifyH5WebpackChain(ctx, chain, data, config)
     } else {
       // 小程序
-      modifyMiniWebpackChain(ctx, chain, data, config.mini)
+      modifyMiniWebpackChain(ctx, chain, data, config)
     }
   })
 }

--- a/packages/taro-plugin-vue3/src/webpack.h5.ts
+++ b/packages/taro-plugin-vue3/src/webpack.h5.ts
@@ -5,12 +5,13 @@ import { getVueLoaderPath } from './index'
 
 import type { IPluginContext } from '@tarojs/service'
 import type { RootNode, TemplateChildNode, ElementNode } from '@vue/compiler-core'
+import type { IConfig } from './index'
 
-export function modifyH5WebpackChain (ctx: IPluginContext, chain) {
+export function modifyH5WebpackChain (ctx: IPluginContext, chain, __, config: IConfig) {
   // vue3 tsx 使用原生组件
   setAlias(chain)
   setStyleLoader(ctx, chain)
-  setVueLoader(chain)
+  setVueLoader(chain, config)
   setLoader(chain)
   setTaroApiLoader(chain)
 }
@@ -34,7 +35,7 @@ function setStyleLoader (ctx: IPluginContext, chain) {
     })
 }
 
-function setVueLoader (chain) {
+function setVueLoader (chain, config: IConfig) {
   const vueLoaderPath = getVueLoaderPath()
 
   // plugin
@@ -42,6 +43,8 @@ function setVueLoader (chain) {
   chain
     .plugin('vueLoaderPlugin')
     .use(VueLoaderPlugin)
+
+  const compilerOptions = config?.vueLoaderOption?.compilerOptions || {}
 
   // loader
   const vueLoaderOption = {
@@ -60,6 +63,7 @@ function setVueLoader (chain) {
       'taro-cover-image': 'src'
     },
     compilerOptions: {
+      ...compilerOptions,
       // https://github.com/vuejs/vue-next/blob/master/packages/compiler-core/src/options.ts
       nodeTransforms: [(node: RootNode | TemplateChildNode) => {
         if (node.type === 1 /* ELEMENT */) {
@@ -71,7 +75,8 @@ function setVueLoader (chain) {
           }
         }
       }]
-    }
+    },
+    ...(config?.vueLoaderOption ?? {})
   }
 
   chain.module

--- a/packages/taro-plugin-vue3/src/webpack.h5.ts
+++ b/packages/taro-plugin-vue3/src/webpack.h5.ts
@@ -7,7 +7,7 @@ import type { IPluginContext } from '@tarojs/service'
 import type { RootNode, TemplateChildNode, ElementNode } from '@vue/compiler-core'
 import type { IConfig } from './index'
 
-export function modifyH5WebpackChain (ctx: IPluginContext, chain, __, config: IConfig) {
+export function modifyH5WebpackChain (ctx: IPluginContext, chain, config: IConfig) {
   // vue3 tsx 使用原生组件
   setAlias(chain)
   setStyleLoader(ctx, chain)
@@ -44,8 +44,7 @@ function setVueLoader (chain, config: IConfig) {
     .plugin('vueLoaderPlugin')
     .use(VueLoaderPlugin)
 
-  const compilerOptions = config?.vueLoaderOption?.compilerOptions || {}
-
+  const compilerOptions = config.vueLoaderOption?.compilerOptions || {}
   // loader
   const vueLoaderOption = {
     transformAssetUrls: {
@@ -62,6 +61,7 @@ function setVueLoader (chain, config: IConfig) {
       'taro-image': 'src',
       'taro-cover-image': 'src'
     },
+    ...(config.vueLoaderOption ?? {}),
     compilerOptions: {
       ...compilerOptions,
       // https://github.com/vuejs/vue-next/blob/master/packages/compiler-core/src/options.ts
@@ -75,8 +75,7 @@ function setVueLoader (chain, config: IConfig) {
           }
         }
       }]
-    },
-    ...(config?.vueLoaderOption ?? {})
+    }
   }
 
   chain.module

--- a/packages/taro-plugin-vue3/src/webpack.mini.ts
+++ b/packages/taro-plugin-vue3/src/webpack.mini.ts
@@ -24,7 +24,7 @@ function setVueLoader (chain, data, config: IConfig) {
     .plugin('vueLoaderPlugin')
     .use(VueLoaderPlugin)
 
-  const compilerOptions = config?.vueLoaderOption?.compilerOptions || config?.mini?.compilerOptions || {}
+  const compilerOptions = config.vueLoaderOption?.compilerOptions || config.mini?.compilerOptions || {}
   // loader
   const vueLoaderOption: any = {
     optimizeSSR: false,
@@ -36,8 +36,8 @@ function setVueLoader (chain, data, config: IConfig) {
       image: 'src',
       'cover-image': 'src'
     },
-    compilerOptions,
-    ...(config?.vueLoaderOption ?? {})
+    ...(config.vueLoaderOption ?? {}),
+    compilerOptions
   }
 
   vueLoaderOption.compilerOptions.nodeTransforms ||= []

--- a/packages/taro-plugin-vue3/src/webpack.mini.ts
+++ b/packages/taro-plugin-vue3/src/webpack.mini.ts
@@ -9,15 +9,13 @@ import type { IConfig } from './index'
 
 const CUSTOM_WRAPPER = 'custom-wrapper'
 
-type MiniConfig = IConfig['mini']
-
-export function modifyMiniWebpackChain (_ctx: IPluginContext, chain, data, config: MiniConfig) {
+export function modifyMiniWebpackChain (_ctx: IPluginContext, chain, data, config: IConfig) {
   setVueLoader(chain, data, config)
   setLoader(chain)
   setDefinePlugin(chain)
 }
 
-function setVueLoader (chain, data, config: MiniConfig) {
+function setVueLoader (chain, data, config: IConfig) {
   const vueLoaderPath = getVueLoaderPath()
 
   // plugin
@@ -26,6 +24,7 @@ function setVueLoader (chain, data, config: MiniConfig) {
     .plugin('vueLoaderPlugin')
     .use(VueLoaderPlugin)
 
+  const compilerOptions = config?.vueLoaderOption?.compilerOptions || config?.mini?.compilerOptions || {}
   // loader
   const vueLoaderOption: any = {
     optimizeSSR: false,
@@ -37,11 +36,8 @@ function setVueLoader (chain, data, config: MiniConfig) {
       image: 'src',
       'cover-image': 'src'
     },
-    compilerOptions: {}
-  }
-
-  if (config?.compilerOptions) {
-    vueLoaderOption.compilerOptions = Object.assign({}, config.compilerOptions)
+    compilerOptions,
+    ...(config?.vueLoaderOption ?? {})
   }
 
   vueLoaderOption.compilerOptions.nodeTransforms ||= []


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

允许用户给插件 `@tarojs/plugin-framework-vue3` 传递配置项，以更改 `vue-loader` 配置项.
同时，调整 `compilerOptions` 参数的配置，优先读取 `vueLoaderOption` 内的参数:

```js
const config = {
plugins: [
    [
      "@tarojs/plugin-framework-vue3",
      {
        mini: {
          compilerOptions: {  // 兼容旧版配置
            hotReload: false
          },
        },
        vueLoaderOption: {
          reactivityTransform: true,
          compilerOptions: {  // 优先读取
            hotReload: true
          },
        },
      },
    ],
  ],
}
```


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
