### PR TITLE
fix: 修复 designWidth 配置为函数，cli 校验不通过的问题

### DIFF
--- a/packages/taro-cli/src/doctor/configSchema.ts
+++ b/packages/taro-cli/src/doctor/configSchema.ts
@@ -3,7 +3,7 @@ import * as Joi from 'joi'
 const schema = Joi.object().keys({
   projectName: Joi.string().required(),
   date: Joi.date(),
-  designWidth: Joi.number().integer().positive(),
+  designWidth: Joi.alternatives(Joi.number().integer().positive(), Joi.function()),
   deviceRatio: Joi.object().pattern(Joi.number(), Joi.number()),
   sourceRoot: Joi.string().required(),
   outputRoot: Joi.string().required(),


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

配置文件中的 [designWidth](https://taro-docs.jd.com/taro/docs/config-detail#designwidth) 支持配置为整数和函数，当配置为函数时，无法启动项目，会有报错。检查，发现校验schema少了项对函数的判断，在此加上。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
