### PR TITLE
fix(h5): devserver publicPath error

### DIFF
--- a/packages/taro-webpack5-prebundle/src/h5.ts
+++ b/packages/taro-webpack5-prebundle/src/h5.ts
@@ -29,6 +29,7 @@ import webpack, { Stats } from 'webpack'
 import webpackDevServer from 'webpack-dev-server'
 import VirtualModulesPlugin from 'webpack-virtual-modules'
 
+import type { IPrebundle } from './prebundle'
 import BasePrebundle, { IPrebundleConfig } from './prebundle'
 import {
   createResolve,
@@ -48,6 +49,12 @@ export interface IH5PrebundleConfig extends IPrebundleConfig {
 }
 
 export class H5Prebundle extends BasePrebundle<IH5PrebundleConfig> {
+  publicPath: string
+  constructor (protected config: IH5PrebundleConfig, protected option: IPrebundle) {
+    super(config, option)
+    this.publicPath = parsePublicPath(this.config.publicPath)
+  }
+
   async buildLib () {
     const BUILD_LIB_START = performance.now()
 
@@ -55,13 +62,12 @@ export class H5Prebundle extends BasePrebundle<IH5PrebundleConfig> {
     const mode = process.env.NODE_ENV === 'production' ? 'production' : 'development'
     const devtool = this.config.enableSourceMap && 'hidden-source-map'
     const mainBuildOutput = this.chain.output.entries()
-    const publicPath = parsePublicPath(this.config.publicPath)
     const output = {
       chunkFilename: this.config.chunkFilename,
       chunkLoadingGlobal: mainBuildOutput.chunkLoadingGlobal,
       globalObject: mainBuildOutput.globalObject,
       path: this.remoteCacheDir,
-      publicPath
+      publicPath: this.publicPath
     }
 
     this.metadata.mfHash = getMfHash({
@@ -187,6 +193,7 @@ export class H5Prebundle extends BasePrebundle<IH5PrebundleConfig> {
       this.chain.devServer.merge({
         static: [{
           directory: this.remoteCacheDir,
+          publicPath: this.publicPath,
           watch: true
         }]
       })

--- a/packages/taro-webpack5-runner/src/index.h5.ts
+++ b/packages/taro-webpack5-runner/src/index.h5.ts
@@ -204,7 +204,7 @@ async function getDevServerOptions (appPath: string, config: H5BuildConfig): Pro
       hot: true,
       https: false,
       // inline: true, // the inline option (iframe live mode) was removed
-      open: true,
+      open: [publicPath],
       client: {
         overlay: true
       },


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

```js
// config/index.js
{
  h5: {
    publicPath: '/taro-playground/',
}
```
remoteEntry 加载链接为：
/taro-playground/remoteEntry.js

解决方法：
为 static 加上 publicPath

![image](https://user-images.githubusercontent.com/1876158/180348321-252ab334-6a5c-4116-93e9-8deeff4c5095.png)


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
