### PR TITLE
fix(h5 webpack5): h5plugin pageName in view of os

### DIFF
--- a/packages/taro-webpack5-runner/src/plugins/H5Plugin.ts
+++ b/packages/taro-webpack5-runner/src/plugins/H5Plugin.ts
@@ -79,7 +79,7 @@ export default class H5Plugin {
         if (!suffixRgx.test(name)) return
 
         const filePath = path.join(dir, name)
-        const pageName = filePath.replace(sourceDir + process.platform === 'win32' ? '\\' : '/', '').replace(suffixRgx, '')
+        const pageName = filePath.replace(sourceDir + (process.platform === 'win32' ? '\\' : '/'), '').replace(suffixRgx, '')
         const routerMode = routerConfig?.mode || 'hash'
         const isMultiRouterMode = routerMode === 'multi'
         const isApp = !isMultiRouterMode && pageName === entryFileName

--- a/packages/taro-webpack5-runner/src/plugins/H5Plugin.ts
+++ b/packages/taro-webpack5-runner/src/plugins/H5Plugin.ts
@@ -79,7 +79,7 @@ export default class H5Plugin {
         if (!suffixRgx.test(name)) return
 
         const filePath = path.join(dir, name)
-        const pageName = filePath.replace(sourceDir + '/', '').replace(suffixRgx, '')
+        const pageName = filePath.replace(sourceDir + process.platform === 'win32' ? '\\' : '/', '').replace(suffixRgx, '')
         const routerMode = routerConfig?.mode || 'hash'
         const isMultiRouterMode = routerMode === 'multi'
         const isApp = !isMultiRouterMode && pageName === entryFileName


### PR DESCRIPTION
h5plugin get pageName in view of os.修复从filePath获取pageName时没考虑到Windows路径问题，这个问题会导致编译H5端失败.

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复webpack5-runner h5plugin 获取pageName未考虑Windows系统路径问题


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #11872
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
