### PR TITLE
feat(components-rn): enable access to rn native View ref

### DIFF
--- a/packages/taro-components-rn/src/components/View/PropsType.tsx
+++ b/packages/taro-components-rn/src/components/View/PropsType.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { StyleProp, ViewStyle, ViewProps } from 'react-native'
 
 export interface _ViewProps extends ViewProps {
+  _ref?: React.Ref<any>
   className?: string;
   style?: StyleProp<ViewStyle>;
   children?: React.ReactNode;

--- a/packages/taro-components-rn/src/components/View/index.tsx
+++ b/packages/taro-components-rn/src/components/View/index.tsx
@@ -26,6 +26,7 @@ const _View: React.FC<_ViewProps> = (props: _ViewProps) => {
   const child = Array.isArray(props.children) ? props.children.map((c: any, i: number) => stringToText(c, { key: i, ...props, style: textStyle })) : stringToText(props.children, { ...props, style: textStyle })
   return (
     <View
+      ref={props._ref}
       style={props.style}
       {...props}
     >


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

在React Native端可以获取到原生View组件的ref引用，从上层组件View可透传属性_ref进行获取（防止与Taro View的ref冲突）

1. 可以调用原生View上的方法或者属性
2. 可以使用React Native measure相关的API获取当前原生View节点在屏幕上的位置

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
