### PR TITLE
feat: 支持传递函数作为三方组件参数

### DIFF
--- a/packages/shared/src/runtime-hooks.ts
+++ b/packages/shared/src/runtime-hooks.ts
@@ -195,7 +195,7 @@ type ITaroHooks = {
    * @todo: multi
    * 修改 Taro DOM 序列化数据
    **/
-  modifyHydrateData:(data: Record<string, any>) => void
+  modifyHydrateData: (data: Record<string, any>) => void
   /**
     * @todo: multi
     * 修改 Taro DOM 序列化数据
@@ -220,6 +220,10 @@ type ITaroHooks = {
   modifyDispatchEvent: (event, element) => void
   initNativeApi: (taro: Record<string, any>) => void
   patchElement: (node) => void
+  /** 用于修改 支付宝小程序传递函数参数 */
+  onSetThirdPartyComponentsEvent: (elemet, name: string, value: any) => void
+  /** 用于支付宝三方组件函数参数绑定至页面 */
+  bindFunctionPropertyToPage: (Current: { page: any }, dom: any, name: string, value: any) => void
 }
 
 export const hooks = new TaroHooks<ITaroHooks>({
@@ -297,5 +301,10 @@ export const hooks = new TaroHooks<ITaroHooks>({
 
   initNativeApi: TaroHook(HOOK_TYPE.MULTI),
 
-  patchElement: TaroHook(HOOK_TYPE.MULTI)
+  patchElement: TaroHook(HOOK_TYPE.MULTI),
+
+  onSetThirdPartyComponentsEvent: TaroHook(HOOK_TYPE.SINGLE),
+
+  bindFunctionPropertyToPage: TaroHook(HOOK_TYPE.SINGLE),
+
 })

--- a/packages/taro-alipay/src/runtime.ts
+++ b/packages/taro-alipay/src/runtime.ts
@@ -1,4 +1,4 @@
-import { mergeInternalComponents, mergeReconciler } from '@tarojs/shared'
+import { hooks, mergeInternalComponents, mergeReconciler } from '@tarojs/shared'
 
 import { components, hostConfig } from './runtime-utils'
 
@@ -10,6 +10,17 @@ Object.defineProperty(navigator, 'userAgent', {
   get () {
     return userAgent || (navigator as any).swuserAgent || ''
   }
+})
+
+hooks.tap('onSetThirdPartyComponentsEvent', (dom: any, name: string, value: any) => {
+  // 以on开头的参数成员，作为attr设置，最终给原生三方组件使用
+  dom.setAttribute(name, value)
+  dom.props[name] = value
+})
+
+hooks.tap('bindFunctionPropertyToPage', (Current:{page:any},dom: any, name: string, value: any) => {
+  // 如果是三方组件的函数，需要绑定到页面上进行处理
+  Current.page[`${dom.sid}${name}`] = value
 })
 
 mergeReconciler(hostConfig)

--- a/packages/taro-alipay/src/template.ts
+++ b/packages/taro-alipay/src/template.ts
@@ -50,7 +50,8 @@ export class Template extends RecursiveTemplate {
       } else if (attr.startsWith('bind')) {
         return str + `${attr}="eh" `
       } else if (attr.startsWith('on')) {
-        return str + `${attr}="eh" `
+        // 普通函数传递，使用页面上的函数实例
+        return str + `${attr}="{{ i.sid }}${toCamelCase(attr)}" `
       }
 
       return str + `${attr}="{{ i.${toCamelCase(attr)} }}" `

--- a/packages/taro-runtime/src/dom/element.ts
+++ b/packages/taro-runtime/src/dom/element.ts
@@ -1,4 +1,4 @@
-import { EMPTY_OBJ, hooks, isArray, isFunction, isObject, isString, isUndefined, Shortcuts, toCamelCase, warn } from '@tarojs/shared'
+import { capitalize, EMPTY_OBJ, hooks, internalComponents, isArray, isFunction, isObject, isString, isUndefined, Shortcuts, toCamelCase, warn } from '@tarojs/shared'
 
 import {
   CATCH_VIEW,
@@ -12,6 +12,7 @@ import {
   STYLE,
   VIEW
 } from '../constants'
+import { Current } from '../current'
 import { MutationObserver, MutationRecordType } from '../dom-external/mutation-observer'
 import type { Attributes, Func } from '../interface'
 import { extend, getComponentsAlias, isElement, isHasExtractProp, shortcutAttr } from '../utils'
@@ -161,6 +162,13 @@ export class TaroElement extends TaroNode {
         eventSource.set(value, this)
         break
       default:
+        // eslint-disable-next-line no-case-declarations
+        const isInternalComponents = (dom: TaroElement) => capitalize(toCamelCase(dom.tagName.toLowerCase())) in internalComponents
+
+        if (isFunction(value) && !isInternalComponents(this) && hooks.isExist('bindFunctionPropertyToPage')) {
+          hooks.call('bindFunctionPropertyToPage', Current, this, qualifiedName, value)
+        }
+        
         this.props[qualifiedName] = value as string
 
         if (qualifiedName.startsWith('data-')) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -523,12 +523,6 @@ importers:
       xml2js: registry.npmjs.org/xml2js/0.4.23
       xxhashjs: registry.npmjs.org/xxhashjs/0.2.2
 
-  packages/taro-cli/templates/wxcloud/cloud/functions/login:
-    specifiers:
-      wx-server-sdk: latest
-    dependencies:
-      wx-server-sdk: registry.npmjs.org/wx-server-sdk/2.6.3
-
   packages/taro-components:
     specifiers:
       '@stencil/core': ~2.13.0
@@ -970,6 +964,7 @@ importers:
 
   packages/taro-react:
     specifiers:
+      '@tarojs/react': ^3.5.0-theta.1
       '@tarojs/runtime': workspace:*
       '@tarojs/shared': workspace:*
       react-reconciler: 0.27.0
@@ -5765,75 +5760,6 @@ packages:
     version: 0.2.3
     dev: true
 
-  registry.npmjs.org/@cloudbase/database/0.9.15:
-    resolution: {integrity: sha512-63e7iIl+van41B39Tw4ScNe9TRCt+5GHjc7q6i8NzkWBLC3U3KlbWo79YHsUHUPI79POpQ8UMlMVo7HXIAO3dg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@cloudbase/database/-/database-0.9.15.tgz}
-    name: '@cloudbase/database'
-    version: 0.9.15
-    dependencies:
-      bson: registry.npmjs.org/bson/4.6.4
-      lodash.clonedeep: registry.npmjs.org/lodash.clonedeep/4.5.0
-      lodash.set: registry.npmjs.org/lodash.set/4.3.2
-      lodash.unset: registry.npmjs.org/lodash.unset/4.5.2
-    dev: false
-
-  registry.npmjs.org/@cloudbase/database/1.4.1:
-    resolution: {integrity: sha512-BYLXHS6c+WhxAvvdak8Z3W+heScqBBPu/CQ76gC8v1Scuy5qf4qxuPWNzyoxde/eZsmc+BRRCFyIq4xUnIot8g==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@cloudbase/database/-/database-1.4.1.tgz}
-    name: '@cloudbase/database'
-    version: 1.4.1
-    dependencies:
-      bson: registry.npmjs.org/bson/4.6.4
-      lodash.clonedeep: registry.npmjs.org/lodash.clonedeep/4.5.0
-      lodash.set: registry.npmjs.org/lodash.set/4.3.2
-      lodash.unset: registry.npmjs.org/lodash.unset/4.5.2
-    dev: false
-
-  registry.npmjs.org/@cloudbase/node-sdk/2.9.1:
-    resolution: {integrity: sha512-4JGLiy9/Ko7d1pnBgq5mtIUm5v9ig1tHqAeLrkMc8b4vVBRTnYlxJer3uKXq6+9fjLprxNyRSahEg4QR8/Gbkw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@cloudbase/node-sdk/-/node-sdk-2.9.1.tgz}
-    name: '@cloudbase/node-sdk'
-    version: 2.9.1
-    engines: {node: '>=8.6.0'}
-    dependencies:
-      '@cloudbase/database': registry.npmjs.org/@cloudbase/database/1.4.1
-      '@cloudbase/signature-nodejs': registry.npmjs.org/@cloudbase/signature-nodejs/1.0.0-beta.0
-      '@types/retry': registry.npmjs.org/@types/retry/0.12.0
-      agentkeepalive: registry.npmjs.org/agentkeepalive/4.2.1
-      axios: registry.npmjs.org/axios/0.21.4
-      is-regex: registry.npmjs.org/is-regex/1.1.4
-      jsonwebtoken: registry.npmjs.org/jsonwebtoken/8.5.1
-      lodash.merge: registry.npmjs.org/lodash.merge/4.6.2
-      request: registry.npmjs.org/request/2.88.2
-      request-promise: registry.npmjs.org/request-promise/4.2.6_request@2.88.2
-      retry: registry.npmjs.org/retry/0.12.0
-      ts-node: registry.npmjs.org/ts-node/8.10.2
-      xml2js: registry.npmjs.org/xml2js/0.4.23
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-      - typescript
-    dev: false
-
-  registry.npmjs.org/@cloudbase/signature-nodejs/1.0.0-beta.0:
-    resolution: {integrity: sha512-gpKqwsVk/D2PzvFamYNReymXSdvRSY90eZ1ARf+1wZ8oT6OpK9kr6nmevGykMxN1n17Gn92hBbWqAxU9o3+kAQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@cloudbase/signature-nodejs/-/signature-nodejs-1.0.0-beta.0.tgz}
-    name: '@cloudbase/signature-nodejs'
-    version: 1.0.0-beta.0
-    dependencies:
-      '@types/clone': registry.npmjs.org/@types/clone/0.1.30
-      clone: registry.npmjs.org/clone/2.1.2
-      is-stream: registry.npmjs.org/is-stream/2.0.1
-      url: registry.npmjs.org/url/0.11.0
-    dev: false
-
-  registry.npmjs.org/@cloudbase/signature-nodejs/1.1.0:
-    resolution: {integrity: sha512-Uqj7tbeAufyAl8xxHr0BxmO9mcfjYqs/FNTDif/38KeRRB438kRlnqd06nXNkJdJWgryw0xQGDxiywVxbAaLxg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@cloudbase/signature-nodejs/-/signature-nodejs-1.1.0.tgz}
-    name: '@cloudbase/signature-nodejs'
-    version: 1.1.0
-    dependencies:
-      '@types/clone': registry.npmjs.org/@types/clone/0.1.30
-      clone: registry.npmjs.org/clone/2.1.2
-      is-stream: registry.npmjs.org/is-stream/2.0.1
-      url: registry.npmjs.org/url/0.11.0
-    dev: false
-
   registry.npmjs.org/@cnakazawa/watch/1.0.4:
     resolution: {integrity: sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz}
     name: '@cnakazawa/watch'
@@ -7628,69 +7554,6 @@ packages:
       '@parcel/css-win32-x64-msvc': registry.npmjs.org/@parcel/css-win32-x64-msvc/1.10.1
     dev: false
 
-  registry.npmjs.org/@protobufjs/aspromise/1.1.2:
-    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz}
-    name: '@protobufjs/aspromise'
-    version: 1.1.2
-    dev: false
-
-  registry.npmjs.org/@protobufjs/base64/1.1.2:
-    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz}
-    name: '@protobufjs/base64'
-    version: 1.1.2
-    dev: false
-
-  registry.npmjs.org/@protobufjs/codegen/2.0.4:
-    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz}
-    name: '@protobufjs/codegen'
-    version: 2.0.4
-    dev: false
-
-  registry.npmjs.org/@protobufjs/eventemitter/1.1.0:
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz}
-    name: '@protobufjs/eventemitter'
-    version: 1.1.0
-    dev: false
-
-  registry.npmjs.org/@protobufjs/fetch/1.1.0:
-    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz}
-    name: '@protobufjs/fetch'
-    version: 1.1.0
-    dependencies:
-      '@protobufjs/aspromise': registry.npmjs.org/@protobufjs/aspromise/1.1.2
-      '@protobufjs/inquire': registry.npmjs.org/@protobufjs/inquire/1.1.0
-    dev: false
-
-  registry.npmjs.org/@protobufjs/float/1.0.2:
-    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz}
-    name: '@protobufjs/float'
-    version: 1.0.2
-    dev: false
-
-  registry.npmjs.org/@protobufjs/inquire/1.1.0:
-    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz}
-    name: '@protobufjs/inquire'
-    version: 1.1.0
-    dev: false
-
-  registry.npmjs.org/@protobufjs/path/1.1.2:
-    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz}
-    name: '@protobufjs/path'
-    version: 1.1.2
-    dev: false
-
-  registry.npmjs.org/@protobufjs/pool/1.1.0:
-    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz}
-    name: '@protobufjs/pool'
-    version: 1.1.0
-    dev: false
-
-  registry.npmjs.org/@protobufjs/utf8/1.1.0:
-    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz}
-    name: '@protobufjs/utf8'
-    version: 1.1.0
-    dev: false
-
   registry.npmjs.org/@react-native-async-storage/async-storage/1.15.17_react-native@0.68.2:
     resolution: {integrity: sha512-NQCFs47aFEch9kya/bqwdpvSdZaVRtzU7YB02L8VrmLSLpKgQH/1VwzFUBPcc1/JI1s3GU4yOLVrEbwxq+Fqcw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.17.tgz}
     id: registry.npmjs.org/@react-native-async-storage/async-storage/1.15.17
