### PR TITLE
feat(shared): 支持为第三方自定义组件的属性设置默认值，fix #11575

### DIFF
--- a/packages/shared/src/template.ts
+++ b/packages/shared/src/template.ts
@@ -22,6 +22,7 @@ import {
 import { Shortcuts } from './shortcuts'
 import { isBooleanStringLiteral, isNumber, isFunction } from './is'
 import { toCamelCase, toKebabCase, toDashed, hasOwn, indent, capitalize } from './utils'
+import { isString } from 'lodash'
 
 interface Component {
   nodeName: string;
@@ -79,6 +80,7 @@ export class BaseTemplate {
   protected isSupportRecursive: boolean
   protected supportXS = false
   protected miniComponents: Components
+  protected thirdPartyPatcher: Record<string, Record<string, string>> = {}
   protected modifyCompProps?: (compName: string, target: Record<string, string>) => Record<string, string>
   protected modifyLoopBody?: (child: string, nodeName: string) => string
   protected modifyLoopContainer?: (children: string, nodeName: string) => string
@@ -206,7 +208,7 @@ export class BaseTemplate {
 `
   }
 
-  protected buildThirdPartyAttr (attrs: Set<string>) {
+  protected buildThirdPartyAttr (attrs: Set<string>, patcher: Record<string, string> = {}) {
     return Array.from(attrs).reduce((str, attr) => {
       if (attr.startsWith('@')) {
         // vue2
@@ -231,6 +233,13 @@ export class BaseTemplate {
         return str + `style="{{i.${Shortcuts.Style}}}" `
       }
 
+      const patchValue = patcher[attr]
+      if (isBooleanStringLiteral(patchValue) || isNumber(patchValue) || isString(patchValue)) {
+        const propValue = this.supportXS
+          ? `xs.b(i.${toCamelCase(attr)},${patchValue})`
+          : `i.${toCamelCase(attr)}===undefined?${patchValue}:i.${toCamelCase(attr)}`
+        return str + `${attr}="{{${propValue}}}" `
+      }
       return str + `${attr}="{{i.${toCamelCase(attr)}}}" `
     }, '')
   }
@@ -375,7 +384,7 @@ export class BaseTemplate {
 
         template += `
 <template name="tmpl_${level}_${compName}">
-  <${compName} ${this.buildThirdPartyAttr(attrs)} id="{{i.uid||i.sid}}" data-sid="{{i.sid}}">
+  <${compName} ${this.buildThirdPartyAttr(attrs, this.thirdPartyPatcher[compName] || {})} id="{{i.uid||i.sid}}" data-sid="{{i.sid}}">
     <block ${Adapter.for}="{{i.${Shortcuts.Childnodes}}}" ${Adapter.key}="sid">
       ${child}
     </block>
@@ -479,6 +488,10 @@ export class BaseTemplate {
 
   public mergeComponents (ctx, patch: Record<string, Record<string, string>>) {
     ctx.helper.recursiveMerge(this.internalComponents, patch)
+  }
+
+  public mergeThirdPartyComponents (patch: Record<string, Record<string, string>>) {
+    this.thirdPartyPatcher = patch
   }
 
   protected buildXSTmplName () {

--- a/packages/shared/src/template.ts
+++ b/packages/shared/src/template.ts
@@ -20,9 +20,8 @@ import {
   singleQuote
 } from './components'
 import { Shortcuts } from './shortcuts'
-import { isBooleanStringLiteral, isNumber, isFunction } from './is'
+import { isBooleanStringLiteral, isNumber, isFunction, isString } from './is'
 import { toCamelCase, toKebabCase, toDashed, hasOwn, indent, capitalize } from './utils'
-import { isString } from 'lodash'
 
 interface Component {
   nodeName: string;


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

编译平台基类增加 `mergeThirdPartyComponents` 接口，支持为第三方自定义组件的属性设置默认值，fix #11575

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
