### PR TITLE
chore(release): publish 3.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taro",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "开放式跨端跨框架开发解决方案",
   "homepage": "https://github.com/NervJS/taro#readme",
   "author": "O2Team",

--- a/packages/babel-plugin-transform-react-jsx-to-rn-stylesheet/package.json
+++ b/packages/babel-plugin-transform-react-jsx-to-rn-stylesheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-transform-react-jsx-to-rn-stylesheet",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Transform stylesheet selector to style in JSX Elements.",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/babel-plugin-transform-taroapi/package.json
+++ b/packages/babel-plugin-transform-taroapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-transform-taroapi",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc"

--- a/packages/babel-preset-taro/package.json
+++ b/packages/babel-preset-taro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-taro",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Taro babel preset",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/babel-preset-taro#readme",

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/create-app",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "create taro app with one command",
   "author": "VincentW <Vincent.Mr.W@gmail.com>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/create-app#readme",

--- a/packages/css-to-react-native/package.json
+++ b/packages/css-to-react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "taro-css-to-react-native",
   "description": "Convert CSS text to a React Native stylesheet object",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "main": "dist/index.js",
   "license": "MIT",
   "dependencies": {

--- a/packages/eslint-config-taro/package.json
+++ b/packages/eslint-config-taro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-taro",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Taro specific linting rules for ESLint",
   "main": "index.js",
   "files": [

--- a/packages/postcss-html-transform/package.json
+++ b/packages/postcss-html-transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-html-transform",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "transform html tag name selector",
   "main": "index.js",
   "author": "drchan",

--- a/packages/postcss-plugin-constparse/package.json
+++ b/packages/postcss-plugin-constparse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-plugin-constparse",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "parse constants defined in config",
   "main": "index.js",
   "author": "Simba",

--- a/packages/postcss-pxtransform/package.json
+++ b/packages/postcss-pxtransform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-pxtransform",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "PostCSS plugin px 转小程序 rpx及h5 rem 单位",
   "keywords": [
     "postcss",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/shared",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Taro utils internal use.",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/shared#readme",

--- a/packages/stylelint-config-taro-rn/package.json
+++ b/packages/stylelint-config-taro-rn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-taro-rn",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Shareable stylelint config for React Native CSS modules",
   "main": "index.js",
   "files": [

--- a/packages/stylelint-taro-rn/package.json
+++ b/packages/stylelint-taro-rn/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stylelint-taro-rn",
   "description": "A collection of React Native specific rules for stylelint",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/packages/taro-alipay/package.json
+++ b/packages/taro-alipay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-alipay",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "支付宝小程序平台插件",
   "author": "Chen-jj",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-alipay#readme",

--- a/packages/taro-api/package.json
+++ b/packages/taro-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/api",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Taro common API",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/api#readme",

--- a/packages/taro-cli/package.json
+++ b/packages/taro-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/cli",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "cli tool for taro",
   "main": "index.js",
   "scripts": {

--- a/packages/taro-components-react/package.json
+++ b/packages/taro-components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/components-react",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "",
   "main:h5": "src/index.js",
   "main": "dist/index.js",

--- a/packages/taro-components-rn/package.json
+++ b/packages/taro-components-rn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/components-rn",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "多端解决方案基础组件（RN）",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/taro-components/package.json
+++ b/packages/taro-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/components",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "",
   "browser": "dist/index.js",
   "main:h5": "dist/index.js",

--- a/packages/taro-extend/package.json
+++ b/packages/taro-extend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/extend",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Taro extend functionality",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-extend#readme",

--- a/packages/taro-h5/package.json
+++ b/packages/taro-h5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taro-h5",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Taro h5 framework",
   "browser": "dist/index.esm.js",
   "main:h5": "dist/index.js",

--- a/packages/taro-helper/package.json
+++ b/packages/taro-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/helper",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Taro Helper",
   "main": "index.js",
   "types": "dist/index.d.ts",

--- a/packages/taro-jd/package.json
+++ b/packages/taro-jd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-jd",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "京东小程序平台插件",
   "author": "Chen-jj",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-jd#readme",

--- a/packages/taro-loader/package.json
+++ b/packages/taro-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taro-loader",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Taro runner use webpack loader",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-loader#readme",

--- a/packages/taro-mini-runner/package.json
+++ b/packages/taro-mini-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/mini-runner",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Mini app runner for taro",
   "main": "index.js",
   "scripts": {

--- a/packages/taro-plugin-html/package.json
+++ b/packages/taro-plugin-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-html",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Taro 小程序端支持使用 HTML 标签的插件",
   "main": "index.js",
   "scripts": {

--- a/packages/taro-plugin-mini-ci/package.json
+++ b/packages/taro-plugin-mini-ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-mini-ci",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Taro 小程序端构建后支持CI（持续集成）的插件",
   "keywords": [
     "Taro",

--- a/packages/taro-plugin-react-devtools/package.json
+++ b/packages/taro-plugin-react-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-react-devtools",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Taro 小程序端支持使用 React DevTools 的插件",
   "main": "index.js",
   "scripts": {

--- a/packages/taro-plugin-react/package.json
+++ b/packages/taro-plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-framework-react",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "React/Preact/Nerv 框架插件",
   "author": "drchan",
   "homepage": "https://github.com/nervjs/taro",

--- a/packages/taro-plugin-vue-devtools/package.json
+++ b/packages/taro-plugin-vue-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-vue-devtools",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Taro 小程序端支持使用 Vue DevTools 的插件",
   "main": "index.js",
   "scripts": {

--- a/packages/taro-plugin-vue2/package.json
+++ b/packages/taro-plugin-vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-framework-vue2",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Vue2 框架插件",
   "author": "drchan",
   "homepage": "https://github.com/nervjs/taro",

--- a/packages/taro-plugin-vue3/package.json
+++ b/packages/taro-plugin-vue3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-framework-vue3",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Vue3 框架插件",
   "author": "drchan",
   "homepage": "https://github.com/nervjs/taro",

--- a/packages/taro-qq/package.json
+++ b/packages/taro-qq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-qq",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "QQ 小程序平台插件",
   "author": "Chen-jj",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-qq#readme",

--- a/packages/taro-react/package.json
+++ b/packages/taro-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/react",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "like react-dom, but for mini apps.",
   "author": "yuche <i@yuche.me>",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-react#readme",

--- a/packages/taro-rn-runner/package.json
+++ b/packages/taro-rn-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/rn-runner",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "ReactNative build tool for taro",
   "main": "index.js",
   "repository": {

--- a/packages/taro-rn-style-transformer/package.json
+++ b/packages/taro-rn-style-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/rn-style-transformer",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "提供Taro RN 统一处理样式文件能力",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/taro-rn-supporter/package.json
+++ b/packages/taro-rn-supporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/rn-supporter",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Taro rn supporter",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/taro-rn-transformer/package.json
+++ b/packages/taro-rn-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/rn-transformer",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Taro RN 入口文件处理",
   "main": "dist/index.js",
   "types": "./src/types/index.d.ts",

--- a/packages/taro-rn/package.json
+++ b/packages/taro-rn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taro-rn",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Taro RN framework",
   "main": "dist/index.js",
   "typings": "types/index.d.ts",

--- a/packages/taro-router-rn/package.json
+++ b/packages/taro-router-rn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/router-rn",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Taro-router-rn",
   "main": "dist/index.js",
   "typings": "src/index.ts",

--- a/packages/taro-router/package.json
+++ b/packages/taro-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/router",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Taro-router",
   "browser": "dist/index.esm.js",
   "main:h5": "dist/index.js",

--- a/packages/taro-runner-utils/package.json
+++ b/packages/taro-runner-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/runner-utils",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Taro runner utilities.",
   "main": "dist/index.js",
   "types": "types/index.d.ts",

--- a/packages/taro-runtime-rn/package.json
+++ b/packages/taro-runtime-rn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/runtime-rn",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "taro-runtime-rn",
   "main": "dist/index.js",
   "types": "./src/index.ts",

--- a/packages/taro-runtime/package.json
+++ b/packages/taro-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/runtime",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "taro runtime for mini apps.",
   "main": "dist/runtime.esm.js",
   "module": "dist/runtime.esm.js",

--- a/packages/taro-service/package.json
+++ b/packages/taro-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/service",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Taro Service",
   "main": "index.js",
   "types": "types/index.d.ts",

--- a/packages/taro-swan/package.json
+++ b/packages/taro-swan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-swan",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "百度小程序平台插件",
   "author": "Chen-jj",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-swan#readme",

--- a/packages/taro-tt/package.json
+++ b/packages/taro-tt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-tt",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "头条小程序平台插件",
   "author": "Chen-jj",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-tt#readme",

--- a/packages/taro-weapp/package.json
+++ b/packages/taro-weapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-weapp",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "微信小程序平台插件",
   "author": "drchan",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro-weapp#readme",

--- a/packages/taro-webpack-runner/package.json
+++ b/packages/taro-webpack-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/webpack-runner",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "webpack runner for taro",
   "main": "index.js",
   "scripts": {

--- a/packages/taro-webpack5-prebundle/package.json
+++ b/packages/taro-webpack5-prebundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/webpack5-prebundle",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Taro app webpack5 prebundle",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/taro-webpack5-runner/package.json
+++ b/packages/taro-webpack5-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/webpack5-runner",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Taro app runner",
   "main": "index.js",
   "scripts": {

--- a/packages/taro-with-weapp/package.json
+++ b/packages/taro-with-weapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/with-weapp",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "taroize 之后的运行时",
   "main": "index.js",
   "scripts": {

--- a/packages/taro/package.json
+++ b/packages/taro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taro",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Taro framework",
   "homepage": "https://github.com/nervjs/taro/tree/master/packages/taro#readme",
   "main": "index.js",

--- a/packages/taroize/package.json
+++ b/packages/taroize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taroize",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "转换原生微信小程序代码为 Taro 代码",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## 特性

### H5

- 新增支持 movable 组件 fix #10767，by @baosiqing
- **prebundle:** 默认继承 webpack 配置，并支持开发者自定义拓展 fix #12160

### RN

- **taro-runtime-rn:** 实现 useLoad 钩子 fix #12177，by @peterczg
- **taro-runtime-rn:** 实现 useUnload 钩子 fix #12173，by @peterczg
- 依赖版本升级，by @zhiqingchen

## 修复

### 小程序

- 优化主入口引用样式文件编译问题，by @顾一峰

### H5

- **prebundle:** 支持新版本 prefresh 热更新 fix #12138
- **prebundle:** react 框架默认排除 mobx 依赖预编译 fix #12175
- **router:** 优化自定义路由入口判断 fix #12214

### RN

- 修复 window 平台下编译报错问题 fix #12197，by @zhiqingchen
- **rn-runner/rn-style:** 修复 rollupTransform 参数格式化、丢失问题，并调整相关类型声明文件，by @shinken008
- **rn-style-transformer:** 修复 scss nest importer 不执行问题，by @shinken008
- **rn-support/rn-runner:** 支持 ios/android 文件读取 fix #12200，by @shinken008
- **rn:** 编译组件时移除 clear dist 操作 fix #12183，by @biorz

### ELSE

- **postcss:** pxtransform 语法优化
- **helper:** debug 依赖升级

## Typings

- 更新 video 组件类型，by @spiritree
- 更新 JSX 组件类型缺失，by @lf7817
- 更新组件 props 类型导出