### PR TITLE
fix(h5): stencil slot 与 react render冲突问题 #11379

### DIFF
--- a/packages/taro-components/src/components/view/view.tsx
+++ b/packages/taro-components/src/components/view/view.tsx
@@ -64,7 +64,7 @@ export class View implements ComponentInterface {
   componentDidRender () {
     const el = this.el
     el.childNodes.forEach(item => {
-      if (item.nodeType === document.COMMENT_NODE) el.removeChild(item)
+      if (item.nodeType === document.COMMENT_NODE && item["s-cn"]) item["s-cn"] = false
     })
   }
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
解决原有处理stencil slot与react render冲突时删除注释节点引起的vue中语法失效的问题，改为判断是否是stencil插入的节点，并将其中的属性变更


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id fix #11379
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
