### PR TITLE
feat(taro-plugin-mini-ci):  Taro 小程序端构建CI（持续集成）插件重大更新

### DIFF
--- a/packages/taro-cli/src/doctor/configSchema.ts
+++ b/packages/taro-cli/src/doctor/configSchema.ts
@@ -10,7 +10,10 @@ const schema = Joi.object().keys({
 
   plugins: Joi.array().items(Joi.alternatives(
     Joi.string(),
-    Joi.array().ordered(Joi.string().required(), Joi.object())
+    Joi.array().ordered(
+      Joi.string().required(),
+      Joi.alternatives().try(Joi.object(), Joi.function())
+    )
   )),
 
   presets: Joi.array().items(Joi.alternatives(

--- a/packages/taro-plugin-mini-ci/README.md
+++ b/packages/taro-plugin-mini-ci/README.md
@@ -5,11 +5,13 @@
 ## 使用
 
 ### 安装
-```
+
+```sh
 npm i @tarojs/plugin-mini-ci -D
 ```
 
 ### 使用插件
+
 `/config/index.js`
 
 ```js
@@ -52,6 +54,7 @@ const config = {
 ```
 
 除了给插件传入对象， 你也可以传入一个异步函数，在编译时动态返回相关配置。
+
 ```js
 const CIPluginFn = async () => {
   // 可以在这里做一些异步事情， 比如请求接口获取配置
@@ -116,6 +119,7 @@ const config = {
     }
 }
 ```
+
 由上面的示例可知，插件为taro cli命令扩展了4个选项：
 
 - --open
@@ -134,8 +138,8 @@ const config = {
 
 此选项优先级为： 终端传入的`--projectPath` > CI配置的`projectPath` 选项 > [outputRoot选项](https://taro-docs.jd.com/taro/docs/next/config-detail#outputroot)。
 
-
 ### 作为命令单独使用
+
 ```json
 {
     "scripts": {
@@ -155,15 +159,17 @@ const config = {
 }
 ```
 
-由上面的示例可知，插件额外新增了3个独立命令，让你可以直接操作指定目录。适用于把 `taro` 作为项目一部分的使用场景。 
+由上面的示例可知，插件额外新增了3个独立命令，让你可以直接操作指定目录。适用于把 `taro` 作为项目一部分的使用场景。
 
 当直接作为命令使用时，有两个选项：
+
 - --type
 传入平台名称
 - --projectPath
 传入路径。 此选项优先级为： 终端传入的`--projectPath` > CI配置的`projectPath` 选项 > [outputRoot选项](https://taro-docs.jd.com/taro/docs/next/config-detail#outputroot)
 
 ### Hooks 使用
+
 在插件执行完  `预览`、`上传` 操作后， 插件会触发2个钩子事件：
 
 | 事件名 | 传递参数对象 | 说明 |
@@ -217,7 +223,9 @@ module.exports = function(ctx) {
     })
 }
 ```
+
 然后把自己写的插件配置应用起来：
+
 ```js
 // config/index.js
 const config = {
@@ -239,9 +247,19 @@ module.exports = function (merge) {
 }
 ```
 
+### 各平台 支持的功能情况对比
+
+| 平台/功能 | 自动打开IDE  | 输出预览二维码 | 输出体验二维码  |
+| :---     | :---       | :---         | :---          |
+| weapp    | ✅         | ✅            |✅             |
+| tt       | ✅         | ✅            |✅             |
+| alipay   | ✅         | ✅            |✅             |
+| dd       | ✅         | ✅            |❌             |
+| swan     | ❌         | ✅            |✅             |
+
+> ps: 各平台上传都是支持的，只是不一定会输出二维码
 
 ## API
-
 
 ### 插件配置
 
@@ -257,6 +275,7 @@ module.exports = function (merge) {
 | projectPath | string | 目标项目目录，对所有小程序生效（不传默认取 outputRoot 字段 ）（3.6.0 版本开始支持） |
 
 ### 微信小程序CI配置
+
 | 参数 | 类型 | 说明 |
 | :--- | :--- | :--- |
 | appid | string | 小程序/小游戏项目的 appid |
@@ -318,7 +337,6 @@ health:  阿里医院
 
 官方CI文档[点这里](https://opendocs.alipay.com/mini/02q29z)
 
-
 ### 钉钉小程序CI配置（3.6.0 版本开始支持）
 
 | 参数 | 类型 | 说明 |
@@ -326,6 +344,8 @@ health:  阿里医院
 | appid | string | 钉钉小程序appid,即钉钉开放平台后台应用管理的 MiniAppId 选项（必填） |
 | token | string | 令牌，从钉钉后台获取 （必填） |
 | devToolsInstallPath | string | 小程序开发者工具安装路径（选填）  |
+
+`taro` 集成的钉钉CI使用了[钉钉官方仓库](https://github.com/open-dingtalk/dingtalk-design-cli)中的 `dingtalk-miniapp-opensdk` 包，查阅源码封装而成
 
 ### 百度小程序CI配置
 
@@ -337,6 +357,7 @@ health:  阿里医院
 官方CI文档[点这里](https://smartprogram.baidu.com/docs/develop/devtools/commandtool/)
 
 ### 完整 ts 接口描述
+
 ```ts
 export interface CIOptions {
   /** 发布版本号，默认取 package.json 文件的 taroConfig.version 字段 */

--- a/packages/taro-plugin-mini-ci/README.md
+++ b/packages/taro-plugin-mini-ci/README.md
@@ -255,7 +255,7 @@ module.exports = function (merge) {
 | tt       | ✅         | ✅            |✅             |
 | alipay   | ✅         | ✅            |✅             |
 | dd       | ✅         | ✅            |❌             |
-| swan     | ❌         | ✅            |✅             |
+| swan     | ✅         | ✅            |✅             |
 
 > ps: 各平台上传都是支持的，只是不一定会输出二维码
 

--- a/packages/taro-plugin-mini-ci/README.md
+++ b/packages/taro-plugin-mini-ci/README.md
@@ -47,6 +47,44 @@ const config = {
 }
 ```
 
+除了给插件传入对象， 你也可以传入一个函数，在编译时动态返回相关配置
+```js
+const CIPluginFn = () => {
+  /**
+   * @typedef { import("@tarojs/plugin-mini-ci").CIOptions } CIOptions
+   * @type {CIOptions}
+   */
+  return {
+      weapp: {
+          appid: "微信小程序appid",
+          privateKeyPath: "密钥文件相对项目根目录的相对路径，例如 key/private.appid.key"
+      },
+      tt: {
+          email: "字节小程序邮箱",
+          password: "字节小程序密码"
+      },
+      alipay: {
+        appId: "支付宝小程序appId",
+        toolId: "工具id",
+        privateKeyPath: "密钥文件相对项目根目录的相对路径，例如 key/pkcs8-private-pem"
+      },
+      swan: {
+        token: "鉴权需要的token令牌"
+      },
+      // 版本号
+      version: "1.0.0",
+      // 版本发布描述
+      desc: "版本描述"
+  }
+}
+
+const config = {
+  plugins: [
+    [ "@tarojs/plugin-mini-ci", CIPluginFn ]
+  ]
+}
+```
+
 ### 配置命令
 
 `package.json` 的 `scripts` 字段使用命令参数

--- a/packages/taro-plugin-mini-ci/README.md
+++ b/packages/taro-plugin-mini-ci/README.md
@@ -33,7 +33,7 @@ const CIPluginOpt = {
       privateKeyPath: "密钥文件相对项目根目录的相对路径，例如 key/pkcs8-private-pem"
     },
     dd: {
-        appid: "钉钉小程序appid,即钉钉开放平台后台应用管理的 MiniAppId 选项"
+        appid: "钉钉小程序appid,即钉钉开放平台后台应用管理的 MiniAppId 选项",
         token: "令牌，从钉钉后台获取"
     },
     swan: {

--- a/packages/taro-plugin-mini-ci/README.md
+++ b/packages/taro-plugin-mini-ci/README.md
@@ -106,7 +106,9 @@ const config = {
             //  构建完后自动 “上传代码作为开发版并生成预览二维码”     
            "build:weapp:preview": "taro build --type weapp --preview",
             //  构建完后自动“上传代码作为体验版”
-           "build:weapp:upload": "taro build --type weapp --upload"
+           "build:weapp:upload": "taro build --type weapp --upload",
+            //  构建完后自动“上传 dist/xxx 目录的代码作为体验版”， `--projectPath` 参数 适用于 taro 和 原生混合的场景
+           "build:weapp:upload": "taro build --type weapp --upload --projectPath dist/xxx"
     },
     "taroConfig": {
         "version": "1.0.0",
@@ -114,7 +116,7 @@ const config = {
     }
 }
 ```
-由上面的示例可知，插件为taro cli命令扩展了3个选项：
+由上面的示例可知，插件为taro cli命令扩展了4个选项：
 
 - --open
 打开开发者工具，类似于网页开发中自动打开谷歌浏览器
@@ -123,7 +125,14 @@ const config = {
 - --upload
 上传代码作为体验版
 
-此3个选项在一条命令里不能同时使用
+此3个选项在一条命令里不能同时使用（互斥）
+
+- --projectPath
+指定要操作（打开、预览、上传）的目录路径， 默认情况下是操作构建后目录路径，即 [outputRoot选项](https://taro-docs.jd.com/taro/docs/next/config-detail#outputroot)；
+
+此选项必须搭配上述三个选项之一一起使用；
+
+此选项优先级为： 终端传入的`--projectPath` > CI配置的`projectPath` 选项 > [outputRoot选项](https://taro-docs.jd.com/taro/docs/next/config-detail#outputroot)。
 
 
 ### 作为命令单独使用
@@ -417,7 +426,7 @@ export type DingtalkProjectType =
 /** 工作台组件 */
 'dingtalk-biz-worktab-plugin'
 export interface DingtalkConfig {
-  /** 小程序ID， 必填 */
+  /** 钉钉小程序appid,即钉钉开放平台后台应用管理的 MiniAppId 选项（必填） */
   appid: string
   /** 令牌，从钉钉后台获取 */
   token: string

--- a/packages/taro-plugin-mini-ci/README.md
+++ b/packages/taro-plugin-mini-ci/README.md
@@ -28,12 +28,12 @@ const CIPluginOpt = {
         password: "字节小程序密码"
     },
     alipay: {
-      appId: "支付宝小程序appId",
+      appid: "支付宝小程序appid",
       toolId: "工具id",
       privateKeyPath: "密钥文件相对项目根目录的相对路径，例如 key/pkcs8-private-pem"
     },
     dd: {
-        appid: "小程序ID，"
+        appid: "钉钉小程序appid,即钉钉开放平台后台应用管理的 MiniAppId 选项"
         token: "令牌，从钉钉后台获取"
     },
     swan: {
@@ -69,12 +69,12 @@ const CIPluginFn = async () => {
           password: "字节小程序密码"
       },
       alipay: {
-        appId: "支付宝小程序appId",
+        appid: "支付宝小程序appid",
         toolId: "工具id",
         privateKeyPath: "密钥文件相对项目根目录的相对路径，例如 key/pkcs8-private-pem"
       },
       dd: {
-        appid: "小程序ID，"
+        appid: "钉钉小程序appid,即钉钉开放平台后台应用管理的 MiniAppId 选项"
         token: "令牌，从钉钉后台获取"
       },
       swan: {
@@ -130,8 +130,8 @@ const config = {
 ```json
 {
     "scripts": {
-            //  直接 “打开开发者工具”
-           "build:weapp": "taro open --type weapp --open",
+            //  直接 “打开开发者工具并载入项目”
+           "build:weapp": "taro open --type weapp  --projectPath dist/xxx",
             //  直接 “上传代码作为开发版并生成预览二维码”     
            "build:weapp:preview": "taro preview --type weapp",
             //  直接“上传代码作为体验版”
@@ -314,7 +314,7 @@ health:  阿里医院
 
 | 参数 | 类型 | 说明 |
 | :--- | :--- | :--- |
-| appid | string | 小程序ID（必填） |
+| appid | string | 钉钉小程序appid,即钉钉开放平台后台应用管理的 MiniAppId 选项（必填） |
 | token | string | 令牌，从钉钉后台获取 （必填） |
 | devToolsInstallPath | string | 小程序开发者工具安装路径（选填）  |
 
@@ -391,8 +391,8 @@ export type AlipayClientType =
 
 /** 支付宝系列小程序配置 */
 export interface AlipayConfig {
-  /** 小程序appId */
-  appId: string
+  /** 小程序appid */
+  appid: string
   /** 工具id */
   toolId: string
   /** 私钥文件路径，在获取项目属性和上传时用于鉴权使用(privateKeyPath和privateKey之间必须要填写其中一个) */

--- a/packages/taro-plugin-mini-ci/package.json
+++ b/packages/taro-plugin-mini-ci/package.json
@@ -50,6 +50,8 @@
     }
   },
   "devDependencies": {
-    "@types/qrcode": "^1.5.0"
+    "@types/qrcode": "^1.5.0",
+    "minidev": "^1.5.1",
+    "tt-ide-cli": "^0.1.13"
   }
 }

--- a/packages/taro-plugin-mini-ci/package.json
+++ b/packages/taro-plugin-mini-ci/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@tarojs/service": "workspace:*",
     "minimist": "^1.2.5",
-    "miniprogram-ci": "^1.6.1",
+    "miniprogram-ci": "^1.8.35",
     "qrcode-terminal": "^0.12.0",
     "shelljs": "^0.8.4"
   },

--- a/packages/taro-plugin-mini-ci/package.json
+++ b/packages/taro-plugin-mini-ci/package.json
@@ -34,14 +34,26 @@
     "miniprogram-ci": "^1.8.35",
     "qrcode": "^1.5.1",
     "qrcode-reader": "^1.0.4",
-    "qrcode-terminal": "^0.12.0",
     "shelljs": "^0.8.4"
   },
   "devDependencies": {
     "@types/qrcode": "^1.5.0",
-    "@types/shelljs": "^0.8.11",
+    "@types/shelljs": "^0.8.11"
+  },
+  "peerDependencies": {
     "dingtalk-miniapp-opensdk": "^1.0.7",
     "minidev": "^1.5.1",
     "tt-ide-cli": "^0.1.13"
+  },
+  "peerDependenciesMeta": {
+    "dingtalk-miniapp-opensdk": {
+      "optional": true
+    },
+    "minidev": {
+      "optional": true
+    },
+    "tt-ide-cli": {
+      "optional": true
+    }
   }
 }

--- a/packages/taro-plugin-mini-ci/package.json
+++ b/packages/taro-plugin-mini-ci/package.json
@@ -29,17 +29,27 @@
   },
   "dependencies": {
     "@tarojs/service": "workspace:*",
+    "jimp": "^0.16.1",
     "minimist": "^1.2.5",
     "miniprogram-ci": "^1.8.35",
+    "qrcode": "^1.5.1",
+    "qrcode-reader": "^1.0.4",
     "qrcode-terminal": "^0.12.0",
     "shelljs": "^0.8.4"
   },
   "peerDependencies": {
-    "minidev": "^1.5.1"
+    "minidev": "^1.5.1",
+    "tt-ide-cli": "^0.1.13"
   },
   "peerDependenciesMeta": {
     "minidev": {
       "optional": true
+    },
+    "tt-ide-cli": {
+      "optional": true
     }
+  },
+  "devDependencies": {
+    "@types/qrcode": "^1.5.0"
   }
 }

--- a/packages/taro-plugin-mini-ci/package.json
+++ b/packages/taro-plugin-mini-ci/package.json
@@ -37,20 +37,9 @@
     "qrcode-terminal": "^0.12.0",
     "shelljs": "^0.8.4"
   },
-  "peerDependencies": {
-    "minidev": "^1.5.1",
-    "tt-ide-cli": "^0.1.13"
-  },
-  "peerDependenciesMeta": {
-    "minidev": {
-      "optional": true
-    },
-    "tt-ide-cli": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@types/qrcode": "^1.5.0",
+    "dingtalk-miniapp-opensdk": "^1.0.7",
     "minidev": "^1.5.1",
     "tt-ide-cli": "^0.1.13"
   }

--- a/packages/taro-plugin-mini-ci/package.json
+++ b/packages/taro-plugin-mini-ci/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@types/qrcode": "^1.5.0",
+    "@types/shelljs": "^0.8.11",
     "dingtalk-miniapp-opensdk": "^1.0.7",
     "minidev": "^1.5.1",
     "tt-ide-cli": "^0.1.13"

--- a/packages/taro-plugin-mini-ci/src/AlipayCI.ts
+++ b/packages/taro-plugin-mini-ci/src/AlipayCI.ts
@@ -92,6 +92,11 @@ export default class AlipayCI extends BaseCI {
       await generateQrcodeImageFile(previewQrcodePath, qrcodeContent)
       printLog(processTypeEnum.REMIND, `预览版二维码已生成，存储在:"${ previewQrcodePath }",二维码内容是："${ qrcodeContent }"`)
 
+      this.triggerPreviewHooks({
+        platform: 'alipay',
+        qrCodeContent: qrcodeContent,
+        qrCodeLocalPath: previewQrcodePath
+      })
     } catch (error) {
       printLog(processTypeEnum.ERROR, chalk.red(`预览上传失败 ${ new Date().toLocaleString() } \n${ error.message }`))
     }
@@ -127,6 +132,12 @@ export default class AlipayCI extends BaseCI {
       await printQrcode2Terminal(qrcodeContent)
       await generateQrcodeImageFile(uploadQrcodePath, qrcodeContent)
       printLog(processTypeEnum.REMIND, `体验版二维码已生成，存储在:"${uploadQrcodePath}",二维码内容是："${qrcodeContent}"`)
+
+      this.triggerUploadHooks({
+        platform: 'alipay',
+        qrCodeContent: qrcodeContent,
+        qrCodeLocalPath: uploadQrcodePath
+      })
     } catch (error) {
       printLog(processTypeEnum.ERROR, chalk.red(`体验版上传失败 ${ new Date().toLocaleString() } \n${ error }`))
     }

--- a/packages/taro-plugin-mini-ci/src/AlipayCI.ts
+++ b/packages/taro-plugin-mini-ci/src/AlipayCI.ts
@@ -71,7 +71,7 @@ export default class AlipayCI extends BaseCI {
 
   async preview () {
     const { chalk, printLog, processTypeEnum } = this.ctx.helper
-    const { appId, clientType = 'alipay' } = this.pluginOpts.alipay!
+    const { appid: appId, clientType = 'alipay' } = this.pluginOpts.alipay!
     try {
       const previewResult = await this.minidev.minidev.preview({
         project: this.projectPath,
@@ -114,7 +114,7 @@ export default class AlipayCI extends BaseCI {
 
   async upload () {
     const { chalk, printLog, processTypeEnum } = this.ctx.helper
-    const { clientType = 'alipay', appId } = this.pluginOpts.alipay!
+    const { clientType = 'alipay', appid: appId } = this.pluginOpts.alipay!
     printLog(processTypeEnum.START, '上传代码到阿里小程序后台', clientType)
 
     //  SDK上传不支持设置描述信息; 版本号必须大于现有版本号

--- a/packages/taro-plugin-mini-ci/src/AlipayCI.ts
+++ b/packages/taro-plugin-mini-ci/src/AlipayCI.ts
@@ -93,12 +93,25 @@ export default class AlipayCI extends BaseCI {
       printLog(processTypeEnum.REMIND, `预览版二维码已生成，存储在:"${ previewQrcodePath }",二维码内容是："${ qrcodeContent }"`)
 
       this.triggerPreviewHooks({
-        platform: 'alipay',
-        qrCodeContent: qrcodeContent,
-        qrCodeLocalPath: previewQrcodePath
+        success: true,
+        data: {
+          platform: 'alipay',
+          qrCodeContent: qrcodeContent,
+          qrCodeLocalPath: previewQrcodePath
+        }
       })
     } catch (error) {
       printLog(processTypeEnum.ERROR, chalk.red(`预览上传失败 ${ new Date().toLocaleString() } \n${ error.message }`))
+
+      this.triggerPreviewHooks({
+        success: false,
+        data: {
+          platform: 'alipay',
+          qrCodeContent: '',
+          qrCodeLocalPath: ''
+        },
+        error
+      })
     }
   }
 
@@ -134,12 +147,25 @@ export default class AlipayCI extends BaseCI {
       printLog(processTypeEnum.REMIND, `体验版二维码已生成，存储在:"${uploadQrcodePath}",二维码内容是："${qrcodeContent}"`)
 
       this.triggerUploadHooks({
-        platform: 'alipay',
-        qrCodeContent: qrcodeContent,
-        qrCodeLocalPath: uploadQrcodePath
+        success: true,
+        data: {
+          platform: 'alipay',
+          qrCodeContent: qrcodeContent,
+          qrCodeLocalPath: uploadQrcodePath
+        },
       })
     } catch (error) {
       printLog(processTypeEnum.ERROR, chalk.red(`体验版上传失败 ${ new Date().toLocaleString() } \n${ error }`))
+
+      this.triggerUploadHooks({
+        success: false,
+        data: {
+          platform: 'alipay',
+          qrCodeContent: '',
+          qrCodeLocalPath: ''
+        },
+        error
+      })
     }
   }
 

--- a/packages/taro-plugin-mini-ci/src/BaseCi.ts
+++ b/packages/taro-plugin-mini-ci/src/BaseCi.ts
@@ -143,37 +143,57 @@ export default abstract class BaseCI {
     this._init()
   }
 
-  async triggerPreviewHooks (content: { platform: string, qrCodeLocalPath: string, qrCodeContent: string }) {
+  /** 执行预览命令后触发 */
+  async triggerPreviewHooks (content: {
+    success: boolean
+    data: { platform: string, qrCodeLocalPath: string, qrCodeContent: string }
+    error?: Error
+  }) {
+    const { success, data, error } = content
     await this.ctx.applyPlugins({
       name: ON_PREVIEW_COMPLETE,
       opts: {
-        version: this.version,
-        desc: this.desc,
-        ...content
-      }
+        success,
+        data: {
+          version: this.version,
+          desc: this.desc,
+          ...data
+        },
+        error
+      },
     })
   }
 
-  async triggerUploadHooks (content: { platform: string, qrCodeLocalPath: string, qrCodeContent: string }) {
+  /** 执行上传命令后触发 */
+  async triggerUploadHooks (content: {
+    success: boolean
+    data: { platform: string, qrCodeLocalPath: string, qrCodeContent: string }
+    error?: Error
+  }) {
+    const { success, data, error } = content
     await this.ctx.applyPlugins({
       name: ON_UPLOAD_COMPLETE,
       opts: {
-        version: this.version,
-        desc: this.desc,
-        ...content
-      }
+        success,
+        data: {
+          version: this.version,
+          desc: this.desc,
+          ...data
+        },
+        error
+      },
     })
   }
 
   /** 初始化函数，会被构造函数调用 */
-  protected abstract _init():void;
+  protected abstract _init(): void
 
   /** 打开小程序项目 */
-  abstract open();
+  abstract open()
 
   /** 上传小程序 */
-  abstract upload();
+  abstract upload()
 
   /** 预览小程序 */
-  abstract preview();
+  abstract preview()
 }

--- a/packages/taro-plugin-mini-ci/src/BaseCi.ts
+++ b/packages/taro-plugin-mini-ci/src/BaseCi.ts
@@ -17,6 +17,8 @@ export interface WeappConfig {
   type?: ProjectType
   /** 上传需要排除的目录 */
   ignores?: Array<string>
+  /** 指定使用哪一个 ci 机器人，可选值：1 ~ 30 */
+  robot?: number
 }
 
 /** 头条小程序配置 */

--- a/packages/taro-plugin-mini-ci/src/BaseCi.ts
+++ b/packages/taro-plugin-mini-ci/src/BaseCi.ts
@@ -46,8 +46,8 @@ export type AlipayClientType =
 
 /** 支付宝系列小程序配置 */
 export interface AlipayConfig {
-  /** 小程序appId */
-  appId: string
+  /** 小程序appid */
+  appid: string
   /** 工具id */
   toolId: string
   /** 私钥文件路径，在获取项目属性和上传时用于鉴权使用(privateKeyPath和privateKey之间必须要填写其中一个) */

--- a/packages/taro-plugin-mini-ci/src/BaseCi.ts
+++ b/packages/taro-plugin-mini-ci/src/BaseCi.ts
@@ -72,7 +72,7 @@ export type DingtalkProjectType =
 /** 工作台组件 */
 'dingtalk-biz-worktab-plugin'
 export interface DingtalkConfig {
-  /** 小程序ID， 必填 */
+  /** 钉钉小程序appid,即钉钉开放平台后台应用管理的 MiniAppId 选项（必填） */
   appid: string
   /** 令牌，从钉钉后台获取 */
   token: string

--- a/packages/taro-plugin-mini-ci/src/BaseCi.ts
+++ b/packages/taro-plugin-mini-ci/src/BaseCi.ts
@@ -88,6 +88,8 @@ export interface SwanConfig {
   token: string
   /** 最低基础库版本, 不传默认为 3.350.6 */
   minSwanVersion?: string
+  /** 小程序开发者工具安装路径 */
+  devToolsInstallPath?: string
 }
 
 export interface CIOptions {

--- a/packages/taro-plugin-mini-ci/src/BaseCi.ts
+++ b/packages/taro-plugin-mini-ci/src/BaseCi.ts
@@ -30,7 +30,7 @@ export interface TTConfig {
 }
 
 /** 终端类型 */
-export type ClientType =
+export type AlipayClientType =
 /** 支付宝 */'alipay' |
 /** AMPE */'ampe' |
 /** 高德 */'amap' |
@@ -59,7 +59,31 @@ export interface AlipayConfig {
   /** 目标项目目录, 默认为 outputPath（可选） */
   project?: string
   /** 上传的终端, 默认alipay */
-  clientType?: ClientType
+  clientType?: AlipayClientType
+}
+
+export type DingtalkProjectType =
+/** 第三方个人应用 */
+'dingtalk-personal'|
+/** 第三方企业应用 */
+'dingtalk-biz-isv'|
+/** 企业内部应用 */
+'dingtalk-biz'|
+/** 企业定制应用 */
+'dingtalk-biz-custom'|
+/** 工作台组件 */
+'dingtalk-biz-worktab-plugin'
+export interface DingtalkConfig {
+  /** 小程序ID， 必填 */
+  appid: string
+  /** 令牌，从钉钉后台获取 */
+  token: string
+  /** 上传的小程序的路径（默认 outputPath ） */
+  projectPath?: string
+  /** 小程序开发者工具安装路径 */
+  devToolsInstallPath?: string
+  /** 钉钉应用类型， 默认为:'dingtalk-biz' (企业内部应用) */
+  projectType?: DingtalkProjectType
 }
 
 /** 百度小程序配置 */
@@ -81,6 +105,8 @@ export interface CIOptions {
   tt?: TTConfig
   /** 支付宝系列小程序配置，官方文档地址： https://opendocs.alipay.com/mini/miniu/api */
   alipay?: AlipayConfig
+  /** 钉钉小程序配置 */
+  dd?: DingtalkConfig
   /** 百度小程序配置, 官方文档地址：https://smartprogram.baidu.com/docs/develop/devtools/commandtool/ */
   swan?: SwanConfig
 }

--- a/packages/taro-plugin-mini-ci/src/BaseCi.ts
+++ b/packages/taro-plugin-mini-ci/src/BaseCi.ts
@@ -159,6 +159,7 @@ export default abstract class BaseCI {
         data: {
           version: this.version,
           desc: this.desc,
+          projectPath: this.projectPath,
           ...data
         },
         error
@@ -180,6 +181,7 @@ export default abstract class BaseCI {
         data: {
           version: this.version,
           desc: this.desc,
+          projectPath: this.projectPath,
           ...data
         },
         error

--- a/packages/taro-plugin-mini-ci/src/BaseCi.ts
+++ b/packages/taro-plugin-mini-ci/src/BaseCi.ts
@@ -13,8 +13,6 @@ export interface WeappConfig {
   privateKeyPath: string
   /** 微信开发者工具安装路径 */
   devToolsInstallPath?: string
-  /** 上传的小程序的路径（默认 outputPath ） */
-  projectPath?: string
   /** 类型，默认miniProgram 小程序 */
   type?: ProjectType
   /** 上传需要排除的目录 */
@@ -58,8 +56,6 @@ export interface AlipayConfig {
   privateKey: string
   /** 小程序开发者工具安装路径 */
   devToolsInstallPath?: string
-  /** 目标项目目录, 默认为 outputPath（可选） */
-  project?: string
   /** 上传的终端, 默认alipay */
   clientType?: AlipayClientType
 }
@@ -80,8 +76,6 @@ export interface DingtalkConfig {
   appid: string
   /** 令牌，从钉钉后台获取 */
   token: string
-  /** 上传的小程序的路径（默认 outputPath ） */
-  projectPath?: string
   /** 小程序开发者工具安装路径 */
   devToolsInstallPath?: string
   /** 钉钉应用类型， 默认为:'dingtalk-biz' (企业内部应用) */
@@ -98,9 +92,11 @@ export interface SwanConfig {
 
 export interface CIOptions {
   /** 发布版本号，默认取 package.json 文件的 taroConfig.version 字段 */
-  version: string
+  version?: string
   /** 版本发布描述， 默认取 package.json 文件的 taroConfig.desc 字段 */
-  desc: string
+  desc?: string
+  /** 目标项目目录，对所有小程序生效（不传默认取 outputRoot 字段 ） */
+  projectPath?: string
   /** 微信小程序CI配置, 官方文档地址：https://developers.weixin.qq.com/miniprogram/dev/devtools/ci.html */
   weapp?: WeappConfig
   /** 头条小程序配置, 官方文档地址：https://microapp.bytedance.com/docs/zh-CN/mini-app/develop/developer-instrument/development-assistance/ide-order-instrument */
@@ -126,6 +122,9 @@ export default abstract class BaseCI {
   /** 当前发布内容的描述 */
   protected desc: string
 
+  /** 命令要操作的项目目录 */
+  protected projectPath: string
+
   constructor (ctx: IPluginContext, pluginOpts: CIOptions) {
     this.ctx = ctx
     this.pluginOpts = pluginOpts
@@ -140,7 +139,10 @@ export default abstract class BaseCI {
     this.version = pluginOpts.version || packageInfo.taroConfig?.version || '1.0.0'
     this.desc = pluginOpts.desc || packageInfo.taroConfig?.desc || `CI构建自动构建于${new Date().toLocaleTimeString()}`
 
-    this._init()
+  }
+
+  setProjectPath (path: string) {
+    this.projectPath = path
   }
 
   /** 执行预览命令后触发 */
@@ -185,8 +187,8 @@ export default abstract class BaseCI {
     })
   }
 
-  /** 初始化函数，会被构造函数调用 */
-  protected abstract _init(): void
+  /** 初始化函数，new实例化后会被立即调用一次 */
+  abstract init(): void
 
   /** 打开小程序项目 */
   abstract open()

--- a/packages/taro-plugin-mini-ci/src/BaseCi.ts
+++ b/packages/taro-plugin-mini-ci/src/BaseCi.ts
@@ -7,7 +7,7 @@ export type ProjectType = 'miniProgram' | 'miniGame' | 'miniProgramPlugin' | 'mi
 export interface WeappConfig {
   /** 小程序/小游戏项目的 appid */
   appid: string
-  /** 私钥，在获取项目属性和上传时用于鉴权使用(必填) */
+  /** 私钥文件路径，在获取项目属性和上传时用于鉴权使用 */
   privateKeyPath: string
   /** 微信开发者工具安装路径 */
   devToolsInstallPath?: string
@@ -38,11 +38,11 @@ export type ClientType =
 /** ALIOS */ 'alios'|
 /** UC */'uc'|
 /** 夸克 */ 'quark'|
-/** 淘宝 */ 'taobao'|
 /** 口碑 */'koubei' |
 /** loT */'alipayiot'|
 /** 菜鸟 */'cainiao' |
-/** 阿里健康 */ 'alihealth'
+/** 阿里健康(医蝶谷) */ 'alihealth'|
+/** 阿里医院 */ 'health'
 
 /** 支付宝系列小程序配置 */
 export interface AlipayConfig {
@@ -50,12 +50,12 @@ export interface AlipayConfig {
   appId: string
   /** 工具id */
   toolId: string
+  /** 私钥文件路径，在获取项目属性和上传时用于鉴权使用(privateKeyPath和privateKey之间必须要填写其中一个) */
+  privateKeyPath: string
+  /** 私钥文本内容，在获取项目属性和上传时用于鉴权使用(privateKeyPath和privateKey之间必须要填写其中一个) */
+  privateKey: string
   /** 小程序开发者工具安装路径 */
   devToolsInstallPath?: string
-  /** 私钥相对路径 */
-  privateKeyPath: string
-  /** 服务代理地址（可选） */
-  proxy?: string
   /** 目标项目目录, 默认为 outputPath（可选） */
   project?: string
   /** 上传的终端, 默认alipay */

--- a/packages/taro-plugin-mini-ci/src/BaseCi.ts
+++ b/packages/taro-plugin-mini-ci/src/BaseCi.ts
@@ -1,6 +1,8 @@
 import { IPluginContext } from '@tarojs/service'
 import * as path from 'path'
 
+import { ON_PREVIEW_COMPLETE, ON_UPLOAD_COMPLETE } from './hooks'
+
 export type ProjectType = 'miniProgram' | 'miniGame' | 'miniProgramPlugin' | 'miniGamePlugin';
 
 /** 微信小程序配置 */
@@ -139,6 +141,28 @@ export default abstract class BaseCI {
     this.desc = pluginOpts.desc || packageInfo.taroConfig?.desc || `CI构建自动构建于${new Date().toLocaleTimeString()}`
 
     this._init()
+  }
+
+  async triggerPreviewHooks (content: { platform: string, qrCodeLocalPath: string, qrCodeContent: string }) {
+    await this.ctx.applyPlugins({
+      name: ON_PREVIEW_COMPLETE,
+      opts: {
+        version: this.version,
+        desc: this.desc,
+        ...content
+      }
+    })
+  }
+
+  async triggerUploadHooks (content: { platform: string, qrCodeLocalPath: string, qrCodeContent: string }) {
+    await this.ctx.applyPlugins({
+      name: ON_UPLOAD_COMPLETE,
+      opts: {
+        version: this.version,
+        desc: this.desc,
+        ...content
+      }
+    })
   }
 
   /** 初始化函数，会被构造函数调用 */

--- a/packages/taro-plugin-mini-ci/src/DingtalkCI.ts
+++ b/packages/taro-plugin-mini-ci/src/DingtalkCI.ts
@@ -1,0 +1,163 @@
+/* eslint-disable no-console */
+import * as fs from 'fs'
+import * as path from 'path'
+
+import BaseCI from './BaseCi'
+import { AlipayInstance, DingTalk } from './types'
+import { getNpmPkgSync } from './utils/npm'
+import { generateQrcodeImageFile } from './utils/qrcode'
+
+/**
+ * 钉钉小程序CI https://github.com/open-dingtalk/dingtalk-design-cli/blob/develop/packages/opensdk/package.json
+ */
+export default class DingtalkCI extends BaseCI {
+  protected dingtalkSDK: DingTalk.MiniAppOpenSDK
+
+  private entryPage: string
+
+  protected _init (): void {
+    if (this.pluginOpts.dd == null) {
+      throw new Error('请为"@tarojs/plugin-mini-ci"插件配置 "dd" 选项')
+    }
+    const { printLog, processTypeEnum, chalk } = this.ctx.helper
+    const { outputPath } = this.ctx.paths
+    const { token, projectPath } = this.pluginOpts.dd!
+    try {
+      this.dingtalkSDK = getNpmPkgSync('dingtalk-miniapp-opensdk', process.cwd()).sdk
+    } catch (error) {
+      printLog( processTypeEnum.ERROR, chalk.red('请安装依赖：dingtalk-miniapp-opensdk , 该依赖用于CI预览、上传钉钉小程序'))
+      process.exit(1)
+    }
+
+    this.dingtalkSDK.setConfig({
+      appKey: '',
+      appSecret: '',
+      accessToken: token,
+      host: 'https://oapi.dingtalk.com',
+    })
+
+    const appInfo = JSON.parse(
+      fs.readFileSync(path.join(projectPath || outputPath, 'app.json'), {
+        encoding: 'utf8'
+      })
+    )
+    this.entryPage = appInfo.pages[0]
+  }
+
+  //  和支付宝小程序共用ide
+  async open () {
+    const { projectPath, devToolsInstallPath, projectType = 'dingtalk-biz' } = this.pluginOpts.dd!
+    const { chalk, printLog, processTypeEnum } = this.ctx.helper
+    const { outputPath } = this.ctx.paths
+    let minidev: AlipayInstance
+    try {
+      minidev = getNpmPkgSync('minidev', process.cwd())
+    } catch (error) {
+      printLog(processTypeEnum.ERROR, chalk.red('请安装依赖：minidev ,该依赖用于编译后自动打开小程序开发者工具'))
+      process.exit(1)
+    }
+    try {
+      await minidev.minidev.startIde(
+        Object.assign(
+          {
+            project: projectPath || outputPath,
+            projectType,
+          },
+          devToolsInstallPath ? { appPath: devToolsInstallPath } : {}
+        )
+      )
+      printLog(processTypeEnum.START, '打开 IDE 成功')
+    } catch (error) {
+      printLog(processTypeEnum.ERROR, chalk.red(error.message))
+    }
+  }
+
+  //  特性： CI 内部会自己打印二维码； 预览版不会上传到后台，只有预览码作为入口访问
+  async preview () {
+    const { chalk, printLog, processTypeEnum } = this.ctx.helper
+    const { outputPath } = this.ctx.paths
+    const { appid,  projectPath } = this.pluginOpts.dd!
+    
+
+    try {
+      const previewUrl = await this.dingtalkSDK.previewBuild({
+        project: projectPath || outputPath,
+        miniAppId: appid,
+        page: this.entryPage,
+        query: '',
+        ignoreHttpReqPermission: true,
+        ignoreWebViewDomainCheck: true,
+        buildTarget: 'Preview',
+        onProgressUpdate (info) {
+          //   logger.debug('拉取构建结果', info);
+          console.log('info.status', info.status)
+          if (info.status === 'failed') {
+            console.error('构建失败')
+          } else if (info.status === 'overtime') {
+            console.error('构建超时')
+          } else if (info.status === 'success') {
+            console.log('构建成功', info)
+          }
+        },
+      })
+
+      const previewQrcodePath = path.join(outputPath, 'preview.png')
+      await generateQrcodeImageFile(previewQrcodePath, previewUrl)
+      printLog(processTypeEnum.REMIND, `预览版二维码已生成，存储在:"${ previewQrcodePath }",二维码内容是："${ previewUrl }"`)
+    } catch (error) {
+      printLog(processTypeEnum.ERROR, chalk.red(`预览失败 ${ new Date().toLocaleString() } \n${ error.message }`))
+    }
+  }
+
+  // 特性： CI内部暂时未支持上传后返回体验码,等待官方支持： https://github.com/open-dingtalk/dingtalk-design-cli/issues/34
+  async upload () {
+    const { chalk, printLog, processTypeEnum } = this.ctx.helper
+    const { outputPath } = this.ctx.paths
+    const {  appid, projectPath } = this.pluginOpts.dd!
+    printLog(processTypeEnum.START, '上传代码到钉钉小程序后台')
+
+    let hasDone = false
+    const uploadCommonParams = {
+      project: projectPath || outputPath,
+      miniAppId: appid,
+      packageVersion: this.version
+    }
+
+    try {
+      const result = await this.dingtalkSDK.miniUpload({
+        ...uploadCommonParams,
+        onProgressUpdate: info => {
+          console.log(info)
+          const { data = {} as any, status } = info
+          const logId = path.basename(data.logUrl || '')
+          // @ts-ignore
+          const log = data.log
+
+          if (status === 'success') {
+            if (!hasDone) {
+              console.log('构建成功')
+              console.log('本次上传版本号', data.version)
+              hasDone = true
+            }
+          } else if (status === 'building') {
+            console.log(
+              `构建中，正在查询构建结果。 ${
+                logId ? `logId: ${logId}` : ''
+              }`
+            )
+          } else if (status === 'overtime') {
+            console.log('构建超时，请重试', log)
+          } else if (status === 'failed') {
+            console.log('构建失败', logId)
+            console.error(log)
+          }
+        }
+      })
+
+      // 体验码规则：dingtalk://dingtalkclient/action/open_micro_app?corpId=xxx&miniAppId=yyy&source=trial&version=构建id&agentId=xxx&pVersion=1&packageType=1
+      console.log(chalk.green(`版本 ${ result.packageVersion } 上传成功 ${new Date().toLocaleString()}`))
+    } catch (error) {
+      printLog(processTypeEnum.ERROR, chalk.red(`体验版上传失败 ${new Date().toLocaleString()} \n${error.message}`))
+    }
+  }
+}

--- a/packages/taro-plugin-mini-ci/src/DingtalkCI.ts
+++ b/packages/taro-plugin-mini-ci/src/DingtalkCI.ts
@@ -104,6 +104,11 @@ export default class DingtalkCI extends BaseCI {
       const previewQrcodePath = path.join(outputPath, 'preview.png')
       await generateQrcodeImageFile(previewQrcodePath, previewUrl)
       printLog(processTypeEnum.REMIND, `预览版二维码已生成，存储在:"${ previewQrcodePath }",二维码内容是："${ previewUrl }"`)
+      this.triggerPreviewHooks({
+        platform: 'dd',
+        qrCodeContent: previewUrl,
+        qrCodeLocalPath: previewQrcodePath
+      })
     } catch (error) {
       printLog(processTypeEnum.ERROR, chalk.red(`预览失败 ${ new Date().toLocaleString() } \n${ error.message }`))
     }
@@ -156,6 +161,11 @@ export default class DingtalkCI extends BaseCI {
 
       // 体验码规则：dingtalk://dingtalkclient/action/open_micro_app?corpId=xxx&miniAppId=yyy&source=trial&version=构建id&agentId=xxx&pVersion=1&packageType=1
       console.log(chalk.green(`版本 ${ result.packageVersion } 上传成功 ${new Date().toLocaleString()}`))
+      this.triggerUploadHooks({
+        platform: 'dd',
+        qrCodeContent: '',
+        qrCodeLocalPath: ''
+      })
     } catch (error) {
       printLog(processTypeEnum.ERROR, chalk.red(`体验版上传失败 ${new Date().toLocaleString()} \n${error.message}`))
     }

--- a/packages/taro-plugin-mini-ci/src/DingtalkCI.ts
+++ b/packages/taro-plugin-mini-ci/src/DingtalkCI.ts
@@ -104,13 +104,27 @@ export default class DingtalkCI extends BaseCI {
       const previewQrcodePath = path.join(outputPath, 'preview.png')
       await generateQrcodeImageFile(previewQrcodePath, previewUrl)
       printLog(processTypeEnum.REMIND, `预览版二维码已生成，存储在:"${ previewQrcodePath }",二维码内容是："${ previewUrl }"`)
+
       this.triggerPreviewHooks({
-        platform: 'dd',
-        qrCodeContent: previewUrl,
-        qrCodeLocalPath: previewQrcodePath
+        success: true,
+        data: {
+          platform: 'dd',
+          qrCodeContent: previewUrl,
+          qrCodeLocalPath: previewQrcodePath
+        }
       })
     } catch (error) {
       printLog(processTypeEnum.ERROR, chalk.red(`预览失败 ${ new Date().toLocaleString() } \n${ error.message }`))
+
+      this.triggerPreviewHooks({
+        success: false,
+        data: {
+          platform: 'dd',
+          qrCodeContent: '',
+          qrCodeLocalPath: ''
+        },
+        error
+      })
     }
   }
 
@@ -161,13 +175,27 @@ export default class DingtalkCI extends BaseCI {
 
       // 体验码规则：dingtalk://dingtalkclient/action/open_micro_app?corpId=xxx&miniAppId=yyy&source=trial&version=构建id&agentId=xxx&pVersion=1&packageType=1
       console.log(chalk.green(`版本 ${ result.packageVersion } 上传成功 ${new Date().toLocaleString()}`))
+
       this.triggerUploadHooks({
-        platform: 'dd',
-        qrCodeContent: '',
-        qrCodeLocalPath: ''
+        success: true,
+        data: {
+          platform: 'dd',
+          qrCodeContent: '',
+          qrCodeLocalPath: ''
+        }
       })
     } catch (error) {
       printLog(processTypeEnum.ERROR, chalk.red(`体验版上传失败 ${new Date().toLocaleString()} \n${error.message}`))
+
+      this.triggerUploadHooks({
+        success: false,
+        data: {
+          platform: 'dd',
+          qrCodeContent: '',
+          qrCodeLocalPath: ''
+        },
+        error
+      })
     }
   }
 }

--- a/packages/taro-plugin-mini-ci/src/QRCode.ts
+++ b/packages/taro-plugin-mini-ci/src/QRCode.ts
@@ -1,7 +1,0 @@
-/**
- * 生产二维码输出到控制台
- * @param url 链接地址
- */
-export default function generateQrCode (url: string) {
-  require('qrcode-terminal').generate(url, { small: true })
-}

--- a/packages/taro-plugin-mini-ci/src/SwanCI.ts
+++ b/packages/taro-plugin-mini-ci/src/SwanCI.ts
@@ -3,7 +3,8 @@ import * as path from 'path'
 import * as shell from 'shelljs'
 
 import BaseCI from './BaseCi'
-import generateQrCode from './QRCode'
+import {  resolveNpmSync } from './utils/npm'
+import { generateQrcodeImageFile, printQrcode2Terminal } from './utils/qrcode'
 
 export default class SwanCI extends BaseCI {
   private swanBin
@@ -12,16 +13,38 @@ export default class SwanCI extends BaseCI {
     if (this.pluginOpts.swan == null) {
       throw new Error('请为"@tarojs/plugin-mini-ci"插件配置 "swan" 选项')
     }
+    const { chalk, printLog, processTypeEnum } = this.ctx.helper
     try {
-      this.swanBin = path.resolve(require.resolve('swan-toolkit'), '../../.bin/swan')
+      this.swanBin = resolveNpmSync('swan-toolkit/bin/swan',process.cwd())
     } catch (error) {
-      throw new Error('请安装依赖：swan-toolkit')
+      printLog(processTypeEnum.ERROR, chalk.red('请安装依赖：swan-toolkit'))
+      process.exit(1)
     }
   }
 
   open () {
     const { printLog, processTypeEnum } = this.ctx.helper
     printLog(processTypeEnum.WARNING, '百度小程序不支持 "--open" 参数打开开发者工具')
+  }
+
+  async preview () {
+    const { outputPath } = this.ctx.paths
+    const { printLog, processTypeEnum } = this.ctx.helper
+    const previewQrcodePath = path.join(outputPath, 'preview.png')
+    printLog(processTypeEnum.START, '预览百度小程序')
+    shell.exec(`${this.swanBin} preview --project-path ${outputPath} --token ${this.pluginOpts.swan!.token} --min-swan-version ${this.pluginOpts.swan!.minSwanVersion || '3.350.6'} --json`, async (_code, stdout, stderr) => {
+      if (!stderr) {
+        stdout = JSON.parse(stdout)
+        const qrContent = stdout.list[0].url
+        // console.log('预览图片：', stdout.list[0].urlBase64)
+        await printQrcode2Terminal(qrContent)
+        await generateQrcodeImageFile(previewQrcodePath, qrContent)
+        printLog(
+          processTypeEnum.REMIND,
+          `预览二维码已生成，存储在:"${ previewQrcodePath }",二维码内容是：${ qrContent }`
+        )
+      }
+    })
   }
 
   async upload () {
@@ -31,24 +54,11 @@ export default class SwanCI extends BaseCI {
     printLog(processTypeEnum.REMIND, `本次上传版本号为："${this.version}"，上传描述为：“${this.desc}”`)
     shell.exec(`${this.swanBin} upload --project-path ${outputPath} --token ${this.pluginOpts.swan!.token} --release-version ${this.version} --min-swan-version ${this.pluginOpts.swan!.minSwanVersion || '3.350.6'} --desc ${this.desc} --json`, (_code, _stdout, stderr) => {
       if (!stderr) {
+        // TODO 没有百度小程序账号， 不知道它的上传码规则
         // stdout = JSON.parse(stdout)
         console.log(chalk.green(`上传成功 ${new Date().toLocaleString()}`))
       }
     })
   }
-
-  async preview () {
-    const { outputPath } = this.ctx.paths
-    const { printLog, processTypeEnum } = this.ctx.helper
-    printLog(processTypeEnum.START, '预览百度小程序')
-    shell.exec(`${this.swanBin} preview --project-path ${outputPath} --token ${this.pluginOpts.swan!.token} --min-swan-version ${this.pluginOpts.swan!.minSwanVersion || '3.350.6'} --json`, (_code, stdout, stderr) => {
-      if (!stderr) {
-        stdout = JSON.parse(stdout)
-        console.log('在线预览地址：', stdout.list[0].url)
-        // console.log('预览图片：', stdout.list[0].urlBase64)
-        // 需要自己将预览二维码打印到控制台
-        generateQrCode(stdout.list[0].url)
-      }
-    })
-  }
+  
 }

--- a/packages/taro-plugin-mini-ci/src/SwanCI.ts
+++ b/packages/taro-plugin-mini-ci/src/SwanCI.ts
@@ -22,9 +22,18 @@ export default class SwanCI extends BaseCI {
     }
   }
 
-  open () {
-    const { printLog, processTypeEnum } = this.ctx.helper
-    printLog(processTypeEnum.WARNING, '百度小程序不支持 "--open" 参数打开开发者工具')
+  async open () {
+    // 官方CI包不支持CLI打开IDE，吾通过查看百度开发者工具安装包下的cli文件、以及类比微信开发者工具的调用方式，再加上一点“推理”，发现了调用协议，从而实现了此功能
+    const { printLog, processTypeEnum, fs } = this.ctx.helper
+    const isMac = process.platform === 'darwin'
+    const devToolsInstallPath = this.pluginOpts.swan!.devToolsInstallPath || (isMac ? '/Applications/百度开发者工具.app' : 'C:\\Program Files (x86)\\百度开发者工具')
+    const cliPath = path.join(devToolsInstallPath, isMac ? '/Contents/MacOS/cli' : '/cli.bat')
+
+    if (!(await fs.pathExists(cliPath))) {
+      printLog(processTypeEnum.ERROR, '命令行工具路径不存在', cliPath)
+    }
+    printLog(processTypeEnum.START, '百度开发者工具...', this.projectPath)
+    shell.exec(`${cliPath}  --project-path ${this.projectPath}`)
   }
 
   async preview () {

--- a/packages/taro-plugin-mini-ci/src/SwanCI.ts
+++ b/packages/taro-plugin-mini-ci/src/SwanCI.ts
@@ -9,7 +9,7 @@ import { generateQrcodeImageFile, printQrcode2Terminal } from './utils/qrcode'
 export default class SwanCI extends BaseCI {
   private swanBin
 
-  protected _init (): void {
+  init (): void {
     if (this.pluginOpts.swan == null) {
       throw new Error('请为"@tarojs/plugin-mini-ci"插件配置 "swan" 选项')
     }
@@ -28,11 +28,10 @@ export default class SwanCI extends BaseCI {
   }
 
   async preview () {
-    const { outputPath } = this.ctx.paths
     const { printLog, processTypeEnum } = this.ctx.helper
-    const previewQrcodePath = path.join(outputPath, 'preview.png')
+    const previewQrcodePath = path.join(this.projectPath, 'preview.png')
     printLog(processTypeEnum.START, '预览百度小程序')
-    shell.exec(`${this.swanBin} preview --project-path ${outputPath} --token ${this.pluginOpts.swan!.token} --min-swan-version ${this.pluginOpts.swan!.minSwanVersion || '3.350.6'} --json`, async (_code, stdout, stderr) => {
+    shell.exec(`${this.swanBin} preview --project-path ${this.projectPath} --token ${this.pluginOpts.swan!.token} --min-swan-version ${this.pluginOpts.swan!.minSwanVersion || '3.350.6'} --json`, async (_code, stdout, stderr) => {
       if (!stderr) {
         stdout = JSON.parse(stdout)
         const qrContent = stdout.list[0].url
@@ -68,11 +67,10 @@ export default class SwanCI extends BaseCI {
   }
 
   async upload () {
-    const { outputPath } = this.ctx.paths
     const { chalk, printLog, processTypeEnum } = this.ctx.helper
     printLog(processTypeEnum.START, '上传体验版代码到百度后台')
     printLog(processTypeEnum.REMIND, `本次上传版本号为："${this.version}"，上传描述为：“${this.desc}”`)
-    shell.exec(`${this.swanBin} upload --project-path ${outputPath} --token ${this.pluginOpts.swan!.token} --release-version ${this.version} --min-swan-version ${this.pluginOpts.swan!.minSwanVersion || '3.350.6'} --desc ${this.desc} --json`, (_code, _stdout, stderr) => {
+    shell.exec(`${this.swanBin} upload --project-path ${this.projectPath} --token ${this.pluginOpts.swan!.token} --release-version ${this.version} --min-swan-version ${this.pluginOpts.swan!.minSwanVersion || '3.350.6'} --desc ${this.desc} --json`, (_code, _stdout, stderr) => {
       if (!stderr) {
         // TODO 没有百度小程序账号， 不知道它的上传码规则
         // stdout = JSON.parse(stdout)

--- a/packages/taro-plugin-mini-ci/src/SwanCI.ts
+++ b/packages/taro-plugin-mini-ci/src/SwanCI.ts
@@ -43,6 +43,13 @@ export default class SwanCI extends BaseCI {
           processTypeEnum.REMIND,
           `预览二维码已生成，存储在:"${ previewQrcodePath }",二维码内容是：${ qrContent }`
         )
+
+        this.triggerPreviewHooks({
+          platform: 'swan',
+          qrCodeContent: qrContent,
+          qrCodeLocalPath: previewQrcodePath
+        })
+
       }
     })
   }
@@ -57,6 +64,12 @@ export default class SwanCI extends BaseCI {
         // TODO 没有百度小程序账号， 不知道它的上传码规则
         // stdout = JSON.parse(stdout)
         console.log(chalk.green(`上传成功 ${new Date().toLocaleString()}`))
+        
+        this.triggerUploadHooks({
+          platform: 'swan',
+          qrCodeContent: '',
+          qrCodeLocalPath: ''
+        })
       }
     })
   }

--- a/packages/taro-plugin-mini-ci/src/SwanCI.ts
+++ b/packages/taro-plugin-mini-ci/src/SwanCI.ts
@@ -34,6 +34,7 @@ export default class SwanCI extends BaseCI {
     shell.exec(`${this.swanBin} preview --project-path ${this.projectPath} --token ${this.pluginOpts.swan!.token} --min-swan-version ${this.pluginOpts.swan!.minSwanVersion || '3.350.6'} --json`, async (_code, stdout, stderr) => {
       if (!stderr) {
         stdout = JSON.parse(stdout)
+        // @ts-ignore
         const qrContent = stdout.list[0].url
         // console.log('预览图片：', stdout.list[0].urlBase64)
         await printQrcode2Terminal(qrContent)
@@ -60,7 +61,7 @@ export default class SwanCI extends BaseCI {
             qrCodeContent: '',
             qrCodeLocalPath: ''
           },
-          error: stderr
+          error: new Error(stderr.split('\n')[0])
         })
       }
     })
@@ -92,7 +93,7 @@ export default class SwanCI extends BaseCI {
             qrCodeContent: '',
             qrCodeLocalPath: ''
           },
-          error: stderr
+          error: new Error(stderr.split('\n')[0])
         })
       }
     })

--- a/packages/taro-plugin-mini-ci/src/SwanCI.ts
+++ b/packages/taro-plugin-mini-ci/src/SwanCI.ts
@@ -45,11 +45,24 @@ export default class SwanCI extends BaseCI {
         )
 
         this.triggerPreviewHooks({
-          platform: 'swan',
-          qrCodeContent: qrContent,
-          qrCodeLocalPath: previewQrcodePath
+          success: true,
+          data: {
+            platform: 'swan',
+            qrCodeContent: qrContent,
+            qrCodeLocalPath: previewQrcodePath
+          }
         })
 
+      } else {
+        this.triggerPreviewHooks({
+          success: false,
+          data: {
+            platform: 'swan',
+            qrCodeContent: '',
+            qrCodeLocalPath: ''
+          },
+          error: stderr
+        })
       }
     })
   }
@@ -66,9 +79,22 @@ export default class SwanCI extends BaseCI {
         console.log(chalk.green(`上传成功 ${new Date().toLocaleString()}`))
         
         this.triggerUploadHooks({
-          platform: 'swan',
-          qrCodeContent: '',
-          qrCodeLocalPath: ''
+          success: true,
+          data: {
+            platform: 'swan',
+            qrCodeContent: '',
+            qrCodeLocalPath: ''
+          }
+        })
+      } else {
+        this.triggerUploadHooks({
+          success: false,
+          data: {
+            platform: 'swan',
+            qrCodeContent: '',
+            qrCodeLocalPath: ''
+          },
+          error: stderr
         })
       }
     })

--- a/packages/taro-plugin-mini-ci/src/TTCI.ts
+++ b/packages/taro-plugin-mini-ci/src/TTCI.ts
@@ -9,7 +9,7 @@ import { printQrcode2Terminal } from './utils/qrcode'
 export default class TTCI extends BaseCI {
   tt: TTInstance
 
-  _init () {
+  init () {
     const { chalk, printLog, processTypeEnum } = this.ctx.helper
     if (this.pluginOpts.tt == null) {
       printLog(processTypeEnum.ERROR, chalk.red(('请为"@tarojs/plugin-mini-ci"插件配置 "tt" 选项')))
@@ -33,16 +33,15 @@ export default class TTCI extends BaseCI {
   }
 
   async open () {
-    const { outputPath: projectPath } = this.ctx.paths
     const { chalk, printLog, processTypeEnum } = this.ctx.helper
-    printLog(processTypeEnum.START, '字节跳动开发者工具...')
+    printLog(processTypeEnum.START, '启动字节跳动开发者工具...', this.projectPath)
     try {
       await this.tt.open({
         project: {
-          path: projectPath
+          path: this.projectPath
         }
       })
-      console.log(chalk.green('打开IDE成功'))
+      console.log(chalk.green(`打开IDE成功`))
     } catch (error) {
       printLog(processTypeEnum.ERROR, chalk.red('打开IDE失败', error))
     }
@@ -51,13 +50,12 @@ export default class TTCI extends BaseCI {
   async preview () {
     await this._beforeCheck()
     const { chalk, printLog, processTypeEnum } = this.ctx.helper
-    const { outputPath } = this.ctx.paths
     try {
       printLog(processTypeEnum.START, '预览字节跳动小程序')
-      const previewQrcodePath = path.join(outputPath, 'preview.png')
+      const previewQrcodePath = path.join(this.projectPath, 'preview.png')
       const previewResult = await this.tt.preview({
         project: {
-          path: outputPath
+          path: this.projectPath
         },
         // @ts-ignore
         page: {
@@ -105,14 +103,13 @@ export default class TTCI extends BaseCI {
   async upload () {
     await this._beforeCheck()
     const { chalk, printLog, processTypeEnum } = this.ctx.helper
-    const { outputPath } = this.ctx.paths
     try {
       printLog(processTypeEnum.START, '上传代码到字节跳动后台')
       printLog(processTypeEnum.REMIND, `本次上传版本号为："${ this.version }"，上传描述为：“${ this.desc }”`)
-      const uploadQrcodePath = path.join(outputPath, 'upload.png')
+      const uploadQrcodePath = path.join(this.projectPath, 'upload.png')
       const uploadResult = await this.tt.upload({
         project: {
-          path: outputPath
+          path: this.projectPath
         },
         qrcode: {
           format: 'imageFile',

--- a/packages/taro-plugin-mini-ci/src/TTCI.ts
+++ b/packages/taro-plugin-mini-ci/src/TTCI.ts
@@ -79,12 +79,26 @@ export default class TTCI extends BaseCI {
       )
 
       this.triggerPreviewHooks({
-        platform: 'tt',
-        qrCodeContent: qrContent,
-        qrCodeLocalPath: previewQrcodePath
+        success: true,
+        data: {
+          platform: 'tt',
+          qrCodeContent: qrContent,
+          qrCodeLocalPath: previewQrcodePath
+        }
       })
+
     } catch (error) {
       printLog(processTypeEnum.ERROR, chalk.red(`上传失败 ${ new Date().toLocaleString() } \n${ error }`))
+
+      this.triggerPreviewHooks({
+        success: false,
+        data: {
+          platform: 'tt',
+          qrCodeContent: '',
+          qrCodeLocalPath: ''
+        },
+        error
+      })
     }
   }
 
@@ -118,12 +132,25 @@ export default class TTCI extends BaseCI {
       )
 
       this.triggerUploadHooks({
-        platform: 'tt',
-        qrCodeContent: qrContent,
-        qrCodeLocalPath: uploadQrcodePath
+        success: true,
+        data: {
+          platform: 'tt',
+          qrCodeContent: qrContent,
+          qrCodeLocalPath: uploadQrcodePath
+        }
       })
     } catch (error) {
       printLog(processTypeEnum.ERROR, chalk.red(`上传失败 ${ new Date().toLocaleString() } \n${ error }`))
+
+      this.triggerUploadHooks({
+        success: false,
+        data: {
+          platform: 'tt',
+          qrCodeContent: '',
+          qrCodeLocalPath: ''
+        },
+        error
+      })
     }
   }
 }

--- a/packages/taro-plugin-mini-ci/src/TTCI.ts
+++ b/packages/taro-plugin-mini-ci/src/TTCI.ts
@@ -71,11 +71,18 @@ export default class TTCI extends BaseCI {
         cache: true
       })
       console.log(chalk.green(`开发版上传成功 ${ new Date().toLocaleString() }\n`))
-      await printQrcode2Terminal(previewResult.shortUrl)
+      const qrContent = previewResult.shortUrl
+      await printQrcode2Terminal(qrContent)
       printLog(
         processTypeEnum.REMIND,
-        `预览二维码已生成，存储在:"${ previewQrcodePath }",二维码内容是：${ previewResult.shortUrl },过期时间：${ new Date(previewResult.expireTime * 1000).toLocaleString() }`
+        `预览二维码已生成，存储在:"${ previewQrcodePath }",二维码内容是：${ qrContent },过期时间：${ new Date(previewResult.expireTime * 1000).toLocaleString() }`
       )
+
+      this.triggerPreviewHooks({
+        platform: 'tt',
+        qrCodeContent: qrContent,
+        qrCodeLocalPath: previewQrcodePath
+      })
     } catch (error) {
       printLog(processTypeEnum.ERROR, chalk.red(`上传失败 ${ new Date().toLocaleString() } \n${ error }`))
     }
@@ -103,11 +110,18 @@ export default class TTCI extends BaseCI {
         copyToClipboard: false
       })
       console.log(chalk.green(`体验版版上传成功 ${ new Date().toLocaleString() }\n`))
-      await printQrcode2Terminal(uploadResult.shortUrl)
+      const qrContent = uploadResult.shortUrl
+      await printQrcode2Terminal(qrContent)
       printLog(
         processTypeEnum.REMIND,
-        `体验版二维码已生成，存储在:"${ uploadQrcodePath }",二维码内容是："${ uploadResult.shortUrl }", 过期时间：${ new Date(uploadResult.expireTime * 1000).toLocaleString() }`
+        `体验版二维码已生成，存储在:"${ uploadQrcodePath }",二维码内容是："${ qrContent}", 过期时间：${ new Date(uploadResult.expireTime * 1000).toLocaleString() }`
       )
+
+      this.triggerUploadHooks({
+        platform: 'tt',
+        qrCodeContent: qrContent,
+        qrCodeLocalPath: uploadQrcodePath
+      })
     } catch (error) {
       printLog(processTypeEnum.ERROR, chalk.red(`上传失败 ${ new Date().toLocaleString() } \n${ error }`))
     }

--- a/packages/taro-plugin-mini-ci/src/TTCI.ts
+++ b/packages/taro-plugin-mini-ci/src/TTCI.ts
@@ -2,7 +2,8 @@
 import * as path from 'path'
 
 import BaseCI from './BaseCi'
-import {TTInstance} from './types'
+import { TTInstance } from './types'
+import { getNpmPkgSync } from './utils/npm'
 import { printQrcode2Terminal } from './utils/qrcode'
 
 export default class TTCI extends BaseCI {
@@ -11,11 +12,12 @@ export default class TTCI extends BaseCI {
   _init () {
     const { chalk, printLog, processTypeEnum } = this.ctx.helper
     if (this.pluginOpts.tt == null) {
-      throw new Error('请为"@tarojs/plugin-mini-ci"插件配置 "tt" 选项')
+      printLog(processTypeEnum.ERROR, chalk.red(('请为"@tarojs/plugin-mini-ci"插件配置 "tt" 选项')))
+      process.exit(1)
     }
     try {
       // 调试使用版本是： tt-ide-cli@0.1.13
-      this.tt = require('tt-ide-cli')
+      this.tt = getNpmPkgSync('tt-ide-cli',process.cwd())
     } catch (error) {
       printLog(processTypeEnum.ERROR, chalk.red('请安装依赖：tt-ide-cli'))
       process.exit(1)
@@ -67,11 +69,14 @@ export default class TTCI extends BaseCI {
         copyToClipboard: true,
         cache: true
       })
-      console.log(chalk.green(`开发版上传成功 ${new Date().toLocaleString()}\n`))
+      console.log(chalk.green(`开发版上传成功 ${ new Date().toLocaleString() }\n`))
       printQrcode2Terminal(previewResult.shortUrl)
-      printLog(processTypeEnum.REMIND, `预览二维码已生成，存储在:"${previewQrcodePath}",二维码内容是：${previewResult.shortUrl},过期时间：${new Date(previewResult.expireTime * 1000).toLocaleString()}`)
+      printLog(
+        processTypeEnum.REMIND,
+        `预览二维码已生成，存储在:"${ previewQrcodePath }",二维码内容是：${ previewResult.shortUrl },过期时间：${ new Date(previewResult.expireTime * 1000).toLocaleString() }`
+      )
     } catch (error) {
-      printLog(processTypeEnum.ERROR, chalk.red(`上传失败 ${new Date().toLocaleString()} \n${error.message}`))
+      printLog(processTypeEnum.ERROR, chalk.red(`上传失败 ${ new Date().toLocaleString() } \n${ error.message }`))
     }
   }
 
@@ -81,7 +86,7 @@ export default class TTCI extends BaseCI {
     const { outputPath } = this.ctx.paths
     try {
       printLog(processTypeEnum.START, '上传代码到字节跳动后台')
-      printLog(processTypeEnum.REMIND, `本次上传版本号为："${this.version}"，上传描述为：“${this.desc}”`)
+      printLog(processTypeEnum.REMIND, `本次上传版本号为："${ this.version }"，上传描述为：“${ this.desc }”`)
       const uploadQrcodePath = path.join(outputPath, 'upload.png')
       const uploadResult = await this.tt.upload({
         project: {
@@ -95,10 +100,13 @@ export default class TTCI extends BaseCI {
         changeLog: this.desc,
         needUploadSourcemap: true
       })
-      console.log(chalk.green(`体验版版上传成功 ${new Date().toLocaleString()}\n`))
-      printLog(processTypeEnum.REMIND, `体验版二维码已生成，存储在:"${uploadQrcodePath}",二维码内容是："${uploadResult.shortUrl}", 过期时间：${new Date(uploadResult.expireTime * 1000).toLocaleString()}`)
+      console.log(chalk.green(`体验版版上传成功 ${ new Date().toLocaleString() }\n`))
+      printLog(
+        processTypeEnum.REMIND,
+        `体验版二维码已生成，存储在:"${ uploadQrcodePath }",二维码内容是："${ uploadResult.shortUrl }", 过期时间：${ new Date(uploadResult.expireTime * 1000).toLocaleString() }`
+      )
     } catch (error) {
-      printLog(processTypeEnum.ERROR, chalk.red(`上传失败 ${new Date().toLocaleString()} \n${error.message}`))
+      printLog(processTypeEnum.ERROR, chalk.red(`上传失败 ${ new Date().toLocaleString() } \n${ error.message }`))
     }
   }
 }

--- a/packages/taro-plugin-mini-ci/src/TTCI.ts
+++ b/packages/taro-plugin-mini-ci/src/TTCI.ts
@@ -59,6 +59,7 @@ export default class TTCI extends BaseCI {
         project: {
           path: outputPath
         },
+        // @ts-ignore
         page: {
           path: ''
         },
@@ -70,13 +71,13 @@ export default class TTCI extends BaseCI {
         cache: true
       })
       console.log(chalk.green(`开发版上传成功 ${ new Date().toLocaleString() }\n`))
-      printQrcode2Terminal(previewResult.shortUrl)
+      await printQrcode2Terminal(previewResult.shortUrl)
       printLog(
         processTypeEnum.REMIND,
         `预览二维码已生成，存储在:"${ previewQrcodePath }",二维码内容是：${ previewResult.shortUrl },过期时间：${ new Date(previewResult.expireTime * 1000).toLocaleString() }`
       )
     } catch (error) {
-      printLog(processTypeEnum.ERROR, chalk.red(`上传失败 ${ new Date().toLocaleString() } \n${ error.message }`))
+      printLog(processTypeEnum.ERROR, chalk.red(`上传失败 ${ new Date().toLocaleString() } \n${ error }`))
     }
   }
 
@@ -98,15 +99,17 @@ export default class TTCI extends BaseCI {
         },
         version: this.version,
         changeLog: this.desc,
-        needUploadSourcemap: true
+        needUploadSourcemap: true,
+        copyToClipboard: false
       })
       console.log(chalk.green(`体验版版上传成功 ${ new Date().toLocaleString() }\n`))
+      await printQrcode2Terminal(uploadResult.shortUrl)
       printLog(
         processTypeEnum.REMIND,
         `体验版二维码已生成，存储在:"${ uploadQrcodePath }",二维码内容是："${ uploadResult.shortUrl }", 过期时间：${ new Date(uploadResult.expireTime * 1000).toLocaleString() }`
       )
     } catch (error) {
-      printLog(processTypeEnum.ERROR, chalk.red(`上传失败 ${ new Date().toLocaleString() } \n${ error.message }`))
+      printLog(processTypeEnum.ERROR, chalk.red(`上传失败 ${ new Date().toLocaleString() } \n${ error }`))
     }
   }
 }

--- a/packages/taro-plugin-mini-ci/src/TTCI.ts
+++ b/packages/taro-plugin-mini-ci/src/TTCI.ts
@@ -95,7 +95,7 @@ export default class TTCI extends BaseCI {
           qrCodeContent: '',
           qrCodeLocalPath: ''
         },
-        error
+        error: new Error(error)
       })
     }
   }
@@ -146,7 +146,7 @@ export default class TTCI extends BaseCI {
           qrCodeContent: '',
           qrCodeLocalPath: ''
         },
-        error
+        error: new Error(error)
       })
     }
   }

--- a/packages/taro-plugin-mini-ci/src/WeappCI.ts
+++ b/packages/taro-plugin-mini-ci/src/WeappCI.ts
@@ -101,13 +101,20 @@ export default class WeappCI extends BaseCI {
         const extInfo = `本次上传${allPackageInfo!.size / 1024}kb ${mainPackageInfo ? ',其中主包' + mainPackageInfo.size + 'kb' : ''}`
         console.log(chalk.green(`开发版上传成功 ${new Date().toLocaleString()} ${extInfo}\n`))
       }
+      let qrContent
       try {
-        const qrContent = await readQrcodeImageContent(previewQrcodePath)
+        qrContent = await readQrcodeImageContent(previewQrcodePath)
         await printQrcode2Terminal(qrContent)
         printLog(processTypeEnum.REMIND, `预览二维码已生成，存储在:"${previewQrcodePath}",二维码内容是：${qrContent}`)
       } catch (error) {
         printLog(processTypeEnum.ERROR, chalk.red(`获取预览二维码失败：${error.message}`))
       }
+      
+      this.triggerPreviewHooks({
+        platform: 'weapp',
+        qrCodeContent: qrContent,
+        qrCodeLocalPath: previewQrcodePath
+      })
     } catch (error) {
       printLog(processTypeEnum.ERROR, chalk.red(`上传失败 ${new Date().toLocaleString()} \n${error.message}`))
     }
@@ -143,6 +150,12 @@ export default class WeappCI extends BaseCI {
         printLog(processTypeEnum.REMIND, `体验版二维码已生成，存储在:"${uploadQrcodePath}",二维码内容是："${qrContent}"`)
         printLog(processTypeEnum.REMIND, `可能需要您前往微信后台，将当前上传版本设置为“体验版”`)
         printLog(processTypeEnum.REMIND, `若本次上传的robot机器人和上次一致，并且之前已经在微信后台设置其为“体验版”，则本次无需再次设置`)
+
+        this.triggerUploadHooks({
+          platform: 'weapp',
+          qrCodeContent: qrContent,
+          qrCodeLocalPath: uploadQrcodePath
+        })
       } catch (error) {
         printLog(processTypeEnum.ERROR, chalk.red(`体验二维码生成失败：${error.message}`))
       }

--- a/packages/taro-plugin-mini-ci/src/WeappCI.ts
+++ b/packages/taro-plugin-mini-ci/src/WeappCI.ts
@@ -8,6 +8,7 @@ import * as os from 'os'
 import * as path from 'path'
 
 import BaseCI from './BaseCi'
+import { generateQrcodeImageFile, printQrcode2Terminal, readQrcodeImageContent } from './utils/qrcode'
 
 export default class WeappCI extends BaseCI {
   private instance: Project
@@ -82,29 +83,40 @@ export default class WeappCI extends BaseCI {
 
   async preview () {
     const { chalk, printLog, processTypeEnum } = this.ctx.helper
+    const { outputPath } = this.ctx.paths
     try {
       printLog(processTypeEnum.START, '上传开发版代码到微信后台并预览')
+      const previewQrcodePath = path.join(outputPath, 'preview.jpg')
       const uploadResult = await ci.preview({
         project: this.instance,
         version: this.version,
         desc: this.desc,
         onProgressUpdate: undefined,
-        robot: this.pluginOpts.weapp!.robot
+        robot: this.pluginOpts.weapp!.robot,
+        qrcodeFormat: 'image',
+        qrcodeOutputDest: previewQrcodePath
       })
-
       if (uploadResult.subPackageInfo) {
         const allPackageInfo = uploadResult.subPackageInfo.find((item) => item.name === '__FULL__')
         const mainPackageInfo = uploadResult.subPackageInfo.find((item) => item.name === '__APP__')
         const extInfo = `本次上传${allPackageInfo!.size / 1024}kb ${mainPackageInfo ? ',其中主包' + mainPackageInfo.size + 'kb' : ''}`
-        console.log(chalk.green(`上传成功 ${new Date().toLocaleString()} ${extInfo}`))
+        console.log(chalk.green(`开发版上传成功 ${new Date().toLocaleString()} ${extInfo}\n`))
+      }
+      try {
+        const qrContent = await readQrcodeImageContent(previewQrcodePath)
+        await printQrcode2Terminal(qrContent)
+        printLog(processTypeEnum.REMIND, `预览二维码已生成，存储在:"${previewQrcodePath}",二维码内容是：${qrContent}`)
+      } catch (error) {
+        printLog(processTypeEnum.ERROR, chalk.red(`获取预览二维码失败：${error.message}`))
       }
     } catch (error) {
-      console.log(chalk.red(`上传失败 ${new Date().toLocaleString()} \n${error.message}`))
+      printLog(processTypeEnum.ERROR, chalk.red(`上传失败 ${new Date().toLocaleString()} \n${error.message}`))
     }
   }
 
   async upload () {
     const { chalk, printLog, processTypeEnum } = this.ctx.helper
+    const { outputPath } = this.ctx.paths
     try {
       printLog(processTypeEnum.START, '上传体验版代码到微信后台')
       printLog(processTypeEnum.REMIND, `本次上传版本号为："${this.version}"，上传描述为：“${this.desc}”`)
@@ -120,10 +132,23 @@ export default class WeappCI extends BaseCI {
         const allPackageInfo = uploadResult.subPackageInfo.find((item) => item.name === '__FULL__')
         const mainPackageInfo = uploadResult.subPackageInfo.find((item) => item.name === '__APP__')
         const extInfo = `本次上传${allPackageInfo!.size / 1024}kb ${mainPackageInfo ? ',其中主包' + mainPackageInfo.size + 'kb' : ''}`
-        console.log(chalk.green(`上传成功 ${new Date().toLocaleString()} ${extInfo}`))
+        console.log(chalk.green(`上传成功 ${new Date().toLocaleString()} ${extInfo}\n`))
+      }
+
+      try {
+        const uploadQrcodePath = path.join(outputPath, 'upload.png')
+        // 体验码规则： https://open.weixin.qq.com/sns/getexpappinfo?appid=xxx&path=入口路径.html#wechat-redirect
+        const qrContent = `https://open.weixin.qq.com/sns/getexpappinfo?appid=${this.pluginOpts.weapp!.appid}#wechat-redirect`
+        await printQrcode2Terminal(qrContent)
+        await generateQrcodeImageFile(uploadQrcodePath, qrContent)
+        printLog(processTypeEnum.REMIND, `体验版二维码已生成，存储在:"${uploadQrcodePath}",二维码内容是："${qrContent}"`)
+        printLog(processTypeEnum.REMIND, `可能需要您前往微信后台，将当前上传版本设置为“体验版”`)
+        printLog(processTypeEnum.REMIND, `若本次上传的robot机器人和上次一致，并且之前已经在微信后台设置其为“体验版”，则本次无需再次设置`)
+      } catch (error) {
+        printLog(processTypeEnum.ERROR, chalk.red(`体验二维码生成失败：${error.message}`))
       }
     } catch (error) {
-      console.log(chalk.red(`上传失败 ${new Date().toLocaleString()} \n${error.message}`))
+      printLog(processTypeEnum.ERROR, chalk.red(`上传失败 ${new Date().toLocaleString()} \n${error.message}`))
     }
   }
 }

--- a/packages/taro-plugin-mini-ci/src/WeappCI.ts
+++ b/packages/taro-plugin-mini-ci/src/WeappCI.ts
@@ -111,12 +111,25 @@ export default class WeappCI extends BaseCI {
       }
       
       this.triggerPreviewHooks({
-        platform: 'weapp',
-        qrCodeContent: qrContent,
-        qrCodeLocalPath: previewQrcodePath
+        success: true,
+        data: {
+          platform: 'weapp',
+          qrCodeContent: qrContent,
+          qrCodeLocalPath: previewQrcodePath
+        }
       })
     } catch (error) {
       printLog(processTypeEnum.ERROR, chalk.red(`上传失败 ${new Date().toLocaleString()} \n${error.message}`))
+
+      this.triggerPreviewHooks({
+        success: false,
+        data: {
+          platform: 'weapp',
+          qrCodeContent: '',
+          qrCodeLocalPath: ''
+        },
+        error
+      })
     }
   }
 
@@ -141,8 +154,8 @@ export default class WeappCI extends BaseCI {
         console.log(chalk.green(`上传成功 ${new Date().toLocaleString()} ${extInfo}\n`))
       }
 
+      const uploadQrcodePath = path.join(outputPath, 'upload.png')
       try {
-        const uploadQrcodePath = path.join(outputPath, 'upload.png')
         // 体验码规则： https://open.weixin.qq.com/sns/getexpappinfo?appid=xxx&path=入口路径.html#wechat-redirect
         const qrContent = `https://open.weixin.qq.com/sns/getexpappinfo?appid=${this.pluginOpts.weapp!.appid}#wechat-redirect`
         await printQrcode2Terminal(qrContent)
@@ -152,15 +165,39 @@ export default class WeappCI extends BaseCI {
         printLog(processTypeEnum.REMIND, `若本次上传的robot机器人和上次一致，并且之前已经在微信后台设置其为“体验版”，则本次无需再次设置`)
 
         this.triggerUploadHooks({
-          platform: 'weapp',
-          qrCodeContent: qrContent,
-          qrCodeLocalPath: uploadQrcodePath
+          success: true,
+          data: {
+            platform: 'weapp',
+            qrCodeContent: qrContent,
+            qrCodeLocalPath: uploadQrcodePath
+          }
         })
       } catch (error) {
+        // 实际读取二维码时有极小概率会读取失败，待观察
         printLog(processTypeEnum.ERROR, chalk.red(`体验二维码生成失败：${error.message}`))
+
+        this.triggerUploadHooks({
+          success: true,
+          data: {
+            platform: 'weapp',
+            qrCodeContent: '',
+            qrCodeLocalPath: uploadQrcodePath
+          },
+          error
+        })
       }
     } catch (error) {
       printLog(processTypeEnum.ERROR, chalk.red(`上传失败 ${new Date().toLocaleString()} \n${error.message}`))
+
+      this.triggerUploadHooks({
+        success: false,
+        data: {
+          platform: 'weapp',
+          qrCodeContent: '',
+          qrCodeLocalPath: ''
+        },
+        error
+      })
     }
   }
 }

--- a/packages/taro-plugin-mini-ci/src/WeappCI.ts
+++ b/packages/taro-plugin-mini-ci/src/WeappCI.ts
@@ -1,7 +1,9 @@
 /* eslint-disable no-console */
 import * as cp from 'child_process'
+import * as crypto from 'crypto'
 import * as ci from 'miniprogram-ci'
 import { Project } from 'miniprogram-ci'
+import { ICreateProjectOptions } from 'miniprogram-ci/dist/@types/ci/project'
 import * as os from 'os'
 import * as path from 'path'
 
@@ -21,13 +23,14 @@ export default class WeappCI extends BaseCI {
     this.devToolsInstallPath = this.pluginOpts.weapp.devToolsInstallPath || (process.platform === 'darwin' ? '/Applications/wechatwebdevtools.app' : 'C:\\Program Files (x86)\\Tencent\\微信web开发者工具')
     delete this.pluginOpts.weapp.devToolsInstallPath
 
-    const weappConfig: any = {
+    const weappConfig: ICreateProjectOptions = {
       type: 'miniProgram',
       projectPath: outputPath,
-      ignores: ['node_modules/**/*'],
-      ...this.pluginOpts.weapp!
+      appid: this.pluginOpts.weapp!.appid,
+      privateKeyPath: this.pluginOpts.weapp!.privateKeyPath,
+      ignores: this.pluginOpts.weapp!.ignores,
     }
-    const privateKeyPath = path.isAbsolute(weappConfig.privateKeyPath) ? weappConfig.privateKeyPath : path.join(appPath, weappConfig.privateKeyPath)
+    const privateKeyPath = path.isAbsolute(weappConfig.privateKeyPath!) ? weappConfig.privateKeyPath : path.join(appPath, weappConfig.privateKeyPath!)
     if (!fs.pathExistsSync(privateKeyPath)) {
       throw new Error(`"weapp.privateKeyPath"选项配置的路径不存在,本次上传终止:${privateKeyPath}`)
     }
@@ -49,7 +52,7 @@ export default class WeappCI extends BaseCI {
     // 检查是否开启了命令行
     const errMesg = '工具的服务端口已关闭。要使用命令行调用工具，请打开工具 -> 设置 -> 安全设置，将服务端口开启。详细信息: https://developers.weixin.qq.com/miniprogram/dev/devtools/cli.html'
     const installPath = isWindows ? this.devToolsInstallPath : `${this.devToolsInstallPath}/Contents/MacOS`
-    const md5 = require('crypto').createHash('md5').update(installPath).digest('hex')
+    const md5 = crypto.createHash('md5').update(installPath).digest('hex')
     const ideStatusFile = path.join(
       getUserHomeDir(),
       isWindows
@@ -85,7 +88,8 @@ export default class WeappCI extends BaseCI {
         project: this.instance,
         version: this.version,
         desc: this.desc,
-        onProgressUpdate: undefined
+        onProgressUpdate: undefined,
+        robot: this.pluginOpts.weapp!.robot
       })
 
       if (uploadResult.subPackageInfo) {
@@ -108,7 +112,8 @@ export default class WeappCI extends BaseCI {
         project: this.instance,
         version: this.version,
         desc: this.desc,
-        onProgressUpdate: undefined
+        onProgressUpdate: undefined,
+        robot: this.pluginOpts.weapp!.robot
       })
 
       if (uploadResult.subPackageInfo) {

--- a/packages/taro-plugin-mini-ci/src/WeappCI.ts
+++ b/packages/taro-plugin-mini-ci/src/WeappCI.ts
@@ -1,8 +1,7 @@
 /* eslint-disable no-console */
 import * as cp from 'child_process'
 import * as crypto from 'crypto'
-import * as ci from 'miniprogram-ci'
-import { Project } from 'miniprogram-ci'
+import ci, { Project }from 'miniprogram-ci'
 import { ICreateProjectOptions } from 'miniprogram-ci/dist/@types/ci/project'
 import * as os from 'os'
 import * as path from 'path'

--- a/packages/taro-plugin-mini-ci/src/hooks.ts
+++ b/packages/taro-plugin-mini-ci/src/hooks.ts
@@ -1,0 +1,4 @@
+/** CI 执行预览后触发 */
+export const ON_PREVIEW_COMPLETE = 'onPreviewComplete'
+/** CI 执行上传后触发 */
+export const ON_UPLOAD_COMPLETE = 'onUploadComplete'

--- a/packages/taro-plugin-mini-ci/src/index.ts
+++ b/packages/taro-plugin-mini-ci/src/index.ts
@@ -3,6 +3,7 @@ import * as minimist from 'minimist'
 
 import AlipayCI from './AlipayCI'
 import BaseCI, { CIOptions } from './BaseCi'
+import DingtalkCI from './DingtalkCI'
 import SwanCI from './SwanCI'
 import TTCI from './TTCI'
 import WeappCI from './WeappCI'
@@ -62,6 +63,19 @@ export default (ctx: IPluginContext, _pluginOpts: CIOptions | (() => CIOptions))
             }),
 
           ),
+          /** 钉钉小程序配置 */
+          dd: joi.object({
+            token: joi.string().required(),
+            appid: joi.string().required(),
+            projectPath: joi.string(),
+            devToolsInstallPath: joi.string(),
+            projectType: joi.string().valid(
+              'dingtalk-personal',
+              'dingtalk-biz-isv',
+              'dingtalk-biz',
+              'dingtalk-biz-custom',
+              'dingtalk-biz-worktab-plugin')
+          }),
           /** 百度小程序上传配置 */
           swan: joi.object({
             token: joi.string().required(),
@@ -93,6 +107,9 @@ export default (ctx: IPluginContext, _pluginOpts: CIOptions | (() => CIOptions))
       case 'alipay':
       case 'iot':
         ci = new AlipayCI(ctx, pluginOpts)
+        break
+      case 'dd':
+        ci = new DingtalkCI(ctx, pluginOpts)
         break
       case 'swan':
         ci = new SwanCI(ctx, pluginOpts)

--- a/packages/taro-plugin-mini-ci/src/index.ts
+++ b/packages/taro-plugin-mini-ci/src/index.ts
@@ -48,16 +48,16 @@ export default (ctx: IPluginContext, _pluginOpts: CIOptions | (() => CIOptions))
           /** 阿里小程序上传配置 */
           alipay:joi.alternatives().try(
             joi.object({
-              appId: joi.string().required(),
+              appid: joi.string().required(),
               toolId: joi.string().required(),
               privateKeyPath: joi.string().required(),
-              clientType: joi.string().valid('alipay', 'ampe', 'amap', 'genie', 'alios', 'uc', 'quark', 'taobao', 'koubei', 'alipayiot', 'cainiao', 'alihealth')
+              clientType: joi.string().valid('alipay', 'ampe', 'amap', 'genie', 'alios', 'uc', 'quark', 'health', 'koubei', 'alipayiot', 'cainiao', 'alihealth')
             }),
             joi.object({
-              appId: joi.string().required(),
+              appid: joi.string().required(),
               toolId: joi.string().required(),
               privateKey: joi.string().required(),
-              clientType: joi.string().valid('alipay', 'ampe', 'amap', 'genie', 'alios', 'uc', 'quark', 'taobao', 'koubei', 'alipayiot', 'cainiao', 'alihealth')
+              clientType: joi.string().valid('alipay', 'ampe', 'amap', 'genie', 'alios', 'uc', 'quark', 'health', 'koubei', 'alipayiot', 'cainiao', 'alihealth')
             }),
 
           ),

--- a/packages/taro-plugin-mini-ci/src/index.ts
+++ b/packages/taro-plugin-mini-ci/src/index.ts
@@ -45,14 +45,23 @@ export default (ctx: IPluginContext, _pluginOpts: CIOptions | (() => CIOptions))
             password: joi.string().required()
           }),
           /** 阿里小程序上传配置 */
-          alipay: joi.object({
-            appId: joi.string().required(),
-            toolId: joi.string().required(),
-            privateKeyPath: joi.string().required(),
-            proxy: joi.string(),
-            project: joi.string(),
-            clientType: joi.string().valid('alipay', 'ampe', 'amap', 'genie', 'alios', 'uc', 'quark', 'taobao', 'koubei', 'alipayiot', 'cainiao', 'alihealth')
-          }),
+          alipay:joi.alternatives().try(
+            joi.object({
+              appId: joi.string().required(),
+              toolId: joi.string().required(),
+              privateKeyPath: joi.string().required(),
+              project: joi.string(),
+              clientType: joi.string().valid('alipay', 'ampe', 'amap', 'genie', 'alios', 'uc', 'quark', 'taobao', 'koubei', 'alipayiot', 'cainiao', 'alihealth')
+            }),
+            joi.object({
+              appId: joi.string().required(),
+              toolId: joi.string().required(),
+              privateKey: joi.string().required(),
+              project: joi.string(),
+              clientType: joi.string().valid('alipay', 'ampe', 'amap', 'genie', 'alios', 'uc', 'quark', 'taobao', 'koubei', 'alipayiot', 'cainiao', 'alihealth')
+            }),
+
+          ),
           /** 百度小程序上传配置 */
           swan: joi.object({
             token: joi.string().required(),

--- a/packages/taro-plugin-mini-ci/src/index.ts
+++ b/packages/taro-plugin-mini-ci/src/index.ts
@@ -18,13 +18,27 @@ const enum EnumAction  {
   'upload' = 'upload' ,
 }
 
+interface MinimistArgs {
+  /** 自定义要处理的项目目录 */
+  projectPath: string
+  /** 自动打开预览工具 */
+  open: boolean
+  /** 预览小程序 */
+  preview: boolean
+  /** 上传小程序 */
+  upload: boolean
+}
+
 export { CIOptions } from './BaseCi'
 export default (ctx: IPluginContext, _pluginOpts: CIOptions | (() => CIOptions)) => {
-  const args = minimist(process.argv.slice(2), {
-    boolean: [EnumAction.open,EnumAction.preview, EnumAction.upload]
+  const args = minimist<MinimistArgs>(process.argv.slice(2), {
+    boolean: [EnumAction.open,EnumAction.preview, EnumAction.upload],
+    string: ['projectPath'],
+    default: {
+      projectPath: ''
+    }
   })
   const command = args._[0]
-
   // 参数验证，支持传入配置对象、返回配置对象的异步函数
   ctx.addPluginOptsSchema((joi) => {
     return joi.alternatives().try(
@@ -86,7 +100,7 @@ export default (ctx: IPluginContext, _pluginOpts: CIOptions | (() => CIOptions))
     )
   })
 
-  const doAction = async (platform: string, action: EnumAction, projectPath?: string) => {
+  const doAction = async (platform: string, action: EnumAction, projectPath: string) => {
     const { printLog, processTypeEnum, fs } = ctx.helper
     if (typeof platform !== 'string') {
       printLog(processTypeEnum.ERROR, '请传入正确的编译类型！')
@@ -159,7 +173,7 @@ export default (ctx: IPluginContext, _pluginOpts: CIOptions | (() => CIOptions))
           break
       }
       if (action) {
-        await doAction(ctx.runOpts.options.platform, action)
+        await doAction(ctx.runOpts.options.platform, action, args.projectPath)
       }
     })
   }

--- a/packages/taro-plugin-mini-ci/src/index.ts
+++ b/packages/taro-plugin-mini-ci/src/index.ts
@@ -8,44 +8,49 @@ import TTCI from './TTCI'
 import WeappCI from './WeappCI'
 
 export { CIOptions } from './BaseCi'
-export default (ctx: IPluginContext, pluginOpts: CIOptions) => {
+export default (ctx: IPluginContext, _pluginOpts: CIOptions | (() => CIOptions)) => {
   const onBuildDone = ctx.onBuildComplete || ctx.onBuildFinish
+  const pluginOpts = typeof _pluginOpts === 'function' ? _pluginOpts() : _pluginOpts
+
 
   ctx.addPluginOptsSchema((joi) => {
-    return joi
-      .object()
-      .keys({
+    return joi.alternatives().try(
+      joi.function().required(),
+      joi
+        .object()
+        .keys({
         /** 微信小程序上传配置 */
-        weapp: joi.object({
-          appid: joi.string().required(),
-          projectPath: joi.string(),
-          privateKeyPath: joi.string().required(),
-          type: joi.string().valid('miniProgram', 'miniProgramPlugin', 'miniGame', 'miniGamePlugin'),
-          ignores: joi.array().items(joi.string().required())
-        }),
-        /** 字节跳动小程序上传配置 */
-        tt: joi.object({
-          email: joi.string().required(),
-          password: joi.string().required()
-        }),
-        /** 阿里小程序上传配置 */
-        alipay: joi.object({
-          appId: joi.string().required(),
-          toolId: joi.string().required(),
-          privateKeyPath: joi.string().required(),
-          proxy: joi.string(),
-          project: joi.string(),
-          clientType: joi.string().valid('alipay', 'ampe', 'amap', 'genie', 'alios', 'uc', 'quark', 'taobao', 'koubei', 'alipayiot', 'cainiao', 'alihealth')
-        }),
-        /** 百度小程序上传配置 */
-        swan: joi.object({
-          token: joi.string().required(),
-          minSwanVersion: joi.string()
-        }),
-        version: joi.string(),
-        desc: joi.string()
-      })
-      .required()
+          weapp: joi.object({
+            appid: joi.string().required(),
+            projectPath: joi.string(),
+            privateKeyPath: joi.string().required(),
+            type: joi.string().valid('miniProgram', 'miniProgramPlugin', 'miniGame', 'miniGamePlugin'),
+            ignores: joi.array().items(joi.string().required())
+          }),
+          /** 字节跳动小程序上传配置 */
+          tt: joi.object({
+            email: joi.string().required(),
+            password: joi.string().required()
+          }),
+          /** 阿里小程序上传配置 */
+          alipay: joi.object({
+            appId: joi.string().required(),
+            toolId: joi.string().required(),
+            privateKeyPath: joi.string().required(),
+            proxy: joi.string(),
+            project: joi.string(),
+            clientType: joi.string().valid('alipay', 'ampe', 'amap', 'genie', 'alios', 'uc', 'quark', 'taobao', 'koubei', 'alipayiot', 'cainiao', 'alihealth')
+          }),
+          /** 百度小程序上传配置 */
+          swan: joi.object({
+            token: joi.string().required(),
+            minSwanVersion: joi.string()
+          }),
+          version: joi.string(),
+          desc: joi.string()
+        })
+        .required()
+    )
   })
 
   onBuildDone(async () => {

--- a/packages/taro-plugin-mini-ci/src/index.ts
+++ b/packages/taro-plugin-mini-ci/src/index.ts
@@ -33,10 +33,11 @@ export default (ctx: IPluginContext, _pluginOpts: CIOptions | (() => CIOptions))
           /** 微信小程序上传配置 */
           weapp: joi.object({
             appid: joi.string().required(),
-            projectPath: joi.string(),
             privateKeyPath: joi.string().required(),
+            projectPath: joi.string(),
             type: joi.string().valid('miniProgram', 'miniProgramPlugin', 'miniGame', 'miniGamePlugin'),
-            ignores: joi.array().items(joi.string().required())
+            ignores: joi.array().items(joi.string().required()),
+            robot: joi.number()
           }),
           /** 字节跳动小程序上传配置 */
           tt: joi.object({

--- a/packages/taro-plugin-mini-ci/src/types.d.ts
+++ b/packages/taro-plugin-mini-ci/src/types.d.ts
@@ -1,7 +1,47 @@
 import { IMinidev, useDefaults } from 'minidev'
-import  TTInstance from  'tt-ide-cli'
+import TTInstance from 'tt-ide-cli'
 
-export type AlipayInstance = { minidev: IMinidev, useDefaults: typeof useDefaults }
+export type AlipayInstance = { minidev: IMinidev; useDefaults: typeof useDefaults }
 
 export type TTInstance = typeof TTInstance
 
+export module DingTalk {
+
+  interface IOpenSDKConfig {
+    appKey: string
+    appSecret: string
+    accessToken?: string
+    host?: string
+  }
+
+  export interface ITaskProgressMessage<T> {
+    status: 'pending' |'building' |'success' |'failed' | 'overtime'
+    data: T
+  }
+  export interface ITaskOptionBase {
+    project: string
+    miniAppId: string
+    onProgressUpdate: <T>(message: ITaskProgressMessage<T>) => void
+  }
+  export interface IBuildTaskParams extends ITaskOptionBase {
+    packageVersion?: string
+  }
+  interface IPreviewBuildOptions extends ITaskOptionBase {
+    page?: string
+    query?: string
+    corpId?: string
+    ignoreHttpReqPermission?: boolean
+    ignoreWebViewDomainCheck?: boolean
+    buildTarget: 'Preview'|'RemoteLegacy'|'RemoteX'|'RemoteXLite'|'RemoteBoatman'|'Publish'
+  }
+  interface MiniAppOpenSDK {
+    /** 配置 */
+    setConfig(config: IOpenSDKConfig)
+
+    /** 预览小程序 */
+    previewBuild(options: IPreviewBuildOptions): Promise<string>
+
+    /** 上传小程序 */
+    miniUpload(options: IBuildTaskParams)
+  }
+}

--- a/packages/taro-plugin-mini-ci/src/types.d.ts
+++ b/packages/taro-plugin-mini-ci/src/types.d.ts
@@ -1,72 +1,7 @@
+import { IMinidev, useDefaults } from 'minidev'
+import  TTInstance from  'tt-ide-cli'
 
-interface QrcodeInfo {
-  /**
-    // imageSVG 用于产出二维码 SVG
-    // imageFile 用于将二维码存储到某个路径
-    // terminal 用于将二维码在控制台输出
-    // null 则不产出二维码
-     */
-  format: 'imageFile' | 'terminal' | 'imageSVG' | 'plain' | null
-  /** 只在 imageFile 生效，填写图片输出绝对路径 */
-  output?: string
-  options?: {
-    /** 使用小二维码，主要用于 terminal */
-    small?: boolean
-  }
-}
-interface PreviewOption {
-  project: {
-    path: string
-  }
-  page: {
-    /** 小程序打开页面 */
-    path: string
-    /** 小程序打开 query */
-    query?: string
-  }
-  qrcode: QrcodeInfo
-  /** 是否使用缓存 */
-  cache: boolean
-  /** 是否将产出的二维码链接复制到剪切板 */
-  copyToClipboard: boolean
-}
+export type AlipayInstance = { minidev: IMinidev, useDefaults: typeof useDefaults }
 
-interface ProjectQRCode {
-  /** 二维码过期时间 */
-  expireTime: number
-  /** 二维码短链 */
-  shortUrl: string
-  /** 二维码 schema */
-  originSchema: string
-  /** 二维码 SVG */
-  qrcodeSVG?: string
-  /** 二维码存储路径 */
-  qrcodeFilePath?: string
-  /** 是否命中并使用缓存 */
-  useCache: boolean
-}
+export type TTInstance = typeof TTInstance
 
-type UploadOption = Omit<PreviewOption, 'page'> | {
-  version: string
-  changeLog: string
-  needUploadSourcemap: boolean
-}
-export interface TTInstance {
-  /** 打开开发者工具 */
-  open(options: {
-    project: {
-      path: string
-    }
-  }): Promise<void>
-
-  loginByEmail(options: { email: string; password: string; dontSaveCookie?: boolean }): Promise<any>
-
-  checkSession(): Promise<{
-    isValid: boolean
-    errMsg: string
-  }>
-
-  preview(options: PreviewOption): Promise<ProjectQRCode>
-
-  upload(options: UploadOption): Promise<ProjectQRCode>
-}

--- a/packages/taro-plugin-mini-ci/src/types.d.ts
+++ b/packages/taro-plugin-mini-ci/src/types.d.ts
@@ -1,1 +1,72 @@
-declare module 'tt-ide-cli'
+
+interface QrcodeInfo {
+  /**
+    // imageSVG 用于产出二维码 SVG
+    // imageFile 用于将二维码存储到某个路径
+    // terminal 用于将二维码在控制台输出
+    // null 则不产出二维码
+     */
+  format: 'imageFile' | 'terminal' | 'imageSVG' | 'plain' | null
+  /** 只在 imageFile 生效，填写图片输出绝对路径 */
+  output?: string
+  options?: {
+    /** 使用小二维码，主要用于 terminal */
+    small?: boolean
+  }
+}
+interface PreviewOption {
+  project: {
+    path: string
+  }
+  page: {
+    /** 小程序打开页面 */
+    path: string
+    /** 小程序打开 query */
+    query?: string
+  }
+  qrcode: QrcodeInfo
+  /** 是否使用缓存 */
+  cache: boolean
+  /** 是否将产出的二维码链接复制到剪切板 */
+  copyToClipboard: boolean
+}
+
+interface ProjectQRCode {
+  /** 二维码过期时间 */
+  expireTime: number
+  /** 二维码短链 */
+  shortUrl: string
+  /** 二维码 schema */
+  originSchema: string
+  /** 二维码 SVG */
+  qrcodeSVG?: string
+  /** 二维码存储路径 */
+  qrcodeFilePath?: string
+  /** 是否命中并使用缓存 */
+  useCache: boolean
+}
+
+type UploadOption = Omit<PreviewOption, 'page'> | {
+  version: string
+  changeLog: string
+  needUploadSourcemap: boolean
+}
+export interface TTInstance {
+  /** 打开开发者工具 */
+  open(options: {
+    project: {
+      path: string
+    }
+  }): Promise<void>
+
+  loginByEmail(options: { email: string; password: string; dontSaveCookie?: boolean }): Promise<any>
+
+  checkSession(): Promise<{
+    isValid: boolean
+    errMsg: string
+  }>
+
+  preview(options: PreviewOption): Promise<ProjectQRCode>
+
+  upload(options: UploadOption): Promise<ProjectQRCode>
+}

--- a/packages/taro-plugin-mini-ci/src/utils/compareVersion.ts
+++ b/packages/taro-plugin-mini-ci/src/utils/compareVersion.ts
@@ -1,0 +1,24 @@
+export function compareVersion (v1, v2) {
+  v1 = v1.split('.')
+  v2 = v2.split('.')
+  const len = Math.max(v1.length, v2.length)
+
+  while (v1.length < len) {
+    v1.push('0')
+  }
+  while (v2.length < len) {
+    v2.push('0')
+  }
+
+  for (let i = 0; i < len; i++) {
+    const num1 = parseInt(v1[i])
+    const num2 = parseInt(v2[i])
+
+    if (num1 > num2) {
+      return 1
+    } else if (num1 < num2) {
+      return -1
+    }
+  }
+  return 0
+}

--- a/packages/taro-plugin-mini-ci/src/utils/npm.ts
+++ b/packages/taro-plugin-mini-ci/src/utils/npm.ts
@@ -1,0 +1,15 @@
+const npmCached = {}
+export function resolveNpmSync (pluginName: string, root): string {
+  const resolvePath = require('resolve')
+  if (!npmCached[pluginName]) {
+    const res = resolvePath.sync(pluginName, { basedir: root })
+    return res
+  }
+  return npmCached[pluginName]
+}
+
+export function getNpmPkgSync (npmName: string, root: string) {
+  const npmPath = resolveNpmSync(npmName, root)
+  const npmFn = require(npmPath)
+  return npmFn
+}

--- a/packages/taro-plugin-mini-ci/src/utils/qrcode.ts
+++ b/packages/taro-plugin-mini-ci/src/utils/qrcode.ts
@@ -1,0 +1,49 @@
+import Jimp from 'jimp/es'
+import * as QRCode from 'qrcode'
+import * as QrCodeReader from 'qrcode-reader'
+
+/**
+ * 读取出二维码图片中的文本内容
+ * @param imagePath 图片路径
+ */
+export async function readQrcodeImageContent (imagePath: string): Promise<string> {
+  return new Promise((resolve, reject)=> {
+    Jimp.read(imagePath, function (err, image) {
+      if (err) {
+        reject(err)
+        return
+      }
+      const qr = new QrCodeReader()
+      qr.callback = function (err, value) {
+        if (err) {
+          reject(err)
+          return
+        }
+        resolve(value.result)
+      }
+      qr.decode(image.bitmap)
+    }) 
+  })
+}
+
+/**
+ * 将文本内容转换成二维码输出在控制台上
+ * @param content 
+ */
+export async function printQrcode2Terminal (content: string) {
+  const terminalStr = await QRCode.toString(content, { type: 'terminal'})
+  // eslint-disable-next-line no-console
+  console.log(terminalStr)
+}
+
+/**
+ * 生成二维码图片到指定目录
+ * @param content 
+ * @param path 
+ */
+export async function generateQrcodeImageFile ( path: string, content: string,) {
+  await QRCode.toFile(path,content, {
+    errorCorrectionLevel: 'L',
+    type: 'png'
+  })
+}


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

去年的PR实现了从0到1，经过一年的项目沉淀和反馈，此次更新以灵活性、输入输出规范统一为特点
## 功能特性
- `Taro` 插件参数支持传入函数体，并应用到了`@taro/plugin-mini-ci` 插件
之前Taro插件做了强验证，只支持传入对象作为参数，新增了支持传入函数作为参数，更加灵活。
举个例子，比如“构建微信小程序时根据`jenkins`注入的构建号动态分配机器人编号”这个需求
- 支持独立的 `open`、`preview`、`upload` 命令，操作自定义目录
适用于将`taro`作为项目一部分（混合开发）的开发场景
- 重新联调了各个平台的`CI`，一年过去了，各大平台的`CI`包都有不同程度的更新（特别是头条、支付宝）
- 新增 钉钉 小程序`CI`
- 统一所有平台CI构建后的输出数据，并将数据传递给新增的`onPreviewComplete`、`onUploadComplete`两个钩子
用户可以编写新的插件，基于这个钩子实现 `飞书`、`钉钉` 的 `CI` 推送功能，我计划晚点推一个新插件实现这个功能,有强烈特殊定制的用户可基于这两个钩子可自行实现通知插件（比如发发布时短信通知之类的）

## 其他
- 运行时动态加载各端CI包的方式变更，旧的`require`方式不支持`pnpm link`, 不方便调试
- 编写了一些 `ts` 类型供开发插件时使用，维护更友好
- 部分选项统一了字段，不兼容的选项已经在文档加了说明


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [x] 代码重构(Refactor)
- [x] TypeScript 类型定义修改(Typings)
- [x] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 字节跳动小程序
- [x] 钉钉小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
