### PR TITLE
style: 支持较新版本的autoprefixer(7.0.0+)

### DIFF
--- a/packages/taro/html5.css
+++ b/packages/taro/html5.css
@@ -60,7 +60,7 @@
 
 .h5-marquee {
   display: inline-block;
-  width: fill-available;
+  width: stretch;
 }
 
 .h5-address {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)



**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [x] 其他，请描述(Other, please describe):

https://caniuse.com/mdn-css_properties_width_stretch
https://github.com/postcss/autoprefixer/issues/1035

基于警告`autoprefixer: Replace fill-available to stretch, because spec had been changed`, 较新版本的`autoprefixer`需要使用新的写法, 编译结果为:

```css
.h5-marquee {
  display: inline-block;
  width: -webkit-fill-available;
  width: -moz-available;
  width: fill-available;
}
```
该属性历史有关的PR: #9891 #11106

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
