### PR TITLE
feat(runtime): 允许插件配置有副作用的生命周期，#12217

### DIFF
--- a/packages/shared/src/runtime-hooks.ts
+++ b/packages/shared/src/runtime-hooks.ts
@@ -33,7 +33,8 @@ interface MiniLifecycle {
     string, /** onReady */
     string, /** onShow */
     string, /** onHide */
-    string[] /** others */
+    string[], /** others */
+    string[] /** side-effects */
   ]
 }
 
@@ -91,6 +92,10 @@ const defaultMiniLifecycle: MiniLifecycle = {
       'onPopMenuClick',
       'onPullIntercept',
       'onAddToFavorites'
+    ],
+    [
+      'onShareAppMessage',
+      'onShareTimeline'
     ]
   ]
 }

--- a/packages/taro-plugin-react/src/loader-meta.ts
+++ b/packages/taro-plugin-react/src/loader-meta.ts
@@ -59,6 +59,11 @@ function addConfig (source) {
           check(callee.property.value)
         }
       }
+      node.arguments.forEach(item => {
+        if (item.type === 'Literal' && item.value) {
+          check(item.value)
+        }
+      })
     }
   })
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

开发者可以通过 `getMiniLifecycle` 钩子去添加类似 `onShareAppMessage` 等有副作用的生命周期，#12217

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
