### PR TITLE
获取内网IP时，检查family范围放宽点

### DIFF
--- a/packages/taro-rn-runner/src/utils.ts
+++ b/packages/taro-rn-runner/src/utils.ts
@@ -6,7 +6,7 @@ export function getOpenHost () {
   for (const devName in interfaces) {
     const isEnd = interfaces[devName]?.some(item => {
       // 取IPv4, 不为127.0.0.1的内网ip
-      if (item.family === 'IPv4' && item.address !== '127.0.0.1' && !item.internal) {
+      if (['IPv4', 4, '4'].includes(item.family) && item.address !== '127.0.0.1' && !item.internal) {
         result = item.address
         return true
       }


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

修复node18下，启动taro rn时，不显示二维码的问题。

node18这个接口的结果类型有了一些变化，兼容一下比较好，参考 http://nodejs.cn/api/os/os_networkinterfaces.html

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