@@ -8193,6 +8056,7 @@ packages:
     dependencies:
       '@babel/helper-module-imports': registry.npmjs.org/@babel/helper-module-imports/7.16.7
       '@rollup/pluginutils': registry.npmjs.org/@rollup/pluginutils/3.1.0
+    dev: false
 
   registry.npmjs.org/@rollup/plugin-babel/5.3.1_jdbmuitb4lfrmgnwxssk2saqxq:
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz}
@@ -8245,6 +8109,7 @@ packages:
       is-reference: registry.npmjs.org/is-reference/1.2.1
       magic-string: registry.npmjs.org/magic-string/0.25.9
       resolve: registry.npmjs.org/resolve/1.22.1
+    dev: false
 
   registry.npmjs.org/@rollup/plugin-commonjs/20.0.0_rollup@2.75.7:
     resolution: {integrity: sha512-5K0g5W2Ol8hAcTHqcTBHiA7M58tfmYi1o9KxeJuuRNpGaTa5iLjcyemBitCBcKXaHamOBBEH2dGom6v6Unmqjg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-20.0.0.tgz}
@@ -9059,12 +8924,6 @@ packages:
     version: 0.12.2
     dev: true
 
-  registry.npmjs.org/@types/clone/0.1.30:
-    resolution: {integrity: sha512-vcxBr+ybljeSiasmdke1cQ9ICxoEwaBgM1OQ/P5h4MPj/kRyLcDl5L8PrftlbyV1kBbJIs3M3x1A1+rcWd4mEA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/clone/-/clone-0.1.30.tgz}
-    name: '@types/clone'
-    version: 0.1.30
-    dev: false
-
   registry.npmjs.org/@types/connect-history-api-fallback/1.3.5:
     resolution: {integrity: sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz}
     name: '@types/connect-history-api-fallback'
