### PR TITLE
fix: 跳转进入到可下拉刷新的页面无法下拉刷新

### DIFF
--- a/packages/taro-components/src/components/pull-to-refresh/pull-to-refresh.tsx
+++ b/packages/taro-components/src/components/pull-to-refresh/pull-to-refresh.tsx
@@ -138,7 +138,7 @@ export class PullToRefresh implements ComponentInterface {
       touchcancel: this.onTouchEnd.bind(this, ele)
     }
     Object.keys(this._to).forEach(key => {
-      ele.addEventListener(key, this._to[key], willPreventDefault)
+      child.addEventListener(key, this._to[key], willPreventDefault)
     })
   }
 

--- a/packages/taro-components/src/components/pull-to-refresh/pull-to-refresh.tsx
+++ b/packages/taro-components/src/components/pull-to-refresh/pull-to-refresh.tsx
@@ -59,7 +59,7 @@ export class PullToRefresh implements ComponentInterface {
   private get scrollContainer () {
     return this.el.parentElement ||
       document.querySelector('.taro_page_stationed') ||
-      document.querySelector('.taro_page_show.taro_page') ||
+      document.querySelector('.taro_page') ||
       document.querySelector('.taro_router') ||
       document.querySelector('.taro-tabbar__panel') ||
       document.body

--- a/packages/taro-components/src/components/pull-to-refresh/pull-to-refresh.tsx
+++ b/packages/taro-components/src/components/pull-to-refresh/pull-to-refresh.tsx
@@ -57,8 +57,9 @@ export class PullToRefresh implements ComponentInterface {
   private _isMounted = false;
 
   private get scrollContainer () {
-    return document.querySelector('.taro_page_stationed') ||
-      document.querySelector('.taro_page') ||
+    return this.el.parentElement ||
+      document.querySelector('.taro_page_stationed') ||
+      document.querySelector('.taro_page_show.taro_page') ||
       document.querySelector('.taro_router') ||
       document.querySelector('.taro-tabbar__panel') ||
       document.body
@@ -126,11 +127,11 @@ export class PullToRefresh implements ComponentInterface {
 
   init = () => {
     const ele = this.scrollContainer
-    const child = this.el.childNodes[this.el.childNodes.length - 1].childNodes[0]
-    this.el.appendChild = child.appendChild.bind(child)
-    this.el.insertBefore = child.insertBefore.bind(child)
-    this.el.replaceChild = child.replaceChild.bind(child)
-    this.el.removeChild = child.removeChild.bind(child)
+    const child = this.el.querySelector('rmc-pull-to-refresh-content')
+    this.el.appendChild = child?.appendChild.bind(child)
+    this.el.insertBefore = child?.insertBefore.bind(child)
+    this.el.replaceChild = child?.replaceChild.bind(child)
+    this.el.removeChild = child?.removeChild.bind(child)
     this._to = {
       touchstart: this.onTouchStart.bind(this, ele),
       touchmove: this.onTouchMove.bind(this, ele),
@@ -138,7 +139,7 @@ export class PullToRefresh implements ComponentInterface {
       touchcancel: this.onTouchEnd.bind(this, ele)
     }
     Object.keys(this._to).forEach(key => {
-      child.addEventListener(key, this._to[key], willPreventDefault)
+      ele.addEventListener(key, this._to[key], willPreventDefault)
     })
   }
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复了跳转进入到可下拉刷新的页面无法下拉刷新


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id fix #11675 

**这个 PR 涉及以下平台:**

- [ ] 所有小程序（不确定）
- [ ] 快应用平台（QuickApp）（不确定）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）（不确定）
