### PR TITLE
feat(rn): 支持 css module 多 className 写法 (#12226)

### DIFF
--- a/packages/babel-plugin-transform-react-jsx-to-rn-stylesheet/__tests__/index.spec.js
+++ b/packages/babel-plugin-transform-react-jsx-to-rn-stylesheet/__tests__/index.spec.js
@@ -740,4 +740,61 @@ class App extends Component {
 
 }`)
   })
+
+  it('enableMultipleClassName and transform template literal with css module', () => {
+    const result = getTransfromCode(`
+    import { createElement, Component } from 'rax';
+    import styles from './app.module.css';
+
+    class App extends Component {
+      render() {
+        return <StatusBar className={\`\${styles.bar} \${styles.custom}\`} />;
+      }
+    }`, false, { enableCSSModule: true, enableMultipleClassName: true })
+
+    expect(result).toBe(`import { createElement, Component } from 'rax';
+import styles from './app.module.css';
+
+${getClassNameFunctionTemplate}
+
+${getStyleFunctionTemplete}
+
+var _styleSheet = {};
+
+class App extends Component {
+  render() {
+    return <StatusBar style={_getStyle(\`\${"bar"} \${"custom"}\`)} />;
+  }
+
+}`)
+  })
+
+  it('enableMultipleClassName and transform binary expression with css module', () => {
+    const result = getTransfromCode(`
+    import { createElement, Component } from 'rax';
+    import styles from './app.module.css';
+
+    class App extends Component {
+      render() {
+        return <StatusBar className={styles.bar + ' ' + styles.custom} />;
+      }
+    }`, false, { enableCSSModule: true, enableMultipleClassName: true })
+
+    expect(result).toBe(`import { createElement, Component } from 'rax';
+import styles from './app.module.css';
+
+${getClassNameFunctionTemplate}
+
+${getStyleFunctionTemplete}
+
+var _styleSheet = {};
+
+class App extends Component {
+  render() {
+    return <StatusBar style={_getStyle("bar" + ' ' + "custom")} />;
+  }
+
+}`)
+  })
 })
+

--- a/packages/babel-plugin-transform-react-jsx-to-rn-stylesheet/src/index.ts
+++ b/packages/babel-plugin-transform-react-jsx-to-rn-stylesheet/src/index.ts
@@ -218,8 +218,6 @@ export default function (babel: {
 
     if (t.isTemplateLiteral(expression)) {
       for (const index in expression.expressions) {
-        // TODO: 模板字符串插件
-
         if (isStyleSheetMember(expression.expressions[index], cssModuleStylesheets)) {
           expression.expressions[index] = t.stringLiteral(((expression.expressions[index] as Types.MemberExpression)?.property as Types.Identifier)?.name)
         }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
在 rn 端开启 cssModule 时，支持多 stylesheet 写法
```typescript
import styles from './styles.module.scss'
export default function () {
  return <View>
    <View className={`${styles.a} ${styles.b}`} />
    <View className={styles.a + ' ' + styles.b} />
  </View>
}
```



**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