@@ -9304,12 +9163,6 @@ packages:
     resolution: {integrity: sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz}
     name: '@types/lodash'
     version: 4.14.182
-
-  registry.npmjs.org/@types/long/4.0.2:
-    resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz}
-    name: '@types/long'
-    version: 4.0.2
-    dev: false
 
   registry.npmjs.org/@types/mdast/3.0.10:
     resolution: {integrity: sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz}
@@ -9774,6 +9627,7 @@ packages:
       debug: registry.npmjs.org/debug/4.3.4
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   registry.npmjs.org/@typescript-eslint/parser/5.29.0_qt5lczejmvvdmrtns7px3uxl6e:
     resolution: {integrity: sha512-ruKWTv+x0OOxbzIw9nW5oWlUopvP/IQDjB5ZqmTglLIoDTctLlAJpAQFpNPJP/ZI7hTT9sARBosEfaKbcFuECw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.29.0.tgz}
@@ -10905,19 +10759,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  registry.npmjs.org/agentkeepalive/4.2.1:
-    resolution: {integrity: sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz}
-    name: agentkeepalive
-    version: 4.2.1
-    engines: {node: '>= 8.0.0'}
-    dependencies:
-      debug: registry.npmjs.org/debug/4.3.4
-      depd: registry.npmjs.org/depd/1.1.2
-      humanize-ms: registry.npmjs.org/humanize-ms/1.2.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   registry.npmjs.org/aggregate-error/3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz}
     name: aggregate-error
