### PR TITLE
fix: 页面为函数式组件时不再额外包裹 View #12305

### DIFF
--- a/packages/taro-runtime-rn/src/page.ts
+++ b/packages/taro-runtime-rn/src/page.ts
@@ -1,6 +1,6 @@
 import { getCurrentRoute, PageProvider } from '@tarojs/router-rn'
 import * as React from 'react'
-import { AppState, Dimensions, EmitterSubscription, NativeEventSubscription, RefreshControl, ScrollView, View } from 'react-native'
+import { AppState, Dimensions, EmitterSubscription, NativeEventSubscription, RefreshControl, ScrollView } from 'react-native'
 
 import { isClassComponent } from './app'
 import { Current } from './current'
@@ -112,12 +112,7 @@ export function createPageConfig (Page: any, pageConfig: PageConfig): any {
     ScreenPage = React.forwardRef((props, ref) => {
       const newProps: React.Props<any> = { ...props }
       newProps.ref = ref
-      return h(View, {
-        style: {
-          minHeight: '100%'
-        },
-        ...newProps
-      }, h(Page, { ...props }, null))
+      return h(Page, { ...newProps }, null)
     })
   }
 


### PR DESCRIPTION
1. fix #12305
2. 透传 ref, 方便函数式组件配置回调 (如: componentDidShow)

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)



**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
