### PR TITLE
fix: innerAudioContext paused

### DIFF
--- a/packages/taro-h5/src/api/media/audio/InnerAudioContext.ts
+++ b/packages/taro-h5/src/api/media/audio/InnerAudioContext.ts
@@ -28,7 +28,7 @@ export class InnerAudioContext implements Taro.InnerAudioContext {
   get duration () { return this.Instance?.duration || 0 }
   set loop (e) { this.setProperty('loop', e) }
   get loop () { return this.Instance?.loop || false }
-  get paused () { return this.Instance?.paused || true }
+  get paused () { return this.Instance?.paused ?? true }
   set src (e) { this.setProperty('src', e) }
   get src () { return this.Instance?.src || '' }
   set volume (e) { this.setProperty('volume', e) }


### PR DESCRIPTION
this.Instance?.paused 为 false 时 paused 会返回 true

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

把 `||`改成 `??` 以确保 `this.Instance?.paused = false`时可以返回 `false`

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #

**这个 PR 涉及以下平台:**

- [x] Web 平台（H5）