@@ -11344,6 +11185,7 @@ packages:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/arg/-/arg-4.1.3.tgz}
     name: arg
     version: 4.1.3
+    dev: true
 
   registry.npmjs.org/argparse/1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz}
@@ -11753,16 +11595,6 @@ packages:
     resolution: {integrity: sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz}
     name: aws4
     version: 1.11.0
-
-  registry.npmjs.org/axios/0.21.4:
-    resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/axios/-/axios-0.21.4.tgz}
-    name: axios
-    version: 0.21.4
-    dependencies:
-      follow-redirects: registry.npmjs.org/follow-redirects/1.15.1
-    transitivePeerDependencies:
-      - debug
-    dev: false
 
   registry.npmjs.org/babel-code-frame/6.26.0:
     resolution: {integrity: sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz}
@@ -13346,12 +13178,6 @@ packages:
     name: big.js
     version: 5.2.2
 
-  registry.npmjs.org/bignumber.js/9.0.2:
-    resolution: {integrity: sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz}
-    name: bignumber.js
-    version: 9.0.2
-    dev: false
-
   registry.npmjs.org/bin-check/4.1.0:
     resolution: {integrity: sha512-b6weQyEUKsDGFlACWSIOfveEnImkJyK/FGW6FAG42loyoquvjdtOIqO6yBFzHyqyVVhNgNkQxxx09SFLK28YnA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/bin-check/-/bin-check-4.1.0.tgz}
     name: bin-check
