### PR TITLE
fix(taro-components): 优化 input 组件 type 为 number 或 digit 时,输入特殊符号导致交互异常问题

### DIFF
--- a/packages/taro-components/src/components/input/input.tsx
+++ b/packages/taro-components/src/components/input/input.tsx
@@ -95,6 +95,8 @@ export class Input implements ComponentInterface {
     } else {
       this.inputRef?.addEventListener('compositionstart', this.handleComposition)
       this.inputRef?.addEventListener('compositionend', this.handleComposition)
+      this.inputRef?.addEventListener('beforeinput', this.handleBeforeinput)
+      this.inputRef?.addEventListener('textInput', this.handleBeforeinput)
     }
 
     Object.defineProperty(this.el, 'value', {
@@ -107,6 +109,11 @@ export class Input implements ComponentInterface {
   disconnectedCallback () {
     if (this.type === 'file') {
       this.inputRef?.removeEventListener('change', this.fileListener)
+    } else {
+      this.inputRef?.removeEventListener('compositionstart', this.handleComposition)
+      this.inputRef?.removeEventListener('compositionend', this.handleComposition)
+      this.inputRef?.removeEventListener('beforeinput', this.handleBeforeinput)
+      this.inputRef?.removeEventListener('textInput', this.handleBeforeinput)
     }
   }
 
@@ -211,6 +218,19 @@ export class Input implements ComponentInterface {
       })
     } else {
       this.isOnComposition = true
+    }
+  }
+
+  handleBeforeinput = (e) => {
+    if (!e.data) return
+    const isNumber = e.data && /[0-9]/.test(e.data)
+    if (this.type === 'number' && !isNumber) {
+      e.preventDefault()
+    }
+    if (this.type === 'digit' && !isNumber) {
+      if (e.data !== '.' || (e.data === '.' && e.target.value.indexOf('.') > -1)) {
+        e.preventDefault()
+      }
     }
   }
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

优化 H5 端 input 组件 type 为 number 或 digit 时, 输入特殊符号导致交互异常问题。

描述：Web 的 input 组件 type=number时，当开发者输入特殊符号或者多个小数点时，input 组件的 value 值会表现为空，从而在业务场景下，会出现不符合预期的多种表现。在唤起 Web 端数字键盘时，通过对特殊符号的输入拦截可以做到一定交互体验优化。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
