### PR TITLE
fix: iOS screen is frozen when swiping to previous page

### DIFF
--- a/packages/taro-rn/src/lib/setClipboardData/index.ts
+++ b/packages/taro-rn/src/lib/setClipboardData/index.ts
@@ -18,6 +18,7 @@ export function setClipboardData(opts: Taro.setClipboardData.Option): Promise<Ta
     data,
   }
   showToast({
+    icon: "none",
     title: '内容已复制'
   })
   return successHandler(success, complete)(res)

--- a/packages/taro-router-rn/src/router.tsx
+++ b/packages/taro-router-rn/src/router.tsx
@@ -335,6 +335,7 @@ function createTabNavigate (config: RouterConfig) {
     linking={linking}
   >
     <Stack.Navigator
+      detachInactiveScreens={false}
       {...stackProps}
       screenOptions={screenOptions}
       initialRouteName={getInitRouteName(config)}
@@ -370,6 +371,7 @@ function createStackNavigate (config: RouterConfig) {
     linking={linking}
   >
     <Stack.Navigator
+      detachInactiveScreens={false}
       {...stackProps}
       screenOptions={getStackOptions(config)}
       initialRouteName={getInitRouteName(config)}


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

0. 修复生产环境下，iOS后退 crash https://github.com/react-navigation/react-navigation/issues/9015
1. setClipboardData 提示修改

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