@@ -13783,15 +13609,6 @@ packages:
     dependencies:
       node-int64: registry.npmjs.org/node-int64/0.4.0
 
-  registry.npmjs.org/bson/4.6.4:
-    resolution: {integrity: sha512-TdQ3FzguAu5HKPPlr0kYQCyrYUYh8tFM+CMTpxjNzVzxeiJY00Rtuj3LXLHSgiGvmaWlZ8PE+4KyM2thqE38pQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/bson/-/bson-4.6.4.tgz}
-    name: bson
-    version: 4.6.4
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      buffer: registry.npmjs.org/buffer/5.7.1
-    dev: false
-
   registry.npmjs.org/buble/0.20.0:
     resolution: {integrity: sha512-/1gnaMQE8xvd5qsNBl+iTuyjJ9XxeaVxAMF86dQ4EyxFJOZtsgOS8Ra+7WHgZTam5IFDtt4BguN0sH0tVTKrOw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/buble/-/buble-0.20.0.tgz}
     name: buble
@@ -13824,12 +13641,6 @@ packages:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz}
     name: buffer-crc32
     version: 0.2.13
-
-  registry.npmjs.org/buffer-equal-constant-time/1.0.1:
-    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz}
-    name: buffer-equal-constant-time
-    version: 1.0.1
-    dev: false
 
   registry.npmjs.org/buffer-equal/0.0.1:
     resolution: {integrity: sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz}
@@ -17527,14 +17338,6 @@ packages:
     dependencies:
       jsbn: registry.npmjs.org/jsbn/0.1.1
       safer-buffer: registry.npmjs.org/safer-buffer/2.1.2
-
-  registry.npmjs.org/ecdsa-sig-formatter/1.0.11:
-    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz}
-    name: ecdsa-sig-formatter
-    version: 1.0.11
-    dependencies:
-      safe-buffer: registry.npmjs.org/safe-buffer/5.2.1
-    dev: false
 
   registry.npmjs.org/edge-paths/2.2.1:
     resolution: {integrity: sha512-AI5fC7dfDmCdKo3m5y7PkYE8m6bMqR6pvVpgtrZkkhcJXFLelUgkjrhk3kXXx8Kbw2cRaTT4LkOR7hqf39KJdw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/edge-paths/-/edge-paths-2.2.1.tgz}
@@ -22089,14 +21892,6 @@ packages:
     engines: {node: '>=12.20.0'}
     dev: true
 
-  registry.npmjs.org/humanize-ms/1.2.1:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz}
-    name: humanize-ms
-    version: 1.2.1
-    dependencies:
-      ms: registry.npmjs.org/ms/2.1.3
-    dev: false
-
   registry.npmjs.org/humanize-url/1.0.1:
     resolution: {integrity: sha512-RtgTzXCPVb/te+e82NDhAc5paj+DuKSratIGAr+v+HZK24eAQ8LMoBGYoL7N/O+9iEc33AKHg45dOMKw3DNldQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/humanize-url/-/humanize-url-1.0.1.tgz}
     name: humanize-url
@@ -24532,14 +24327,6 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  registry.npmjs.org/json-bigint/1.0.0:
-    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz}
-    name: json-bigint
-    version: 1.0.0
-    dependencies:
-      bignumber.js: registry.npmjs.org/bignumber.js/9.0.2
-    dev: false
-
   registry.npmjs.org/json-buffer/3.0.0:
     resolution: {integrity: sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz}
     name: json-buffer
@@ -24690,24 +24477,6 @@ packages:
     version: 1.4.1
     dev: false
 
-  registry.npmjs.org/jsonwebtoken/8.5.1:
-    resolution: {integrity: sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz}
-    name: jsonwebtoken
-    version: 8.5.1
-    engines: {node: '>=4', npm: '>=1.4.28'}
-    dependencies:
-      jws: registry.npmjs.org/jws/3.2.2
-      lodash.includes: registry.npmjs.org/lodash.includes/4.3.0
-      lodash.isboolean: registry.npmjs.org/lodash.isboolean/3.0.3
-      lodash.isinteger: registry.npmjs.org/lodash.isinteger/4.0.4
-      lodash.isnumber: registry.npmjs.org/lodash.isnumber/3.0.3
-      lodash.isplainobject: registry.npmjs.org/lodash.isplainobject/4.0.6
-      lodash.isstring: registry.npmjs.org/lodash.isstring/4.0.1
-      lodash.once: registry.npmjs.org/lodash.once/4.1.1
-      ms: registry.npmjs.org/ms/2.1.3
-      semver: registry.npmjs.org/semver/5.7.1
-    dev: false
-
   registry.npmjs.org/jsprim/1.4.2:
     resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz}
     name: jsprim
