### PR TITLE
fix(textarea): 修复textarea组件高度设置无法生效的问题

### DIFF
--- a/packages/taro-components/src/components/textarea/style/index.scss
+++ b/packages/taro-components/src/components/textarea/style/index.scss
@@ -16,7 +16,7 @@ taro-textarea-core .auto-height {
   position: relative;
   border: 0;
   width: 100%;
-  height: 150px;
+  height: inherit;
   appearance: none;
   cursor: auto;
   line-height: 1.5;


### PR DESCRIPTION
fix #12317

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复textarea组件高度设置无法生效的问题
style属性在taro-textarea-core，会被内层的taro-textarea的150px替代

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
