### PR TITLE
feat(component): 在Swiper的OnChange事件返回触发阶段

### DIFF
--- a/packages/taro-components/__tests__/swiper.spec.js
+++ b/packages/taro-components/__tests__/swiper.spec.js
@@ -238,6 +238,13 @@ describe('Swiper', () => {
 
     assert(onChange.calledOnceWith({
       current: 1,
+      start: true,
+      source: ''
+    }))
+
+    assert(onChange.calledOnceWith({
+      current: 1,
+      end: true,
       source: ''
     }))
 

--- a/packages/taro-components/src/components/swiper/swiper.tsx
+++ b/packages/taro-components/src/components/swiper/swiper.tsx
@@ -272,16 +272,25 @@ export class Swiper implements ComponentInterface {
         slideTo () {
           that.current = this.realIndex
         },
-        // slideChange 事件在 swiper.slideTo 改写 current 时不触发，因此用 slideChangeTransitionEnd 事件代替
-        slideChangeTransitionEnd (_swiper: ISwiper) {
+        slideChange (_swiper: ISwiper) {
           if (that.circular) {
             if (_swiper.isBeginning || _swiper.isEnd) {
               _swiper.slideToLoop(this.realIndex, 0) // 更新下标
               return
             }
           }
+        },
+        slideChangeTransitionStart (_swiper: ISwiper) {
           that.onChange.emit({
             current: this.realIndex,
+            start: true,
+            source: ''
+          })
+        },
+        slideChangeTransitionEnd (_swiper: ISwiper) {
+          that.onChange.emit({
+            current: this.realIndex,
+            end: true,
             source: ''
           })
         },

--- a/packages/taro-components/types/Swiper.d.ts
+++ b/packages/taro-components/types/Swiper.d.ts
@@ -150,6 +150,10 @@ declare namespace SwiperProps {
     current: number
     /** 导致变更的原因 */
     source: keyof SwiperProps.TChangeSource
+    /** 是否为动画开始时 */
+    start?: boolean
+    /** 是否为动画结束时 */
+    end?: boolean
     /** SwiperItem的itemId参数值 */
     currentItemId?: string
   }


### PR DESCRIPTION
re #10764

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
在Swiper的OnChange事件返回触发阶段,可手动选择在动画开始或结束时执行

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