@@ -24762,25 +24531,6 @@ packages:
     name: just-extend
     version: 4.2.1
     dev: true
-
-  registry.npmjs.org/jwa/1.4.1:
-    resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz}
-    name: jwa
-    version: 1.4.1
-    dependencies:
-      buffer-equal-constant-time: registry.npmjs.org/buffer-equal-constant-time/1.0.1
-      ecdsa-sig-formatter: registry.npmjs.org/ecdsa-sig-formatter/1.0.11
-      safe-buffer: registry.npmjs.org/safe-buffer/5.2.1
-    dev: false
-
-  registry.npmjs.org/jws/3.2.2:
-    resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/jws/-/jws-3.2.2.tgz}
-    name: jws
-    version: 3.2.2
-    dependencies:
-      jwa: registry.npmjs.org/jwa/1.4.1
-      safe-buffer: registry.npmjs.org/safe-buffer/5.2.1
-    dev: false
 
   registry.npmjs.org/karma-chrome-launcher/3.1.1:
     resolution: {integrity: sha512-hsIglcq1vtboGPAN+DGCISCFOxW+ZVnIqhDQcCMqqCp+4dmJ0Qpq5QAjkbA0X2L9Mi6OBkHi2Srrbmm7pUKkzQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-3.1.1.tgz}
@@ -25485,35 +25235,11 @@ packages:
     version: 4.4.0
     dev: true
 
-  registry.npmjs.org/lodash.includes/4.3.0:
-    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz}
-    name: lodash.includes
-    version: 4.3.0
-    dev: false
-
-  registry.npmjs.org/lodash.isboolean/3.0.3:
-    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz}
-    name: lodash.isboolean
-    version: 3.0.3
-    dev: false
-
-  registry.npmjs.org/lodash.isinteger/4.0.4:
-    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz}
-    name: lodash.isinteger
-    version: 4.0.4
-    dev: false
-
   registry.npmjs.org/lodash.ismatch/4.4.0:
     resolution: {integrity: sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz}
     name: lodash.ismatch
     version: 4.4.0
     dev: true
-
-  registry.npmjs.org/lodash.isnumber/3.0.3:
-    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz}
-    name: lodash.isnumber
-    version: 3.0.3
-    dev: false
 
   registry.npmjs.org/lodash.isobject/3.0.2:
     resolution: {integrity: sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz}
@@ -25525,12 +25251,7 @@ packages:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz}
     name: lodash.isplainobject
     version: 4.0.6
-
-  registry.npmjs.org/lodash.isstring/4.0.1:
-    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz}
-    name: lodash.isstring
-    version: 4.0.1
-    dev: false
+    dev: true
 
   registry.npmjs.org/lodash.kebabcase/4.1.1:
     resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz}
@@ -25547,18 +25268,6 @@ packages:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz}
     name: lodash.merge
     version: 4.6.2
-
-  registry.npmjs.org/lodash.once/4.1.1:
-    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz}
-    name: lodash.once
-    version: 4.1.1
-    dev: false
-
-  registry.npmjs.org/lodash.set/4.3.2:
-    resolution: {integrity: sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz}
-    name: lodash.set
-    version: 4.3.2
-    dev: false
 
   registry.npmjs.org/lodash.sortby/4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz}
@@ -25603,12 +25312,6 @@ packages:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz}
     name: lodash.uniq
     version: 4.5.0
-
-  registry.npmjs.org/lodash.unset/4.5.2:
-    resolution: {integrity: sha512-bwKX88k2JhCV9D1vtE8+naDKlLiGrSmf8zi/Y9ivFHwbmRfA8RxS/aVJ+sIht2XOwqoNr4xUPUkGZpc1sHFEKg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/lodash.unset/-/lodash.unset-4.5.2.tgz}
-    name: lodash.unset
-    version: 4.5.2
-    dev: false
 
   registry.npmjs.org/lodash.zip/4.2.0:
     resolution: {integrity: sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz}
@@ -25708,12 +25411,6 @@ packages:
     dependencies:
       '@sinonjs/commons': registry.npmjs.org/@sinonjs/commons/1.8.3
     dev: true
-
-  registry.npmjs.org/long/4.0.0:
-    resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/long/-/long-4.0.0.tgz}
-    name: long
-    version: 4.0.0
-    dev: false
 
   registry.npmjs.org/longest-streak/2.0.4:
     resolution: {integrity: sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz}
