### PR TITLE
feat(components-rn): enable access to rn native View ref

### DIFF
--- a/packages/taro-components-rn/src/components/ClickableSimplified/index.tsx
+++ b/packages/taro-components-rn/src/components/ClickableSimplified/index.tsx
@@ -13,9 +13,8 @@
 
 import * as React from 'react'
 import {
-  PanResponder,
   GestureResponderEvent,
-  GestureResponderHandlers,
+  GestureResponderHandlers, PanResponder
 } from 'react-native'
 import { omit } from '../../utils'
 import { ClickableProps } from './PropsType'
@@ -47,6 +46,7 @@ export default function <P extends Record<string, any>>(WrappedComponent: React.
       isHover: false
     }
 
+    $ref = React.createRef<any>()
     startTimestamp = 0
     startTimer: any
     stayTimer: any
@@ -191,12 +191,13 @@ export default function <P extends Record<string, any>>(WrappedComponent: React.
         !onTouchEnd
       ) {
         return (
-          <WrappedComponent {...this.props} />
+          <WrappedComponent ref={this.$ref} {...this.props} />
         )
       }
 
       return (
         <WrappedComponent
+          ref={this.$ref}
           {...omit(this.props, [
             'style',
             'hoverStyle',

--- a/packages/taro-components-rn/src/components/View/index.tsx
+++ b/packages/taro-components-rn/src/components/View/index.tsx
@@ -20,19 +20,20 @@ const stringToText = (child: any, props: any) => {
     ? <Text {...omit(props, clickableHandlers)}>{child}</Text> : child
 }
 
-const _View: React.FC<_ViewProps> = (props: _ViewProps) => {
+const _View: React.ForwardRefExoticComponent<_ViewProps & React.RefAttributes<any>> = React.forwardRef((props: _ViewProps, ref: React.ForwardedRef<any>) => {
   const textStyle = extracteTextStyle(props.style)
   // 兼容View中没用Text包裹的文字 防止报错 直接继承props在安卓中文字会消失？？？
   const child = Array.isArray(props.children) ? props.children.map((c: any, i: number) => stringToText(c, { key: i, ...props, style: textStyle })) : stringToText(props.children, { ...props, style: textStyle })
   return (
     <View
+      ref={ref}
       style={props.style}
       {...props}
     >
       {child}
     </View>
   )
-}
+})
 
 _View.displayName = '_View'
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

在React Native端可以获取到原生View组件的ref引用，将原生View组件的ref挂在ref.current.$ref属性上

1. 可以调用ref.current.$ref.current来使用原生View上的方法或者属性
2. 可以使用React Native measure相关的API获取当前原生View节点在屏幕上的位置

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
