### PR TITLE
WIP fix(runtime): restore custom wrapper data when instance changed

### DIFF
--- a/packages/taro-runtime/src/dsl/common.ts
+++ b/packages/taro-runtime/src/dsl/common.ts
@@ -1,5 +1,5 @@
 /* eslint-disable dot-notation */
-import { isFunction, EMPTY_OBJ, ensure, Shortcuts, isUndefined, isArray, isString } from '@tarojs/shared'
+import { isFunction, EMPTY_OBJ, ensure, Shortcuts, isUndefined, isArray, isString, isObject } from '@tarojs/shared'
 import { getHooks } from '../container/store'
 import { eventHandler } from '../dom/event'
 import { Current } from '../current'
@@ -295,6 +295,11 @@ export function createRecursiveComponentConfig (componentName?: string) {
       attached () {
         const componentId = this.data.i?.sid
         if (isString(componentId)) {
+          // CustomWrapper 组件实例可能会因为内存原因被引擎回收，当再度实例化时，为新的实例装填数据
+          const existedCustomWrapper = customWrapperCache.get(componentId)
+          if (existedCustomWrapper && isObject(existedCustomWrapper.data)) {
+            setTimeout(() => this.setData(existedCustomWrapper.data), 0)
+          }
           customWrapperCache.set(componentId, this)
         }
       },


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

修复当飞书小程序引擎出于内存等原因将 CustomWrapper 实例回收后，再次实例化时 CustomWrapper 无数据的问题

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix)
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序 issue id #11818
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