@@ -25838,6 +25535,7 @@ packages:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz}
     name: make-error
     version: 1.3.6
+    dev: true
 
   registry.npmjs.org/makeerror/1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz}
@@ -30708,28 +30406,6 @@ packages:
     name: proto-list
     version: 1.2.4
 
-  registry.npmjs.org/protobufjs/6.11.3:
-    resolution: {integrity: sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz}
-    name: protobufjs
-    version: 6.11.3
-    hasBin: true
-    requiresBuild: true
-    dependencies:
-      '@protobufjs/aspromise': registry.npmjs.org/@protobufjs/aspromise/1.1.2
-      '@protobufjs/base64': registry.npmjs.org/@protobufjs/base64/1.1.2
-      '@protobufjs/codegen': registry.npmjs.org/@protobufjs/codegen/2.0.4
-      '@protobufjs/eventemitter': registry.npmjs.org/@protobufjs/eventemitter/1.1.0
-      '@protobufjs/fetch': registry.npmjs.org/@protobufjs/fetch/1.1.0
-      '@protobufjs/float': registry.npmjs.org/@protobufjs/float/1.0.2
-      '@protobufjs/inquire': registry.npmjs.org/@protobufjs/inquire/1.1.0
-      '@protobufjs/path': registry.npmjs.org/@protobufjs/path/1.1.2
-      '@protobufjs/pool': registry.npmjs.org/@protobufjs/pool/1.1.0
-      '@protobufjs/utf8': registry.npmjs.org/@protobufjs/utf8/1.1.0
-      '@types/long': registry.npmjs.org/@types/long/4.0.2
-      '@types/node': registry.npmjs.org/@types/node/18.0.0
-      long: registry.npmjs.org/long/4.0.0
-    dev: false
-
   registry.npmjs.org/proxy-addr/2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz}
     name: proxy-addr
@@ -32146,23 +31822,6 @@ packages:
     peerDependencies:
       request: ^2.34
     dependencies:
-      request: registry.npmjs.org/request/2.88.2
-      request-promise-core: registry.npmjs.org/request-promise-core/1.1.4_request@2.88.2
-      stealthy-require: registry.npmjs.org/stealthy-require/1.1.1
-      tough-cookie: registry.npmjs.org/tough-cookie/2.5.0
-    dev: false
-
-  registry.npmjs.org/request-promise/4.2.6_request@2.88.2:
-    resolution: {integrity: sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz}
-    id: registry.npmjs.org/request-promise/4.2.6
-    name: request-promise
-    version: 4.2.6
-    engines: {node: '>=0.10.0'}
-    deprecated: request-promise has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142
-    peerDependencies:
-      request: ^2.34
-    dependencies:
-      bluebird: registry.npmjs.org/bluebird/3.7.2
       request: registry.npmjs.org/request/2.88.2
       request-promise-core: registry.npmjs.org/request-promise-core/1.1.4_request@2.88.2
       stealthy-require: registry.npmjs.org/stealthy-require/1.1.1
@@ -35113,21 +34772,6 @@ packages:
       mkdirp: registry.npmjs.org/mkdirp/1.0.4
       yallist: registry.npmjs.org/yallist/4.0.0
 
-  registry.npmjs.org/tcb-admin-node/1.23.0:
-    resolution: {integrity: sha512-SAbjTqMsSi63SId1BJ4kWdyGJzhxh9Tjvy3YXxcsoaAC2PtASn4UIYsBsiNEUfcn58QEn2tdvCvvf69WLLjjrg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/tcb-admin-node/-/tcb-admin-node-1.23.0.tgz}
-    name: tcb-admin-node
-    version: 1.23.0
-    engines: {node: '>=8.6.0'}
-    dependencies:
-      '@cloudbase/database': registry.npmjs.org/@cloudbase/database/0.9.15
-      '@cloudbase/signature-nodejs': registry.npmjs.org/@cloudbase/signature-nodejs/1.1.0
-      is-regex: registry.npmjs.org/is-regex/1.1.4
-      jsonwebtoken: registry.npmjs.org/jsonwebtoken/8.5.1
-      lodash.merge: registry.npmjs.org/lodash.merge/4.6.2
-      request: registry.npmjs.org/request/2.88.2
-      xml2js: registry.npmjs.org/xml2js/0.4.23
-    dev: false
-
   registry.npmjs.org/temp-dir/1.0.0:
     resolution: {integrity: sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz}
     name: temp-dir
@@ -35747,22 +35391,6 @@ packages:
       v8-compile-cache-lib: registry.npmjs.org/v8-compile-cache-lib/3.0.1
       yn: registry.npmjs.org/yn/3.1.1
     dev: true
