### PR TITLE
fix(taro-runtime-rn): register hooks in current instance instead of Page Component

### DIFF
--- a/packages/taro-runtime-rn/src/instance.ts
+++ b/packages/taro-runtime-rn/src/instance.ts
@@ -11,7 +11,7 @@ interface Show {
 
 export interface PageLifeCycle extends Show {
   onPullDownRefresh?(): void
-  onReachBottom?(): void
+  onReachBottom?(event: { nativeEvent: any }): void
   onPageScroll?(obj: { scrollTop: number }): void
   onResize?(options: unknown): void
   onTabItemTap?(obj: { index: string, pagePath: string, text: string }): void

--- a/packages/taro-runtime-rn/src/page.ts
+++ b/packages/taro-runtime-rn/src/page.ts
@@ -102,8 +102,6 @@ export function createPageConfig (Page: any, pageConfig: PageConfig): any {
   const h = React.createElement
   const pagePath = pageConfig.pagePath.replace(/^\//, '') || ''
 
-  const pageId = camelCase(pagePath) ?? `taro_page_${compId}`
-
   const isReactComponent = isClassComponent(Page)
   if (PageContext === EMPTY_OBJ) {
     PageContext = React.createContext('')
@@ -124,13 +122,12 @@ export function createPageConfig (Page: any, pageConfig: PageConfig): any {
     })
   }
 
-  // 注入的页面实例
-  injectPageInstance(Page, pageId)
 
   const WrapScreen = (Screen: any) => {
     return class PageScreen extends React.Component<any, any> {
       // eslint-disable-next-line react/sort-comp
       screenRef: React.RefObject<any>
+      pageId: string
       pageScrollView: React.RefObject<any>
       unSubscribleBlur: any
       unSubscribleFocus: any
@@ -141,6 +138,9 @@ export function createPageConfig (Page: any, pageConfig: PageConfig): any {
 
       constructor (props: any) {
         super(props)
+        this.pageId = `${camelCase(pagePath) ?? 'taro_page_'}${compId()}`
+        // 注入的页面实例
+        injectPageInstance(this, this.pageId)
         const refreshStyle = globalAny?.__taroRefreshStyle ?? {}
         const backgroundTextStyle = pageConfig.backgroundTextStyle || globalAny.__taroAppConfig?.appConfig?.window?.backgroundTextStyle || 'dark'
         this.state = {
@@ -190,6 +190,7 @@ export function createPageConfig (Page: any, pageConfig: PageConfig): any {
 
       setPageInstance () {
         const pageRef = this.screenRef
+        const pageId = this.pageId
         const { params = {}, key = '' } = this.props.route
         // 和小程序的page实例保持一致
         const inst: PageInstance = {
@@ -382,7 +383,7 @@ export function createPageConfig (Page: any, pageConfig: PageConfig): any {
 
       handleHooksEvent (method: HooksMethods, options: Record<string, unknown> = {}) {
         if (!isReactComponent) {
-          return safeExecute(pageId, method, options)
+          return safeExecute(this.pageId, method, options)
         }
       }
 
@@ -424,7 +425,7 @@ export function createPageConfig (Page: any, pageConfig: PageConfig): any {
 
       createPage () {
         return h(PageProvider, { currentPath: pagePath, pageConfig, ...this.props },
-          h(PageContext.Provider, { value: pageId }, h(Screen,
+          h(PageContext.Provider, { value: this.pageId }, h(Screen,
             { ...this.props, ref: this.screenRef })
           )
         )


### PR DESCRIPTION
…age component

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
将taro-rn环境下注册的hooks关联到当前页面**实例**，而不是挂载到同一Page Component下。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #12231
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
