### PR TITLE
fix: 修复当主入口不引用样式文件不生成 assets 时也不生成页面的 wxss 文件问题

### DIFF
--- a/packages/taro-webpack5-runner/src/plugins/MiniSplitChunksPlugin.ts
+++ b/packages/taro-webpack5-runner/src/plugins/MiniSplitChunksPlugin.ts
@@ -105,7 +105,7 @@ const normalizeChunksFilter = chunks => {
  * @returns {boolean} true, if the module should be selected
  */
 type TestFunc = (module, context) => boolean
-const checkTest = (test: undefined | boolean |string |RegExp | TestFunc, module, context): boolean => {
+const checkTest = (test: undefined | boolean | string | RegExp | TestFunc, module, context): boolean => {
   if (test === undefined) return true
   if (typeof test === 'function') {
     return test(module, context)
@@ -534,6 +534,8 @@ export default class MiniSplitChunksPlugin extends SplitChunksPlugin {
                     this.assets[chunkName] = new RawSource(`${source.source()}${originSource}`)
                   }
                 }
+              } else {
+                this.assets[chunkName] = new RawSource(`${source.source()}`)
               }
             }
           }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复当引用了 sub-common 组件的主入口文件不引用样式，不生成 wxss 导致页面渲染无样式的问题。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