-
-  registry.npmjs.org/ts-node/8.10.2:
-    resolution: {integrity: sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz}
-    name: ts-node
-    version: 8.10.2
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    peerDependencies:
-      typescript: '>=2.7'
-    dependencies:
-      arg: registry.npmjs.org/arg/4.1.3
-      diff: registry.npmjs.org/diff/4.0.2
-      make-error: registry.npmjs.org/make-error/1.3.6
-      source-map-support: registry.npmjs.org/source-map-support/0.5.21
-      yn: registry.npmjs.org/yn/3.1.1
-    dev: false
 
   registry.npmjs.org/tsconfig-paths/3.14.1:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz}
@@ -37215,6 +36843,7 @@ packages:
       - debug
       - supports-color
       - utf-8-validate
+    dev: false
 
   registry.npmjs.org/webpack-dev-server/4.7.4_webpack@5.69.0:
     resolution: {integrity: sha512-nfdsb02Zi2qzkNmgtZjkrMOcXnYZ6FLKcQwpxT7MvmHKc+oTtDsBju8j+NMyAygZ9GW1jMEUpy3itHtqgEhe1A==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.7.4.tgz}
@@ -37902,22 +37531,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  registry.npmjs.org/wx-server-sdk/2.6.3:
-    resolution: {integrity: sha512-wCSAO94HScMVnalb4WVbOqjTyKxus4/jPYV41ct9liHXv/hGGlDqUWV1vb1icyQKXp+mSslvpBNNjYnZAM5MVA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/wx-server-sdk/-/wx-server-sdk-2.6.3.tgz}
-    name: wx-server-sdk
-    version: 2.6.3
-    dependencies:
-      '@cloudbase/node-sdk': registry.npmjs.org/@cloudbase/node-sdk/2.9.1
-      json-bigint: registry.npmjs.org/json-bigint/1.0.0
-      protobufjs: registry.npmjs.org/protobufjs/6.11.3
-      tcb-admin-node: registry.npmjs.org/tcb-admin-node/1.23.0
-      tslib: registry.npmjs.org/tslib/1.14.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-      - typescript
-    dev: false
-
   registry.npmjs.org/wxml-minifier/0.0.1:
     resolution: {integrity: sha512-g8ZS4fyLdyRIcExnevKTnAFxbtYlAPKBGFO1DXOcsJfmppQWjH2xe2Ff6rRQ2ubYAWalaNjMYpkAl6hurhqkHg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/wxml-minifier/-/wxml-minifier-0.0.1.tgz}
     name: wxml-minifier
@@ -38173,6 +37786,7 @@ packages:
     name: yn
     version: 3.1.1
     engines: {node: '>=6'}
+    dev: true
 
   registry.npmjs.org/yocto-queue/0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz}


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
**支持传递函数作为参数给三方组件使用，修复关联issue；**
支持如下传入函数参数：
```typescript
import { Component } from 'react'
import { View, Text } from '@tarojs/components'
import './index.scss'
import Component2 from './component'

export default class Index extends Component {
  handleCustomClick = (...args) => {
    console.log('child custom component clicked',...args)
  }
  render() {
    return (
      <View className='index'>
        {/* 三方原生组件 */}
        <custom-comp1
          onComponentClick={this.handleCustomClick}
          onComponentClick1={this.handleCustomClick}
          onComponentClick2={this.handleCustomClick}
          onComponentClick23={this.handleCustomClick}
          onComponentClick4={this.handleCustomClick}
          onComponentClick5={this.handleCustomClick}
          componentClick={this.handleCustomClick}
          someAttr='1'
        ></custom-comp1>
        <Component2 queryParams={this.handleCustomClick} onClick={this.handleCustomClick} />
        <view onTap={this.handleCustomClick}>内置原生组件</view>
      </View>
    )
  }
}
```

主要改动：
修改了`@tarojs/plugin-platform-alipay`，使其支持三方组件函数传参，不走原来的事件合成管理逻辑，本身这类参数也是三方组件内部的逻辑，不属于原生事件，注意：**遵循小程序自定义组件参数绑定规则，函数需要在page实例上实现**
修改了`@tarojs/react`,在设置函数类属性的时候判断是否为三方组件，如果是，透传属性到attr（以on开头的）和props（普通函数）；
修改了`@tarojs/runtime`,在setAttribute时判断时三方组件且参数为函数，绑定到页面实例上，供三方组件使用；


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #11992
- [ ] 新功能(Feature)
- [x] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [x] 其他，请描述(Other, please describe):


**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [x] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
