### PR TITLE
fix(h5): 修复pageScrollTo方法缺少对offsetTop参数处理

### DIFF
--- a/packages/taro-h5/src/api/ui/scroll/index.ts
+++ b/packages/taro-h5/src/api/ui/scroll/index.ts
@@ -10,7 +10,7 @@ const FRAME_DURATION = 17
 /**
  * 将页面滚动到目标位置
  */
-export const pageScrollTo: typeof Taro.pageScrollTo = ({ scrollTop, selector = '', duration = 300, success, fail, complete }) => {
+export const pageScrollTo: typeof Taro.pageScrollTo = ({ scrollTop, selector = '', offsetTop = 0, duration = 300, success, fail, complete }) => {
   let scrollFunc
   const handle = new MethodHandler({ name: 'pageScrollTo', success, fail, complete })
   return new Promise((resolve, reject) => {
@@ -52,11 +52,11 @@ export const pageScrollTo: typeof Taro.pageScrollTo = ({ scrollTop, selector = '
       }
       const from = scrollFunc()
       let to: number
-      if (typeof scrollTop === 'number') {
-        to = scrollTop
-      } else {
+      if (selector) {
         const el = document.querySelector(selector) as HTMLElement
-        to = el?.offsetTop || 0
+        to = (el?.offsetTop || 0) + offsetTop
+      } else {
+        to = typeof scrollTop === 'number' ? scrollTop : 0
       }
       const delta = to - from
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复taro-h5中taro.pageScrollTo()使用selector时缺少对offsetTop参数的处理

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
