### PR TITLE
chore: 部分抹平h5与小程序参数差异

### DIFF
--- a/packages/taro-h5/__tests__/utils.ts
+++ b/packages/taro-h5/__tests__/utils.ts
@@ -1,6 +1,6 @@
 import { createReactApp } from '@tarojs/plugin-framework-react/dist/runtime'
 import { createRouter } from '@tarojs/router'
-import React, { Component } from 'react'
+import React, { Component, PropsWithChildren } from 'react'
 import ReactDOM from 'react-test-renderer'
 
 const appConfig: any = {
@@ -63,7 +63,7 @@ export const delay = (ms) => {
 
 export function buildApp () {
   const config: any = { ...appConfig }
-  class App extends Component {
+  class App extends Component<PropsWithChildren> {
     render () {
       return this.props.children
     }

--- a/packages/taro-h5/src/api/base/weapp/life-cycle.ts
+++ b/packages/taro-h5/src/api/base/weapp/life-cycle.ts
@@ -1,13 +1,19 @@
 import Taro from '@tarojs/api'
 
-import taro, { eventCenter } from '../../taro'
-
-function initLaunchOptions (options = {}) {
-  (taro as any).launchOptions = options
+const launchOptions: Taro.getLaunchOptionsSync.LaunchOptions = {
+  path: '',
+  query: {},
+  scene: 0,
+  shareTicket: '',
+  referrerInfo: {}
 }
 
-eventCenter.once('__taroRouterLaunch', initLaunchOptions)
+function initLaunchOptions (options = {}) {
+  Object.assign(launchOptions, options)
+}
+
+Taro.eventCenter.once('__taroRouterLaunch', initLaunchOptions)
 
 // 生命周期
-export const getLaunchOptionsSync: typeof Taro.getLaunchOptionsSync = () => (taro as any).launchOptions
-export const getEnterOptionsSync: typeof Taro.getEnterOptionsSync = () => (taro as any).launchOptions
+export const getLaunchOptionsSync: typeof Taro.getLaunchOptionsSync = () => launchOptions
+export const getEnterOptionsSync: typeof Taro.getEnterOptionsSync = () => launchOptions

--- a/packages/taro-h5/src/api/base/weapp/life-cycle.ts
+++ b/packages/taro-h5/src/api/base/weapp/life-cycle.ts
@@ -1,5 +1,13 @@
-import { temporarilyNotSupport } from '../../../utils'
+import Taro from '@tarojs/api'
+
+import taro, { eventCenter } from '../../taro'
+
+function initLaunchOptions (options = {}) {
+  (taro as any).launchOptions = options
+}
+
+eventCenter.once('__taroRouterLaunch', initLaunchOptions)
 
 // 生命周期
-export const getLaunchOptionsSync = temporarilyNotSupport('getLaunchOptionsSync')
-export const getEnterOptionsSync = temporarilyNotSupport('getEnterOptionsSync')
+export const getLaunchOptionsSync: typeof Taro.getLaunchOptionsSync = () => (taro as any).launchOptions
+export const getEnterOptionsSync: typeof Taro.getEnterOptionsSync = () => (taro as any).launchOptions

--- a/packages/taro-router/src/router/mpa.ts
+++ b/packages/taro-router/src/router/mpa.ts
@@ -28,7 +28,10 @@ export async function createMultiRouter (
 ) {
   RouterConfig.config = config
   const handler = new MultiPageHandler(config)
-  const launchParam = handler.getQuery()
+  const launchParam = {
+    // 其他参数, 需要再抹平
+    query: handler.getQuery()
+  }
   app.onLaunch?.(launchParam)
   app.onError && window.addEventListener('error', e => app.onError?.(e.message))
 

--- a/packages/taro-router/src/router/mpa.ts
+++ b/packages/taro-router/src/router/mpa.ts
@@ -35,6 +35,8 @@ export async function createMultiRouter (
     shareTicket: '',
     referrerInfo: {}
   }
+
+  eventCenter.trigger('__taroRouterLaunch', launchParam)
   app.onLaunch?.(launchParam as Record<string, any>)
   app.onError && window.addEventListener('error', e => app.onError?.(e.message))
 

--- a/packages/taro-router/src/router/mpa.ts
+++ b/packages/taro-router/src/router/mpa.ts
@@ -28,11 +28,14 @@ export async function createMultiRouter (
 ) {
   RouterConfig.config = config
   const handler = new MultiPageHandler(config)
-  const launchParam = {
-    // 其他参数, 需要再抹平
-    query: handler.getQuery()
+  const launchParam: Taro.getLaunchOptionsSync.LaunchOptions = {
+    path: config.pageName, // 多页面模式没新开一个页面相当于重启，所以直接使用当前页面路径
+    query: handler.getQuery(),
+    scene: 0,
+    shareTicket: '',
+    referrerInfo: {}
   }
-  app.onLaunch?.(launchParam)
+  app.onLaunch?.(launchParam as Record<string, any>)
   app.onError && window.addEventListener('error', e => app.onError?.(e.message))
 
   const pathName = config.pageName
@@ -68,11 +71,11 @@ export async function createMultiRouter (
   delete loadConfig['load']
   const page = createPageConfig(
     enablePullDownRefresh ? hooks.call('createPullDownComponent', el, location.pathname, framework, config.PullDownRefresh) : el,
-    pathName + stringify(launchParam),
+    pathName + stringify(launchParam as Record<string, any>),
     {},
     loadConfig
   )
   handler.load(page, pageConfig)
 
-  app.onShow?.(launchParam)
+  app.onShow?.(launchParam as Record<string, any>)
 }

--- a/packages/taro-router/src/router/spa.ts
+++ b/packages/taro-router/src/router/spa.ts
@@ -36,7 +36,10 @@ export function createRouter (
     }
   })
   const router = new UniversalRouter(routes, { baseUrl: basename || '' })
-  const launchParam = handler.getQuery(stacks.length)
+  const launchParam = {
+    // 其他参数, 需要再抹平
+    query: handler.getQuery(stacks.length)
+  }
   app.onLaunch?.(launchParam)
   app.onError && window.addEventListener('error', e => app.onError?.(e.message))
 

--- a/packages/taro-router/src/router/spa.ts
+++ b/packages/taro-router/src/router/spa.ts
@@ -38,6 +38,7 @@ export function createRouter (
   const router = new UniversalRouter(routes, { baseUrl: basename || '' })
   const launchParam = {
     // 其他参数, 需要再抹平
+    path: handler.homePage,
     query: handler.getQuery(stacks.length)
   }
   app.onLaunch?.(launchParam)

--- a/packages/taro-router/src/router/spa.ts
+++ b/packages/taro-router/src/router/spa.ts
@@ -43,6 +43,8 @@ export function createRouter (
     shareTicket: '',
     referrerInfo: {}
   }
+
+  eventCenter.trigger('__taroRouterLaunch', launchParam)
   app.onLaunch?.(launchParam as Record<string, any>)
   app.onError && window.addEventListener('error', e => app.onError?.(e.message))
 

--- a/packages/taro-router/src/router/spa.ts
+++ b/packages/taro-router/src/router/spa.ts
@@ -36,12 +36,14 @@ export function createRouter (
     }
   })
   const router = new UniversalRouter(routes, { baseUrl: basename || '' })
-  const launchParam = {
-    // 其他参数, 需要再抹平
+  const launchParam: Taro.getLaunchOptionsSync.LaunchOptions = {
     path: handler.homePage,
-    query: handler.getQuery(stacks.length)
+    query: handler.getQuery(stacks.length),
+    scene: 0,
+    shareTicket: '',
+    referrerInfo: {}
   }
-  app.onLaunch?.(launchParam)
+  app.onLaunch?.(launchParam as Record<string, any>)
   app.onError && window.addEventListener('error', e => app.onError?.(e.message))
 
   const render: LocationListener = async ({ location, action }) => {
@@ -141,7 +143,7 @@ export function createRouter (
 
   render({ location: history.location, action: LocationAction.Push })
 
-  app.onShow?.(launchParam)
+  app.onShow?.(launchParam as Record<string, any>)
 
   return history.listen(render)
 }

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/babel.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/babel.spec.ts.snap
@@ -3843,7 +3843,9 @@ exports[`babel should convert do expressions 2`] = `
                       case 0:
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
-                        launchParam = handler.getQuery();
+                        launchParam = {
+                            \\"query\\": handler.getQuery()
+                        };
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -4501,7 +4503,9 @@ exports[`babel should convert do expressions 2`] = `
         var router = new universal_router_module(routes, {
             \\"baseUrl\\": basename || \\"\\"
         });
-        var launchParam = handler.getQuery(stack.length);
+        var launchParam = {
+            \\"query\\": handler.getQuery(stack.length)
+        };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/babel.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/babel.spec.ts.snap
@@ -3844,8 +3844,13 @@ exports[`babel should convert do expressions 2`] = `
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
                         launchParam = {
-                            \\"query\\": handler.getQuery()
+                            \\"path\\": config.pageName,
+                            \\"query\\": handler.getQuery(),
+                            \\"scene\\": 0,
+                            \\"shareTicket\\": \\"\\",
+                            \\"referrerInfo\\": {}
                         };
+                        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -3853,31 +3858,31 @@ exports[`babel should convert do expressions 2`] = `
                         }));
                         pathName = config.pageName;
                         pageConfig = handler.pageConfig;
-                        _context.prev = 7;
-                        _context.next = 10;
+                        _context.prev = 8;
+                        _context.next = 11;
                         return (_b = pageConfig.load) === null || _b === void 0 ? void 0 : _b.call(pageConfig);
 
-                      case 10:
+                      case 11:
                         element = _context.sent;
                         if (element instanceof Array) {
                             element = element[0];
                         }
-                        _context.next = 17;
+                        _context.next = 18;
                         break;
 
-                      case 14:
-                        _context.prev = 14;
-                        _context.t0 = _context[\\"catch\\"](7);
+                      case 15:
+                        _context.prev = 15;
+                        _context.t0 = _context[\\"catch\\"](8);
                         throw new Error(_context.t0);
 
-                      case 17:
+                      case 18:
                         if (element) {
-                            _context.next = 19;
+                            _context.next = 20;
                             break;
                         }
                         return _context.abrupt(\\"return\\");
 
-                      case 19:
+                      case 20:
                         enablePullDownRefresh = ((_c = config === null || config === void 0 ? void 0 : config.window) === null || _c === void 0 ? void 0 : _c.enablePullDownRefresh) || false;
                         undefined.trigger(\\"__taroRouterChange\\", {
                             \\"toLocation\\": {
@@ -3898,12 +3903,12 @@ exports[`babel should convert do expressions 2`] = `
                         handler.load(page, pageConfig);
                         (_f = app.onShow) === null || _f === void 0 ? void 0 : _f.call(app, launchParam);
 
-                      case 29:
+                      case 30:
                       case \\"end\\":
                         return _context.stop();
                     }
                 }
-            }), _callee, null, [ [ 7, 14 ] ]);
+            }), _callee, null, [ [ 8, 15 ] ]);
         })));
     }
     var path_to_regexp = __webpack_require__(8);
@@ -4505,8 +4510,12 @@ exports[`babel should convert do expressions 2`] = `
         });
         var launchParam = {
             \\"path\\": handler.homePage,
-            \\"query\\": handler.getQuery(stack.length)
+            \\"query\\": handler.getQuery(stack.length),
+            \\"scene\\": 0,
+            \\"shareTicket\\": \\"\\",
+            \\"referrerInfo\\": {}
         };
+        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/babel.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/babel.spec.ts.snap
@@ -4504,6 +4504,7 @@ exports[`babel should convert do expressions 2`] = `
             \\"baseUrl\\": basename || \\"\\"
         });
         var launchParam = {
+            \\"path\\": handler.homePage,
             \\"query\\": handler.getQuery(stack.length)
         };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/compiler-macros.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/compiler-macros.spec.ts.snap
@@ -3839,8 +3839,13 @@ exports[`compiler-macros - defineAppConfig and definePageConfig should read app 
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
                         launchParam = {
-                            \\"query\\": handler.getQuery()
+                            \\"path\\": config.pageName,
+                            \\"query\\": handler.getQuery(),
+                            \\"scene\\": 0,
+                            \\"shareTicket\\": \\"\\",
+                            \\"referrerInfo\\": {}
                         };
+                        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -3848,31 +3853,31 @@ exports[`compiler-macros - defineAppConfig and definePageConfig should read app 
                         }));
                         pathName = config.pageName;
                         pageConfig = handler.pageConfig;
-                        _context.prev = 7;
-                        _context.next = 10;
+                        _context.prev = 8;
+                        _context.next = 11;
                         return (_b = pageConfig.load) === null || _b === void 0 ? void 0 : _b.call(pageConfig);
 
-                      case 10:
+                      case 11:
                         element = _context.sent;
                         if (element instanceof Array) {
                             element = element[0];
                         }
-                        _context.next = 17;
+                        _context.next = 18;
                         break;
 
-                      case 14:
-                        _context.prev = 14;
-                        _context.t0 = _context[\\"catch\\"](7);
+                      case 15:
+                        _context.prev = 15;
+                        _context.t0 = _context[\\"catch\\"](8);
                         throw new Error(_context.t0);
 
-                      case 17:
+                      case 18:
                         if (element) {
-                            _context.next = 19;
+                            _context.next = 20;
                             break;
                         }
                         return _context.abrupt(\\"return\\");
 
-                      case 19:
+                      case 20:
                         enablePullDownRefresh = ((_c = config === null || config === void 0 ? void 0 : config.window) === null || _c === void 0 ? void 0 : _c.enablePullDownRefresh) || false;
                         undefined.trigger(\\"__taroRouterChange\\", {
                             \\"toLocation\\": {
@@ -3893,12 +3898,12 @@ exports[`compiler-macros - defineAppConfig and definePageConfig should read app 
                         handler.load(page, pageConfig);
                         (_f = app.onShow) === null || _f === void 0 ? void 0 : _f.call(app, launchParam);
 
-                      case 29:
+                      case 30:
                       case \\"end\\":
                         return _context.stop();
                     }
                 }
-            }), _callee, null, [ [ 7, 14 ] ]);
+            }), _callee, null, [ [ 8, 15 ] ]);
         })));
     }
     var path_to_regexp = __webpack_require__(8);
@@ -4500,8 +4505,12 @@ exports[`compiler-macros - defineAppConfig and definePageConfig should read app 
         });
         var launchParam = {
             \\"path\\": handler.homePage,
-            \\"query\\": handler.getQuery(stack.length)
+            \\"query\\": handler.getQuery(stack.length),
+            \\"scene\\": 0,
+            \\"shareTicket\\": \\"\\",
+            \\"referrerInfo\\": {}
         };
+        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/compiler-macros.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/compiler-macros.spec.ts.snap
@@ -3838,7 +3838,9 @@ exports[`compiler-macros - defineAppConfig and definePageConfig should read app 
                       case 0:
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
-                        launchParam = handler.getQuery();
+                        launchParam = {
+                            \\"query\\": handler.getQuery()
+                        };
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -4496,7 +4498,9 @@ exports[`compiler-macros - defineAppConfig and definePageConfig should read app 
         var router = new universal_router_module(routes, {
             \\"baseUrl\\": basename || \\"\\"
         });
-        var launchParam = handler.getQuery(stack.length);
+        var launchParam = {
+            \\"query\\": handler.getQuery(stack.length)
+        };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/compiler-macros.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/compiler-macros.spec.ts.snap
@@ -4499,6 +4499,7 @@ exports[`compiler-macros - defineAppConfig and definePageConfig should read app 
             \\"baseUrl\\": basename || \\"\\"
         });
         var launchParam = {
+            \\"path\\": handler.homePage,
             \\"query\\": handler.getQuery(stack.length)
         };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/config.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/config.spec.ts.snap
@@ -3850,7 +3850,9 @@ exports[`config should build from origin and pipe to output 2`] = `
                       case 0:
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
-                        launchParam = handler.getQuery();
+                        launchParam = {
+                            \\"query\\": handler.getQuery()
+                        };
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -4508,7 +4510,9 @@ exports[`config should build from origin and pipe to output 2`] = `
         var router = new universal_router_module(routes, {
             \\"baseUrl\\": basename || \\"\\"
         });
-        var launchParam = handler.getQuery(stack.length);
+        var launchParam = {
+            \\"query\\": handler.getQuery(stack.length)
+        };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;
@@ -8627,7 +8631,9 @@ I m irrelevant.
                       case 0:
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
-                        launchParam = handler.getQuery();
+                        launchParam = {
+                            \\"query\\": handler.getQuery()
+                        };
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -9285,7 +9291,9 @@ I m irrelevant.
         var router = new universal_router_module(routes, {
             \\"baseUrl\\": basename || \\"\\"
         });
-        var launchParam = handler.getQuery(stack.length);
+        var launchParam = {
+            \\"query\\": handler.getQuery(stack.length)
+        };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;
@@ -13404,7 +13412,9 @@ exports[`config should resolved alias 2`] = `
                       case 0:
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
-                        launchParam = handler.getQuery();
+                        launchParam = {
+                            \\"query\\": handler.getQuery()
+                        };
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -14062,7 +14072,9 @@ exports[`config should resolved alias 2`] = `
         var router = new universal_router_module(routes, {
             \\"baseUrl\\": basename || \\"\\"
         });
-        var launchParam = handler.getQuery(stack.length);
+        var launchParam = {
+            \\"query\\": handler.getQuery(stack.length)
+        };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/config.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/config.spec.ts.snap
@@ -3851,8 +3851,13 @@ exports[`config should build from origin and pipe to output 2`] = `
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
                         launchParam = {
-                            \\"query\\": handler.getQuery()
+                            \\"path\\": config.pageName,
+                            \\"query\\": handler.getQuery(),
+                            \\"scene\\": 0,
+                            \\"shareTicket\\": \\"\\",
+                            \\"referrerInfo\\": {}
                         };
+                        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -3860,31 +3865,31 @@ exports[`config should build from origin and pipe to output 2`] = `
                         }));
                         pathName = config.pageName;
                         pageConfig = handler.pageConfig;
-                        _context.prev = 7;
-                        _context.next = 10;
+                        _context.prev = 8;
+                        _context.next = 11;
                         return (_b = pageConfig.load) === null || _b === void 0 ? void 0 : _b.call(pageConfig);
 
-                      case 10:
+                      case 11:
                         element = _context.sent;
                         if (element instanceof Array) {
                             element = element[0];
                         }
-                        _context.next = 17;
+                        _context.next = 18;
                         break;
 
-                      case 14:
-                        _context.prev = 14;
-                        _context.t0 = _context[\\"catch\\"](7);
+                      case 15:
+                        _context.prev = 15;
+                        _context.t0 = _context[\\"catch\\"](8);
                         throw new Error(_context.t0);
 
-                      case 17:
+                      case 18:
                         if (element) {
-                            _context.next = 19;
+                            _context.next = 20;
                             break;
                         }
                         return _context.abrupt(\\"return\\");
 
-                      case 19:
+                      case 20:
                         enablePullDownRefresh = ((_c = config === null || config === void 0 ? void 0 : config.window) === null || _c === void 0 ? void 0 : _c.enablePullDownRefresh) || false;
                         undefined.trigger(\\"__taroRouterChange\\", {
                             \\"toLocation\\": {
@@ -3905,12 +3910,12 @@ exports[`config should build from origin and pipe to output 2`] = `
                         handler.load(page, pageConfig);
                         (_f = app.onShow) === null || _f === void 0 ? void 0 : _f.call(app, launchParam);
 
-                      case 29:
+                      case 30:
                       case \\"end\\":
                         return _context.stop();
                     }
                 }
-            }), _callee, null, [ [ 7, 14 ] ]);
+            }), _callee, null, [ [ 8, 15 ] ]);
         })));
     }
     var path_to_regexp = __webpack_require__(8);
@@ -4512,8 +4517,12 @@ exports[`config should build from origin and pipe to output 2`] = `
         });
         var launchParam = {
             \\"path\\": handler.homePage,
-            \\"query\\": handler.getQuery(stack.length)
+            \\"query\\": handler.getQuery(stack.length),
+            \\"scene\\": 0,
+            \\"shareTicket\\": \\"\\",
+            \\"referrerInfo\\": {}
         };
+        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;
@@ -8633,8 +8642,13 @@ I m irrelevant.
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
                         launchParam = {
-                            \\"query\\": handler.getQuery()
+                            \\"path\\": config.pageName,
+                            \\"query\\": handler.getQuery(),
+                            \\"scene\\": 0,
+                            \\"shareTicket\\": \\"\\",
+                            \\"referrerInfo\\": {}
                         };
+                        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -8642,31 +8656,31 @@ I m irrelevant.
                         }));
                         pathName = config.pageName;
                         pageConfig = handler.pageConfig;
-                        _context.prev = 7;
-                        _context.next = 10;
+                        _context.prev = 8;
+                        _context.next = 11;
                         return (_b = pageConfig.load) === null || _b === void 0 ? void 0 : _b.call(pageConfig);
 
-                      case 10:
+                      case 11:
                         element = _context.sent;
                         if (element instanceof Array) {
                             element = element[0];
                         }
-                        _context.next = 17;
+                        _context.next = 18;
                         break;
 
-                      case 14:
-                        _context.prev = 14;
-                        _context.t0 = _context[\\"catch\\"](7);
+                      case 15:
+                        _context.prev = 15;
+                        _context.t0 = _context[\\"catch\\"](8);
                         throw new Error(_context.t0);
 
-                      case 17:
+                      case 18:
                         if (element) {
-                            _context.next = 19;
+                            _context.next = 20;
                             break;
                         }
                         return _context.abrupt(\\"return\\");
 
-                      case 19:
+                      case 20:
                         enablePullDownRefresh = ((_c = config === null || config === void 0 ? void 0 : config.window) === null || _c === void 0 ? void 0 : _c.enablePullDownRefresh) || false;
                         undefined.trigger(\\"__taroRouterChange\\", {
                             \\"toLocation\\": {
@@ -8687,12 +8701,12 @@ I m irrelevant.
                         handler.load(page, pageConfig);
                         (_f = app.onShow) === null || _f === void 0 ? void 0 : _f.call(app, launchParam);
 
-                      case 29:
+                      case 30:
                       case \\"end\\":
                         return _context.stop();
                     }
                 }
-            }), _callee, null, [ [ 7, 14 ] ]);
+            }), _callee, null, [ [ 8, 15 ] ]);
         })));
     }
     var path_to_regexp = __webpack_require__(8);
@@ -9294,8 +9308,12 @@ I m irrelevant.
         });
         var launchParam = {
             \\"path\\": handler.homePage,
-            \\"query\\": handler.getQuery(stack.length)
+            \\"query\\": handler.getQuery(stack.length),
+            \\"scene\\": 0,
+            \\"shareTicket\\": \\"\\",
+            \\"referrerInfo\\": {}
         };
+        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;
@@ -13415,8 +13433,13 @@ exports[`config should resolved alias 2`] = `
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
                         launchParam = {
-                            \\"query\\": handler.getQuery()
+                            \\"path\\": config.pageName,
+                            \\"query\\": handler.getQuery(),
+                            \\"scene\\": 0,
+                            \\"shareTicket\\": \\"\\",
+                            \\"referrerInfo\\": {}
                         };
+                        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -13424,31 +13447,31 @@ exports[`config should resolved alias 2`] = `
                         }));
                         pathName = config.pageName;
                         pageConfig = handler.pageConfig;
-                        _context.prev = 7;
-                        _context.next = 10;
+                        _context.prev = 8;
+                        _context.next = 11;
                         return (_b = pageConfig.load) === null || _b === void 0 ? void 0 : _b.call(pageConfig);
 
-                      case 10:
+                      case 11:
                         element = _context.sent;
                         if (element instanceof Array) {
                             element = element[0];
                         }
-                        _context.next = 17;
+                        _context.next = 18;
                         break;
 
-                      case 14:
-                        _context.prev = 14;
-                        _context.t0 = _context[\\"catch\\"](7);
+                      case 15:
+                        _context.prev = 15;
+                        _context.t0 = _context[\\"catch\\"](8);
                         throw new Error(_context.t0);
 
-                      case 17:
+                      case 18:
                         if (element) {
-                            _context.next = 19;
+                            _context.next = 20;
                             break;
                         }
                         return _context.abrupt(\\"return\\");
 
-                      case 19:
+                      case 20:
                         enablePullDownRefresh = ((_c = config === null || config === void 0 ? void 0 : config.window) === null || _c === void 0 ? void 0 : _c.enablePullDownRefresh) || false;
                         undefined.trigger(\\"__taroRouterChange\\", {
                             \\"toLocation\\": {
@@ -13469,12 +13492,12 @@ exports[`config should resolved alias 2`] = `
                         handler.load(page, pageConfig);
                         (_f = app.onShow) === null || _f === void 0 ? void 0 : _f.call(app, launchParam);
 
-                      case 29:
+                      case 30:
                       case \\"end\\":
                         return _context.stop();
                     }
                 }
-            }), _callee, null, [ [ 7, 14 ] ]);
+            }), _callee, null, [ [ 8, 15 ] ]);
         })));
     }
     var path_to_regexp = __webpack_require__(8);
@@ -14076,8 +14099,12 @@ exports[`config should resolved alias 2`] = `
         });
         var launchParam = {
             \\"path\\": handler.homePage,
-            \\"query\\": handler.getQuery(stack.length)
+            \\"query\\": handler.getQuery(stack.length),
+            \\"scene\\": 0,
+            \\"shareTicket\\": \\"\\",
+            \\"referrerInfo\\": {}
         };
+        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/config.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/config.spec.ts.snap
@@ -4511,6 +4511,7 @@ exports[`config should build from origin and pipe to output 2`] = `
             \\"baseUrl\\": basename || \\"\\"
         });
         var launchParam = {
+            \\"path\\": handler.homePage,
             \\"query\\": handler.getQuery(stack.length)
         };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
@@ -9292,6 +9293,7 @@ I m irrelevant.
             \\"baseUrl\\": basename || \\"\\"
         });
         var launchParam = {
+            \\"path\\": handler.homePage,
             \\"query\\": handler.getQuery(stack.length)
         };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
@@ -14073,6 +14075,7 @@ exports[`config should resolved alias 2`] = `
             \\"baseUrl\\": basename || \\"\\"
         });
         var launchParam = {
+            \\"path\\": handler.homePage,
             \\"query\\": handler.getQuery(stack.length)
         };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/css-modules.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/css-modules.spec.ts.snap
@@ -4528,6 +4528,7 @@ exports[`css modules should use css modules with global mode 2`] = `
             \\"baseUrl\\": basename || \\"\\"
         });
         var launchParam = {
+            \\"path\\": handler.homePage,
             \\"query\\": handler.getQuery(stack.length)
         };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
@@ -9318,6 +9319,7 @@ exports[`css modules should use css modules with module mode 2`] = `
             \\"baseUrl\\": basename || \\"\\"
         });
         var launchParam = {
+            \\"path\\": handler.homePage,
             \\"query\\": handler.getQuery(stack.length)
         };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/css-modules.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/css-modules.spec.ts.snap
@@ -3867,7 +3867,9 @@ exports[`css modules should use css modules with global mode 2`] = `
                       case 0:
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
-                        launchParam = handler.getQuery();
+                        launchParam = {
+                            \\"query\\": handler.getQuery()
+                        };
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -4525,7 +4527,9 @@ exports[`css modules should use css modules with global mode 2`] = `
         var router = new universal_router_module(routes, {
             \\"baseUrl\\": basename || \\"\\"
         });
-        var launchParam = handler.getQuery(stack.length);
+        var launchParam = {
+            \\"query\\": handler.getQuery(stack.length)
+        };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;
@@ -8653,7 +8657,9 @@ exports[`css modules should use css modules with module mode 2`] = `
                       case 0:
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
-                        launchParam = handler.getQuery();
+                        launchParam = {
+                            \\"query\\": handler.getQuery()
+                        };
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -9311,7 +9317,9 @@ exports[`css modules should use css modules with module mode 2`] = `
         var router = new universal_router_module(routes, {
             \\"baseUrl\\": basename || \\"\\"
         });
-        var launchParam = handler.getQuery(stack.length);
+        var launchParam = {
+            \\"query\\": handler.getQuery(stack.length)
+        };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/css-modules.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/css-modules.spec.ts.snap
@@ -3868,8 +3868,13 @@ exports[`css modules should use css modules with global mode 2`] = `
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
                         launchParam = {
-                            \\"query\\": handler.getQuery()
+                            \\"path\\": config.pageName,
+                            \\"query\\": handler.getQuery(),
+                            \\"scene\\": 0,
+                            \\"shareTicket\\": \\"\\",
+                            \\"referrerInfo\\": {}
                         };
+                        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -3877,31 +3882,31 @@ exports[`css modules should use css modules with global mode 2`] = `
                         }));
                         pathName = config.pageName;
                         pageConfig = handler.pageConfig;
-                        _context.prev = 7;
-                        _context.next = 10;
+                        _context.prev = 8;
+                        _context.next = 11;
                         return (_b = pageConfig.load) === null || _b === void 0 ? void 0 : _b.call(pageConfig);
 
-                      case 10:
+                      case 11:
                         element = _context.sent;
                         if (element instanceof Array) {
                             element = element[0];
                         }
-                        _context.next = 17;
+                        _context.next = 18;
                         break;
 
-                      case 14:
-                        _context.prev = 14;
-                        _context.t0 = _context[\\"catch\\"](7);
+                      case 15:
+                        _context.prev = 15;
+                        _context.t0 = _context[\\"catch\\"](8);
                         throw new Error(_context.t0);
 
-                      case 17:
+                      case 18:
                         if (element) {
-                            _context.next = 19;
+                            _context.next = 20;
                             break;
                         }
                         return _context.abrupt(\\"return\\");
 
-                      case 19:
+                      case 20:
                         enablePullDownRefresh = ((_c = config === null || config === void 0 ? void 0 : config.window) === null || _c === void 0 ? void 0 : _c.enablePullDownRefresh) || false;
                         undefined.trigger(\\"__taroRouterChange\\", {
                             \\"toLocation\\": {
@@ -3922,12 +3927,12 @@ exports[`css modules should use css modules with global mode 2`] = `
                         handler.load(page, pageConfig);
                         (_f = app.onShow) === null || _f === void 0 ? void 0 : _f.call(app, launchParam);
 
-                      case 29:
+                      case 30:
                       case \\"end\\":
                         return _context.stop();
                     }
                 }
-            }), _callee, null, [ [ 7, 14 ] ]);
+            }), _callee, null, [ [ 8, 15 ] ]);
         })));
     }
     var path_to_regexp = __webpack_require__(8);
@@ -4529,8 +4534,12 @@ exports[`css modules should use css modules with global mode 2`] = `
         });
         var launchParam = {
             \\"path\\": handler.homePage,
-            \\"query\\": handler.getQuery(stack.length)
+            \\"query\\": handler.getQuery(stack.length),
+            \\"scene\\": 0,
+            \\"shareTicket\\": \\"\\",
+            \\"referrerInfo\\": {}
         };
+        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;
@@ -8659,8 +8668,13 @@ exports[`css modules should use css modules with module mode 2`] = `
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
                         launchParam = {
-                            \\"query\\": handler.getQuery()
+                            \\"path\\": config.pageName,
+                            \\"query\\": handler.getQuery(),
+                            \\"scene\\": 0,
+                            \\"shareTicket\\": \\"\\",
+                            \\"referrerInfo\\": {}
                         };
+                        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -8668,31 +8682,31 @@ exports[`css modules should use css modules with module mode 2`] = `
                         }));
                         pathName = config.pageName;
                         pageConfig = handler.pageConfig;
-                        _context.prev = 7;
-                        _context.next = 10;
+                        _context.prev = 8;
+                        _context.next = 11;
                         return (_b = pageConfig.load) === null || _b === void 0 ? void 0 : _b.call(pageConfig);
 
-                      case 10:
+                      case 11:
                         element = _context.sent;
                         if (element instanceof Array) {
                             element = element[0];
                         }
-                        _context.next = 17;
+                        _context.next = 18;
                         break;
 
-                      case 14:
-                        _context.prev = 14;
-                        _context.t0 = _context[\\"catch\\"](7);
+                      case 15:
+                        _context.prev = 15;
+                        _context.t0 = _context[\\"catch\\"](8);
                         throw new Error(_context.t0);
 
-                      case 17:
+                      case 18:
                         if (element) {
-                            _context.next = 19;
+                            _context.next = 20;
                             break;
                         }
                         return _context.abrupt(\\"return\\");
 
-                      case 19:
+                      case 20:
                         enablePullDownRefresh = ((_c = config === null || config === void 0 ? void 0 : config.window) === null || _c === void 0 ? void 0 : _c.enablePullDownRefresh) || false;
                         undefined.trigger(\\"__taroRouterChange\\", {
                             \\"toLocation\\": {
@@ -8713,12 +8727,12 @@ exports[`css modules should use css modules with module mode 2`] = `
                         handler.load(page, pageConfig);
                         (_f = app.onShow) === null || _f === void 0 ? void 0 : _f.call(app, launchParam);
 
-                      case 29:
+                      case 30:
                       case \\"end\\":
                         return _context.stop();
                     }
                 }
-            }), _callee, null, [ [ 7, 14 ] ]);
+            }), _callee, null, [ [ 8, 15 ] ]);
         })));
     }
     var path_to_regexp = __webpack_require__(8);
@@ -9320,8 +9334,12 @@ exports[`css modules should use css modules with module mode 2`] = `
         });
         var launchParam = {
             \\"path\\": handler.homePage,
-            \\"query\\": handler.getQuery(stack.length)
+            \\"query\\": handler.getQuery(stack.length),
+            \\"scene\\": 0,
+            \\"shareTicket\\": \\"\\",
+            \\"referrerInfo\\": {}
         };
+        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/nerv.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/nerv.spec.ts.snap
@@ -4510,6 +4510,7 @@ exports[`nerv should build nerv app 2`] = `
             \\"baseUrl\\": basename || \\"\\"
         });
         var launchParam = {
+            \\"path\\": handler.homePage,
             \\"query\\": handler.getQuery(stack.length)
         };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/nerv.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/nerv.spec.ts.snap
@@ -3849,7 +3849,9 @@ exports[`nerv should build nerv app 2`] = `
                       case 0:
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
-                        launchParam = handler.getQuery();
+                        launchParam = {
+                            \\"query\\": handler.getQuery()
+                        };
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -4507,7 +4509,9 @@ exports[`nerv should build nerv app 2`] = `
         var router = new universal_router_module(routes, {
             \\"baseUrl\\": basename || \\"\\"
         });
-        var launchParam = handler.getQuery(stack.length);
+        var launchParam = {
+            \\"query\\": handler.getQuery(stack.length)
+        };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/nerv.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/nerv.spec.ts.snap
@@ -3850,8 +3850,13 @@ exports[`nerv should build nerv app 2`] = `
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
                         launchParam = {
-                            \\"query\\": handler.getQuery()
+                            \\"path\\": config.pageName,
+                            \\"query\\": handler.getQuery(),
+                            \\"scene\\": 0,
+                            \\"shareTicket\\": \\"\\",
+                            \\"referrerInfo\\": {}
                         };
+                        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -3859,31 +3864,31 @@ exports[`nerv should build nerv app 2`] = `
                         }));
                         pathName = config.pageName;
                         pageConfig = handler.pageConfig;
-                        _context.prev = 7;
-                        _context.next = 10;
+                        _context.prev = 8;
+                        _context.next = 11;
                         return (_b = pageConfig.load) === null || _b === void 0 ? void 0 : _b.call(pageConfig);
 
-                      case 10:
+                      case 11:
                         element = _context.sent;
                         if (element instanceof Array) {
                             element = element[0];
                         }
-                        _context.next = 17;
+                        _context.next = 18;
                         break;
 
-                      case 14:
-                        _context.prev = 14;
-                        _context.t0 = _context[\\"catch\\"](7);
+                      case 15:
+                        _context.prev = 15;
+                        _context.t0 = _context[\\"catch\\"](8);
                         throw new Error(_context.t0);
 
-                      case 17:
+                      case 18:
                         if (element) {
-                            _context.next = 19;
+                            _context.next = 20;
                             break;
                         }
                         return _context.abrupt(\\"return\\");
 
-                      case 19:
+                      case 20:
                         enablePullDownRefresh = ((_c = config === null || config === void 0 ? void 0 : config.window) === null || _c === void 0 ? void 0 : _c.enablePullDownRefresh) || false;
                         undefined.trigger(\\"__taroRouterChange\\", {
                             \\"toLocation\\": {
@@ -3904,12 +3909,12 @@ exports[`nerv should build nerv app 2`] = `
                         handler.load(page, pageConfig);
                         (_f = app.onShow) === null || _f === void 0 ? void 0 : _f.call(app, launchParam);
 
-                      case 29:
+                      case 30:
                       case \\"end\\":
                         return _context.stop();
                     }
                 }
-            }), _callee, null, [ [ 7, 14 ] ]);
+            }), _callee, null, [ [ 8, 15 ] ]);
         })));
     }
     var path_to_regexp = __webpack_require__(8);
@@ -4511,8 +4516,12 @@ exports[`nerv should build nerv app 2`] = `
         });
         var launchParam = {
             \\"path\\": handler.homePage,
-            \\"query\\": handler.getQuery(stack.length)
+            \\"query\\": handler.getQuery(stack.length),
+            \\"scene\\": 0,
+            \\"shareTicket\\": \\"\\",
+            \\"referrerInfo\\": {}
         };
+        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/react.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/react.spec.ts.snap
@@ -3850,7 +3850,9 @@ exports[`react should build react app 2`] = `
                       case 0:
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
-                        launchParam = handler.getQuery();
+                        launchParam = {
+                            \\"query\\": handler.getQuery()
+                        };
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -4508,7 +4510,9 @@ exports[`react should build react app 2`] = `
         var router = new universal_router_module(routes, {
             \\"baseUrl\\": basename || \\"\\"
         });
-        var launchParam = handler.getQuery(stack.length);
+        var launchParam = {
+            \\"query\\": handler.getQuery(stack.length)
+        };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/react.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/react.spec.ts.snap
@@ -3851,8 +3851,13 @@ exports[`react should build react app 2`] = `
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
                         launchParam = {
-                            \\"query\\": handler.getQuery()
+                            \\"path\\": config.pageName,
+                            \\"query\\": handler.getQuery(),
+                            \\"scene\\": 0,
+                            \\"shareTicket\\": \\"\\",
+                            \\"referrerInfo\\": {}
                         };
+                        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -3860,31 +3865,31 @@ exports[`react should build react app 2`] = `
                         }));
                         pathName = config.pageName;
                         pageConfig = handler.pageConfig;
-                        _context.prev = 7;
-                        _context.next = 10;
+                        _context.prev = 8;
+                        _context.next = 11;
                         return (_b = pageConfig.load) === null || _b === void 0 ? void 0 : _b.call(pageConfig);
 
-                      case 10:
+                      case 11:
                         element = _context.sent;
                         if (element instanceof Array) {
                             element = element[0];
                         }
-                        _context.next = 17;
+                        _context.next = 18;
                         break;
 
-                      case 14:
-                        _context.prev = 14;
-                        _context.t0 = _context[\\"catch\\"](7);
+                      case 15:
+                        _context.prev = 15;
+                        _context.t0 = _context[\\"catch\\"](8);
                         throw new Error(_context.t0);
 
-                      case 17:
+                      case 18:
                         if (element) {
-                            _context.next = 19;
+                            _context.next = 20;
                             break;
                         }
                         return _context.abrupt(\\"return\\");
 
-                      case 19:
+                      case 20:
                         enablePullDownRefresh = ((_c = config === null || config === void 0 ? void 0 : config.window) === null || _c === void 0 ? void 0 : _c.enablePullDownRefresh) || false;
                         undefined.trigger(\\"__taroRouterChange\\", {
                             \\"toLocation\\": {
@@ -3905,12 +3910,12 @@ exports[`react should build react app 2`] = `
                         handler.load(page, pageConfig);
                         (_f = app.onShow) === null || _f === void 0 ? void 0 : _f.call(app, launchParam);
 
-                      case 29:
+                      case 30:
                       case \\"end\\":
                         return _context.stop();
                     }
                 }
-            }), _callee, null, [ [ 7, 14 ] ]);
+            }), _callee, null, [ [ 8, 15 ] ]);
         })));
     }
     var path_to_regexp = __webpack_require__(8);
@@ -4512,8 +4517,12 @@ exports[`react should build react app 2`] = `
         });
         var launchParam = {
             \\"path\\": handler.homePage,
-            \\"query\\": handler.getQuery(stack.length)
+            \\"query\\": handler.getQuery(stack.length),
+            \\"scene\\": 0,
+            \\"shareTicket\\": \\"\\",
+            \\"referrerInfo\\": {}
         };
+        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/react.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/react.spec.ts.snap
@@ -4511,6 +4511,7 @@ exports[`react should build react app 2`] = `
             \\"baseUrl\\": basename || \\"\\"
         });
         var launchParam = {
+            \\"path\\": handler.homePage,
             \\"query\\": handler.getQuery(stack.length)
         };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/sass.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/sass.spec.ts.snap
@@ -4496,6 +4496,7 @@ exports[`sass should build app with sass 2`] = `
             \\"baseUrl\\": basename || \\"\\"
         });
         var launchParam = {
+            \\"path\\": handler.homePage,
             \\"query\\": handler.getQuery(stack.length)
         };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
@@ -9263,6 +9264,7 @@ exports[`sass should build app with scss 2`] = `
             \\"baseUrl\\": basename || \\"\\"
         });
         var launchParam = {
+            \\"path\\": handler.homePage,
             \\"query\\": handler.getQuery(stack.length)
         };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
@@ -14040,6 +14042,7 @@ exports[`sass should set global sass content with data 2`] = `
             \\"baseUrl\\": basename || \\"\\"
         });
         var launchParam = {
+            \\"path\\": handler.homePage,
             \\"query\\": handler.getQuery(stack.length)
         };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
@@ -18817,6 +18820,7 @@ exports[`sass should set global sass content with source & dir 2`] = `
             \\"baseUrl\\": basename || \\"\\"
         });
         var launchParam = {
+            \\"path\\": handler.homePage,
             \\"query\\": handler.getQuery(stack.length)
         };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
@@ -23594,6 +23598,7 @@ exports[`sass should set global sass content with source 2`] = `
             \\"baseUrl\\": basename || \\"\\"
         });
         var launchParam = {
+            \\"path\\": handler.homePage,
             \\"query\\": handler.getQuery(stack.length)
         };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/sass.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/sass.spec.ts.snap
@@ -3835,7 +3835,9 @@ exports[`sass should build app with sass 2`] = `
                       case 0:
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
-                        launchParam = handler.getQuery();
+                        launchParam = {
+                            \\"query\\": handler.getQuery()
+                        };
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -4493,7 +4495,9 @@ exports[`sass should build app with sass 2`] = `
         var router = new universal_router_module(routes, {
             \\"baseUrl\\": basename || \\"\\"
         });
-        var launchParam = handler.getQuery(stack.length);
+        var launchParam = {
+            \\"query\\": handler.getQuery(stack.length)
+        };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;
@@ -8598,7 +8602,9 @@ exports[`sass should build app with scss 2`] = `
                       case 0:
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
-                        launchParam = handler.getQuery();
+                        launchParam = {
+                            \\"query\\": handler.getQuery()
+                        };
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -9256,7 +9262,9 @@ exports[`sass should build app with scss 2`] = `
         var router = new universal_router_module(routes, {
             \\"baseUrl\\": basename || \\"\\"
         });
-        var launchParam = handler.getQuery(stack.length);
+        var launchParam = {
+            \\"query\\": handler.getQuery(stack.length)
+        };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;
@@ -13371,7 +13379,9 @@ exports[`sass should set global sass content with data 2`] = `
                       case 0:
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
-                        launchParam = handler.getQuery();
+                        launchParam = {
+                            \\"query\\": handler.getQuery()
+                        };
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -14029,7 +14039,9 @@ exports[`sass should set global sass content with data 2`] = `
         var router = new universal_router_module(routes, {
             \\"baseUrl\\": basename || \\"\\"
         });
-        var launchParam = handler.getQuery(stack.length);
+        var launchParam = {
+            \\"query\\": handler.getQuery(stack.length)
+        };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;
@@ -18144,7 +18156,9 @@ exports[`sass should set global sass content with source & dir 2`] = `
                       case 0:
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
-                        launchParam = handler.getQuery();
+                        launchParam = {
+                            \\"query\\": handler.getQuery()
+                        };
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -18802,7 +18816,9 @@ exports[`sass should set global sass content with source & dir 2`] = `
         var router = new universal_router_module(routes, {
             \\"baseUrl\\": basename || \\"\\"
         });
-        var launchParam = handler.getQuery(stack.length);
+        var launchParam = {
+            \\"query\\": handler.getQuery(stack.length)
+        };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;
@@ -22917,7 +22933,9 @@ exports[`sass should set global sass content with source 2`] = `
                       case 0:
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
-                        launchParam = handler.getQuery();
+                        launchParam = {
+                            \\"query\\": handler.getQuery()
+                        };
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -23575,7 +23593,9 @@ exports[`sass should set global sass content with source 2`] = `
         var router = new universal_router_module(routes, {
             \\"baseUrl\\": basename || \\"\\"
         });
-        var launchParam = handler.getQuery(stack.length);
+        var launchParam = {
+            \\"query\\": handler.getQuery(stack.length)
+        };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/sass.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/sass.spec.ts.snap
@@ -3836,8 +3836,13 @@ exports[`sass should build app with sass 2`] = `
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
                         launchParam = {
-                            \\"query\\": handler.getQuery()
+                            \\"path\\": config.pageName,
+                            \\"query\\": handler.getQuery(),
+                            \\"scene\\": 0,
+                            \\"shareTicket\\": \\"\\",
+                            \\"referrerInfo\\": {}
                         };
+                        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -3845,31 +3850,31 @@ exports[`sass should build app with sass 2`] = `
                         }));
                         pathName = config.pageName;
                         pageConfig = handler.pageConfig;
-                        _context.prev = 7;
-                        _context.next = 10;
+                        _context.prev = 8;
+                        _context.next = 11;
                         return (_b = pageConfig.load) === null || _b === void 0 ? void 0 : _b.call(pageConfig);
 
-                      case 10:
+                      case 11:
                         element = _context.sent;
                         if (element instanceof Array) {
                             element = element[0];
                         }
-                        _context.next = 17;
+                        _context.next = 18;
                         break;
 
-                      case 14:
-                        _context.prev = 14;
-                        _context.t0 = _context[\\"catch\\"](7);
+                      case 15:
+                        _context.prev = 15;
+                        _context.t0 = _context[\\"catch\\"](8);
                         throw new Error(_context.t0);
 
-                      case 17:
+                      case 18:
                         if (element) {
-                            _context.next = 19;
+                            _context.next = 20;
                             break;
                         }
                         return _context.abrupt(\\"return\\");
 
-                      case 19:
+                      case 20:
                         enablePullDownRefresh = ((_c = config === null || config === void 0 ? void 0 : config.window) === null || _c === void 0 ? void 0 : _c.enablePullDownRefresh) || false;
                         undefined.trigger(\\"__taroRouterChange\\", {
                             \\"toLocation\\": {
@@ -3890,12 +3895,12 @@ exports[`sass should build app with sass 2`] = `
                         handler.load(page, pageConfig);
                         (_f = app.onShow) === null || _f === void 0 ? void 0 : _f.call(app, launchParam);
 
-                      case 29:
+                      case 30:
                       case \\"end\\":
                         return _context.stop();
                     }
                 }
-            }), _callee, null, [ [ 7, 14 ] ]);
+            }), _callee, null, [ [ 8, 15 ] ]);
         })));
     }
     var path_to_regexp = __webpack_require__(8);
@@ -4497,8 +4502,12 @@ exports[`sass should build app with sass 2`] = `
         });
         var launchParam = {
             \\"path\\": handler.homePage,
-            \\"query\\": handler.getQuery(stack.length)
+            \\"query\\": handler.getQuery(stack.length),
+            \\"scene\\": 0,
+            \\"shareTicket\\": \\"\\",
+            \\"referrerInfo\\": {}
         };
+        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;
@@ -8604,8 +8613,13 @@ exports[`sass should build app with scss 2`] = `
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
                         launchParam = {
-                            \\"query\\": handler.getQuery()
+                            \\"path\\": config.pageName,
+                            \\"query\\": handler.getQuery(),
+                            \\"scene\\": 0,
+                            \\"shareTicket\\": \\"\\",
+                            \\"referrerInfo\\": {}
                         };
+                        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -8613,31 +8627,31 @@ exports[`sass should build app with scss 2`] = `
                         }));
                         pathName = config.pageName;
                         pageConfig = handler.pageConfig;
-                        _context.prev = 7;
-                        _context.next = 10;
+                        _context.prev = 8;
+                        _context.next = 11;
                         return (_b = pageConfig.load) === null || _b === void 0 ? void 0 : _b.call(pageConfig);
 
-                      case 10:
+                      case 11:
                         element = _context.sent;
                         if (element instanceof Array) {
                             element = element[0];
                         }
-                        _context.next = 17;
+                        _context.next = 18;
                         break;
 
-                      case 14:
-                        _context.prev = 14;
-                        _context.t0 = _context[\\"catch\\"](7);
+                      case 15:
+                        _context.prev = 15;
+                        _context.t0 = _context[\\"catch\\"](8);
                         throw new Error(_context.t0);
 
-                      case 17:
+                      case 18:
                         if (element) {
-                            _context.next = 19;
+                            _context.next = 20;
                             break;
                         }
                         return _context.abrupt(\\"return\\");
 
-                      case 19:
+                      case 20:
                         enablePullDownRefresh = ((_c = config === null || config === void 0 ? void 0 : config.window) === null || _c === void 0 ? void 0 : _c.enablePullDownRefresh) || false;
                         undefined.trigger(\\"__taroRouterChange\\", {
                             \\"toLocation\\": {
@@ -8658,12 +8672,12 @@ exports[`sass should build app with scss 2`] = `
                         handler.load(page, pageConfig);
                         (_f = app.onShow) === null || _f === void 0 ? void 0 : _f.call(app, launchParam);
 
-                      case 29:
+                      case 30:
                       case \\"end\\":
                         return _context.stop();
                     }
                 }
-            }), _callee, null, [ [ 7, 14 ] ]);
+            }), _callee, null, [ [ 8, 15 ] ]);
         })));
     }
     var path_to_regexp = __webpack_require__(8);
@@ -9265,8 +9279,12 @@ exports[`sass should build app with scss 2`] = `
         });
         var launchParam = {
             \\"path\\": handler.homePage,
-            \\"query\\": handler.getQuery(stack.length)
+            \\"query\\": handler.getQuery(stack.length),
+            \\"scene\\": 0,
+            \\"shareTicket\\": \\"\\",
+            \\"referrerInfo\\": {}
         };
+        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;
@@ -13382,8 +13400,13 @@ exports[`sass should set global sass content with data 2`] = `
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
                         launchParam = {
-                            \\"query\\": handler.getQuery()
+                            \\"path\\": config.pageName,
+                            \\"query\\": handler.getQuery(),
+                            \\"scene\\": 0,
+                            \\"shareTicket\\": \\"\\",
+                            \\"referrerInfo\\": {}
                         };
+                        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -13391,31 +13414,31 @@ exports[`sass should set global sass content with data 2`] = `
                         }));
                         pathName = config.pageName;
                         pageConfig = handler.pageConfig;
-                        _context.prev = 7;
-                        _context.next = 10;
+                        _context.prev = 8;
+                        _context.next = 11;
                         return (_b = pageConfig.load) === null || _b === void 0 ? void 0 : _b.call(pageConfig);
 
-                      case 10:
+                      case 11:
                         element = _context.sent;
                         if (element instanceof Array) {
                             element = element[0];
                         }
-                        _context.next = 17;
+                        _context.next = 18;
                         break;
 
-                      case 14:
-                        _context.prev = 14;
-                        _context.t0 = _context[\\"catch\\"](7);
+                      case 15:
+                        _context.prev = 15;
+                        _context.t0 = _context[\\"catch\\"](8);
                         throw new Error(_context.t0);
 
-                      case 17:
+                      case 18:
                         if (element) {
-                            _context.next = 19;
+                            _context.next = 20;
                             break;
                         }
                         return _context.abrupt(\\"return\\");
 
-                      case 19:
+                      case 20:
                         enablePullDownRefresh = ((_c = config === null || config === void 0 ? void 0 : config.window) === null || _c === void 0 ? void 0 : _c.enablePullDownRefresh) || false;
                         undefined.trigger(\\"__taroRouterChange\\", {
                             \\"toLocation\\": {
@@ -13436,12 +13459,12 @@ exports[`sass should set global sass content with data 2`] = `
                         handler.load(page, pageConfig);
                         (_f = app.onShow) === null || _f === void 0 ? void 0 : _f.call(app, launchParam);
 
-                      case 29:
+                      case 30:
                       case \\"end\\":
                         return _context.stop();
                     }
                 }
-            }), _callee, null, [ [ 7, 14 ] ]);
+            }), _callee, null, [ [ 8, 15 ] ]);
         })));
     }
     var path_to_regexp = __webpack_require__(8);
@@ -14043,8 +14066,12 @@ exports[`sass should set global sass content with data 2`] = `
         });
         var launchParam = {
             \\"path\\": handler.homePage,
-            \\"query\\": handler.getQuery(stack.length)
+            \\"query\\": handler.getQuery(stack.length),
+            \\"scene\\": 0,
+            \\"shareTicket\\": \\"\\",
+            \\"referrerInfo\\": {}
         };
+        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;
@@ -18160,8 +18187,13 @@ exports[`sass should set global sass content with source & dir 2`] = `
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
                         launchParam = {
-                            \\"query\\": handler.getQuery()
+                            \\"path\\": config.pageName,
+                            \\"query\\": handler.getQuery(),
+                            \\"scene\\": 0,
+                            \\"shareTicket\\": \\"\\",
+                            \\"referrerInfo\\": {}
                         };
+                        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -18169,31 +18201,31 @@ exports[`sass should set global sass content with source & dir 2`] = `
                         }));
                         pathName = config.pageName;
                         pageConfig = handler.pageConfig;
-                        _context.prev = 7;
-                        _context.next = 10;
+                        _context.prev = 8;
+                        _context.next = 11;
                         return (_b = pageConfig.load) === null || _b === void 0 ? void 0 : _b.call(pageConfig);
 
-                      case 10:
+                      case 11:
                         element = _context.sent;
                         if (element instanceof Array) {
                             element = element[0];
                         }
-                        _context.next = 17;
+                        _context.next = 18;
                         break;
 
-                      case 14:
-                        _context.prev = 14;
-                        _context.t0 = _context[\\"catch\\"](7);
+                      case 15:
+                        _context.prev = 15;
+                        _context.t0 = _context[\\"catch\\"](8);
                         throw new Error(_context.t0);
 
-                      case 17:
+                      case 18:
                         if (element) {
-                            _context.next = 19;
+                            _context.next = 20;
                             break;
                         }
                         return _context.abrupt(\\"return\\");
 
-                      case 19:
+                      case 20:
                         enablePullDownRefresh = ((_c = config === null || config === void 0 ? void 0 : config.window) === null || _c === void 0 ? void 0 : _c.enablePullDownRefresh) || false;
                         undefined.trigger(\\"__taroRouterChange\\", {
                             \\"toLocation\\": {
@@ -18214,12 +18246,12 @@ exports[`sass should set global sass content with source & dir 2`] = `
                         handler.load(page, pageConfig);
                         (_f = app.onShow) === null || _f === void 0 ? void 0 : _f.call(app, launchParam);
 
-                      case 29:
+                      case 30:
                       case \\"end\\":
                         return _context.stop();
                     }
                 }
-            }), _callee, null, [ [ 7, 14 ] ]);
+            }), _callee, null, [ [ 8, 15 ] ]);
         })));
     }
     var path_to_regexp = __webpack_require__(8);
@@ -18821,8 +18853,12 @@ exports[`sass should set global sass content with source & dir 2`] = `
         });
         var launchParam = {
             \\"path\\": handler.homePage,
-            \\"query\\": handler.getQuery(stack.length)
+            \\"query\\": handler.getQuery(stack.length),
+            \\"scene\\": 0,
+            \\"shareTicket\\": \\"\\",
+            \\"referrerInfo\\": {}
         };
+        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;
@@ -22938,8 +22974,13 @@ exports[`sass should set global sass content with source 2`] = `
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
                         launchParam = {
-                            \\"query\\": handler.getQuery()
+                            \\"path\\": config.pageName,
+                            \\"query\\": handler.getQuery(),
+                            \\"scene\\": 0,
+                            \\"shareTicket\\": \\"\\",
+                            \\"referrerInfo\\": {}
                         };
+                        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -22947,31 +22988,31 @@ exports[`sass should set global sass content with source 2`] = `
                         }));
                         pathName = config.pageName;
                         pageConfig = handler.pageConfig;
-                        _context.prev = 7;
-                        _context.next = 10;
+                        _context.prev = 8;
+                        _context.next = 11;
                         return (_b = pageConfig.load) === null || _b === void 0 ? void 0 : _b.call(pageConfig);
 
-                      case 10:
+                      case 11:
                         element = _context.sent;
                         if (element instanceof Array) {
                             element = element[0];
                         }
-                        _context.next = 17;
+                        _context.next = 18;
                         break;
 
-                      case 14:
-                        _context.prev = 14;
-                        _context.t0 = _context[\\"catch\\"](7);
+                      case 15:
+                        _context.prev = 15;
+                        _context.t0 = _context[\\"catch\\"](8);
                         throw new Error(_context.t0);
 
-                      case 17:
+                      case 18:
                         if (element) {
-                            _context.next = 19;
+                            _context.next = 20;
                             break;
                         }
                         return _context.abrupt(\\"return\\");
 
-                      case 19:
+                      case 20:
                         enablePullDownRefresh = ((_c = config === null || config === void 0 ? void 0 : config.window) === null || _c === void 0 ? void 0 : _c.enablePullDownRefresh) || false;
                         undefined.trigger(\\"__taroRouterChange\\", {
                             \\"toLocation\\": {
@@ -22992,12 +23033,12 @@ exports[`sass should set global sass content with source 2`] = `
                         handler.load(page, pageConfig);
                         (_f = app.onShow) === null || _f === void 0 ? void 0 : _f.call(app, launchParam);
 
-                      case 29:
+                      case 30:
                       case \\"end\\":
                         return _context.stop();
                     }
                 }
-            }), _callee, null, [ [ 7, 14 ] ]);
+            }), _callee, null, [ [ 8, 15 ] ]);
         })));
     }
     var path_to_regexp = __webpack_require__(8);
@@ -23599,8 +23640,12 @@ exports[`sass should set global sass content with source 2`] = `
         });
         var launchParam = {
             \\"path\\": handler.homePage,
-            \\"query\\": handler.getQuery(stack.length)
+            \\"query\\": handler.getQuery(stack.length),
+            \\"scene\\": 0,
+            \\"shareTicket\\": \\"\\",
+            \\"referrerInfo\\": {}
         };
+        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/subpackages.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/subpackages.spec.ts.snap
@@ -3913,7 +3913,9 @@ exports[`subpackages should process subpackages 2`] = `
                       case 0:
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
-                        launchParam = handler.getQuery();
+                        launchParam = {
+                            \\"query\\": handler.getQuery()
+                        };
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -4571,7 +4573,9 @@ exports[`subpackages should process subpackages 2`] = `
         var router = new universal_router_module(routes, {
             \\"baseUrl\\": basename || \\"\\"
         });
-        var launchParam = handler.getQuery(stack.length);
+        var launchParam = {
+            \\"query\\": handler.getQuery(stack.length)
+        };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/subpackages.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/subpackages.spec.ts.snap
@@ -4574,6 +4574,7 @@ exports[`subpackages should process subpackages 2`] = `
             \\"baseUrl\\": basename || \\"\\"
         });
         var launchParam = {
+            \\"path\\": handler.homePage,
             \\"query\\": handler.getQuery(stack.length)
         };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/subpackages.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/subpackages.spec.ts.snap
@@ -3914,8 +3914,13 @@ exports[`subpackages should process subpackages 2`] = `
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
                         launchParam = {
-                            \\"query\\": handler.getQuery()
+                            \\"path\\": config.pageName,
+                            \\"query\\": handler.getQuery(),
+                            \\"scene\\": 0,
+                            \\"shareTicket\\": \\"\\",
+                            \\"referrerInfo\\": {}
                         };
+                        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -3923,31 +3928,31 @@ exports[`subpackages should process subpackages 2`] = `
                         }));
                         pathName = config.pageName;
                         pageConfig = handler.pageConfig;
-                        _context.prev = 7;
-                        _context.next = 10;
+                        _context.prev = 8;
+                        _context.next = 11;
                         return (_b = pageConfig.load) === null || _b === void 0 ? void 0 : _b.call(pageConfig);
 
-                      case 10:
+                      case 11:
                         element = _context.sent;
                         if (element instanceof Array) {
                             element = element[0];
                         }
-                        _context.next = 17;
+                        _context.next = 18;
                         break;
 
-                      case 14:
-                        _context.prev = 14;
-                        _context.t0 = _context[\\"catch\\"](7);
+                      case 15:
+                        _context.prev = 15;
+                        _context.t0 = _context[\\"catch\\"](8);
                         throw new Error(_context.t0);
 
-                      case 17:
+                      case 18:
                         if (element) {
-                            _context.next = 19;
+                            _context.next = 20;
                             break;
                         }
                         return _context.abrupt(\\"return\\");
 
-                      case 19:
+                      case 20:
                         enablePullDownRefresh = ((_c = config === null || config === void 0 ? void 0 : config.window) === null || _c === void 0 ? void 0 : _c.enablePullDownRefresh) || false;
                         undefined.trigger(\\"__taroRouterChange\\", {
                             \\"toLocation\\": {
@@ -3968,12 +3973,12 @@ exports[`subpackages should process subpackages 2`] = `
                         handler.load(page, pageConfig);
                         (_f = app.onShow) === null || _f === void 0 ? void 0 : _f.call(app, launchParam);
 
-                      case 29:
+                      case 30:
                       case \\"end\\":
                         return _context.stop();
                     }
                 }
-            }), _callee, null, [ [ 7, 14 ] ]);
+            }), _callee, null, [ [ 8, 15 ] ]);
         })));
     }
     var path_to_regexp = __webpack_require__(9);
@@ -4575,8 +4580,12 @@ exports[`subpackages should process subpackages 2`] = `
         });
         var launchParam = {
             \\"path\\": handler.homePage,
-            \\"query\\": handler.getQuery(stack.length)
+            \\"query\\": handler.getQuery(stack.length),
+            \\"scene\\": 0,
+            \\"shareTicket\\": \\"\\",
+            \\"referrerInfo\\": {}
         };
+        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/ts.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/ts.spec.ts.snap
@@ -3853,7 +3853,9 @@ exports[`typescript should build project with ts 2`] = `
                       case 0:
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
-                        launchParam = handler.getQuery();
+                        launchParam = {
+                            \\"query\\": handler.getQuery()
+                        };
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -4511,7 +4513,9 @@ exports[`typescript should build project with ts 2`] = `
         var router = new universal_router_module(routes, {
             \\"baseUrl\\": basename || \\"\\"
         });
-        var launchParam = handler.getQuery(stack.length);
+        var launchParam = {
+            \\"query\\": handler.getQuery(stack.length)
+        };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/ts.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/ts.spec.ts.snap
@@ -3854,8 +3854,13 @@ exports[`typescript should build project with ts 2`] = `
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
                         launchParam = {
-                            \\"query\\": handler.getQuery()
+                            \\"path\\": config.pageName,
+                            \\"query\\": handler.getQuery(),
+                            \\"scene\\": 0,
+                            \\"shareTicket\\": \\"\\",
+                            \\"referrerInfo\\": {}
                         };
+                        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -3863,31 +3868,31 @@ exports[`typescript should build project with ts 2`] = `
                         }));
                         pathName = config.pageName;
                         pageConfig = handler.pageConfig;
-                        _context.prev = 7;
-                        _context.next = 10;
+                        _context.prev = 8;
+                        _context.next = 11;
                         return (_b = pageConfig.load) === null || _b === void 0 ? void 0 : _b.call(pageConfig);
 
-                      case 10:
+                      case 11:
                         element = _context.sent;
                         if (element instanceof Array) {
                             element = element[0];
                         }
-                        _context.next = 17;
+                        _context.next = 18;
                         break;
 
-                      case 14:
-                        _context.prev = 14;
-                        _context.t0 = _context[\\"catch\\"](7);
+                      case 15:
+                        _context.prev = 15;
+                        _context.t0 = _context[\\"catch\\"](8);
                         throw new Error(_context.t0);
 
-                      case 17:
+                      case 18:
                         if (element) {
-                            _context.next = 19;
+                            _context.next = 20;
                             break;
                         }
                         return _context.abrupt(\\"return\\");
 
-                      case 19:
+                      case 20:
                         enablePullDownRefresh = ((_c = config === null || config === void 0 ? void 0 : config.window) === null || _c === void 0 ? void 0 : _c.enablePullDownRefresh) || false;
                         undefined.trigger(\\"__taroRouterChange\\", {
                             \\"toLocation\\": {
@@ -3908,12 +3913,12 @@ exports[`typescript should build project with ts 2`] = `
                         handler.load(page, pageConfig);
                         (_f = app.onShow) === null || _f === void 0 ? void 0 : _f.call(app, launchParam);
 
-                      case 29:
+                      case 30:
                       case \\"end\\":
                         return _context.stop();
                     }
                 }
-            }), _callee, null, [ [ 7, 14 ] ]);
+            }), _callee, null, [ [ 8, 15 ] ]);
         })));
     }
     var path_to_regexp = __webpack_require__(8);
@@ -4515,8 +4520,12 @@ exports[`typescript should build project with ts 2`] = `
         });
         var launchParam = {
             \\"path\\": handler.homePage,
-            \\"query\\": handler.getQuery(stack.length)
+            \\"query\\": handler.getQuery(stack.length),
+            \\"scene\\": 0,
+            \\"shareTicket\\": \\"\\",
+            \\"referrerInfo\\": {}
         };
+        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/ts.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/ts.spec.ts.snap
@@ -4514,6 +4514,7 @@ exports[`typescript should build project with ts 2`] = `
             \\"baseUrl\\": basename || \\"\\"
         });
         var launchParam = {
+            \\"path\\": handler.homePage,
             \\"query\\": handler.getQuery(stack.length)
         };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue.spec.ts.snap
@@ -3807,7 +3807,9 @@ exports[`vue should build vue app 2`] = `
                       case 0:
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
-                        launchParam = handler.getQuery();
+                        launchParam = {
+                            \\"query\\": handler.getQuery()
+                        };
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -4465,7 +4467,9 @@ exports[`vue should build vue app 2`] = `
         var router = new universal_router_module(routes, {
             \\"baseUrl\\": basename || \\"\\"
         });
-        var launchParam = handler.getQuery(stack.length);
+        var launchParam = {
+            \\"query\\": handler.getQuery(stack.length)
+        };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue.spec.ts.snap
@@ -3808,8 +3808,13 @@ exports[`vue should build vue app 2`] = `
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
                         launchParam = {
-                            \\"query\\": handler.getQuery()
+                            \\"path\\": config.pageName,
+                            \\"query\\": handler.getQuery(),
+                            \\"scene\\": 0,
+                            \\"shareTicket\\": \\"\\",
+                            \\"referrerInfo\\": {}
                         };
+                        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -3817,31 +3822,31 @@ exports[`vue should build vue app 2`] = `
                         }));
                         pathName = config.pageName;
                         pageConfig = handler.pageConfig;
-                        _context.prev = 7;
-                        _context.next = 10;
+                        _context.prev = 8;
+                        _context.next = 11;
                         return (_b = pageConfig.load) === null || _b === void 0 ? void 0 : _b.call(pageConfig);
 
-                      case 10:
+                      case 11:
                         element = _context.sent;
                         if (element instanceof Array) {
                             element = element[0];
                         }
-                        _context.next = 17;
+                        _context.next = 18;
                         break;
 
-                      case 14:
-                        _context.prev = 14;
-                        _context.t0 = _context[\\"catch\\"](7);
+                      case 15:
+                        _context.prev = 15;
+                        _context.t0 = _context[\\"catch\\"](8);
                         throw new Error(_context.t0);
 
-                      case 17:
+                      case 18:
                         if (element) {
-                            _context.next = 19;
+                            _context.next = 20;
                             break;
                         }
                         return _context.abrupt(\\"return\\");
 
-                      case 19:
+                      case 20:
                         enablePullDownRefresh = ((_c = config === null || config === void 0 ? void 0 : config.window) === null || _c === void 0 ? void 0 : _c.enablePullDownRefresh) || false;
                         undefined.trigger(\\"__taroRouterChange\\", {
                             \\"toLocation\\": {
@@ -3862,12 +3867,12 @@ exports[`vue should build vue app 2`] = `
                         handler.load(page, pageConfig);
                         (_f = app.onShow) === null || _f === void 0 ? void 0 : _f.call(app, launchParam);
 
-                      case 29:
+                      case 30:
                       case \\"end\\":
                         return _context.stop();
                     }
                 }
-            }), _callee, null, [ [ 7, 14 ] ]);
+            }), _callee, null, [ [ 8, 15 ] ]);
         })));
     }
     var path_to_regexp = __webpack_require__(3);
@@ -4469,8 +4474,12 @@ exports[`vue should build vue app 2`] = `
         });
         var launchParam = {
             \\"path\\": handler.homePage,
-            \\"query\\": handler.getQuery(stack.length)
+            \\"query\\": handler.getQuery(stack.length),
+            \\"scene\\": 0,
+            \\"shareTicket\\": \\"\\",
+            \\"referrerInfo\\": {}
         };
+        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue.spec.ts.snap
@@ -4468,6 +4468,7 @@ exports[`vue should build vue app 2`] = `
             \\"baseUrl\\": basename || \\"\\"
         });
         var launchParam = {
+            \\"path\\": handler.homePage,
             \\"query\\": handler.getQuery(stack.length)
         };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue3.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue3.spec.ts.snap
@@ -3747,8 +3747,13 @@ exports[`vue3 should build vue3 app 2`] = `
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
                         launchParam = {
-                            \\"query\\": handler.getQuery()
+                            \\"path\\": config.pageName,
+                            \\"query\\": handler.getQuery(),
+                            \\"scene\\": 0,
+                            \\"shareTicket\\": \\"\\",
+                            \\"referrerInfo\\": {}
                         };
+                        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -3756,31 +3761,31 @@ exports[`vue3 should build vue3 app 2`] = `
                         }));
                         pathName = config.pageName;
                         pageConfig = handler.pageConfig;
-                        _context.prev = 7;
-                        _context.next = 10;
+                        _context.prev = 8;
+                        _context.next = 11;
                         return (_b = pageConfig.load) === null || _b === void 0 ? void 0 : _b.call(pageConfig);
 
-                      case 10:
+                      case 11:
                         element = _context.sent;
                         if (element instanceof Array) {
                             element = element[0];
                         }
-                        _context.next = 17;
+                        _context.next = 18;
                         break;
 
-                      case 14:
-                        _context.prev = 14;
-                        _context.t0 = _context[\\"catch\\"](7);
+                      case 15:
+                        _context.prev = 15;
+                        _context.t0 = _context[\\"catch\\"](8);
                         throw new Error(_context.t0);
 
-                      case 17:
+                      case 18:
                         if (element) {
-                            _context.next = 19;
+                            _context.next = 20;
                             break;
                         }
                         return _context.abrupt(\\"return\\");
 
-                      case 19:
+                      case 20:
                         enablePullDownRefresh = ((_c = config === null || config === void 0 ? void 0 : config.window) === null || _c === void 0 ? void 0 : _c.enablePullDownRefresh) || false;
                         undefined.trigger(\\"__taroRouterChange\\", {
                             \\"toLocation\\": {
@@ -3801,12 +3806,12 @@ exports[`vue3 should build vue3 app 2`] = `
                         handler.load(page, pageConfig);
                         (_f = app.onShow) === null || _f === void 0 ? void 0 : _f.call(app, launchParam);
 
-                      case 29:
+                      case 30:
                       case \\"end\\":
                         return _context.stop();
                     }
                 }
-            }), _callee, null, [ [ 7, 14 ] ]);
+            }), _callee, null, [ [ 8, 15 ] ]);
         })));
     }
     var path_to_regexp = __webpack_require__(4);
@@ -4408,8 +4413,12 @@ exports[`vue3 should build vue3 app 2`] = `
         });
         var launchParam = {
             \\"path\\": handler.homePage,
-            \\"query\\": handler.getQuery(stack.length)
+            \\"query\\": handler.getQuery(stack.length),
+            \\"scene\\": 0,
+            \\"shareTicket\\": \\"\\",
+            \\"referrerInfo\\": {}
         };
+        undefined.trigger(\\"__taroRouterLaunch\\", launchParam);
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue3.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue3.spec.ts.snap
@@ -3746,7 +3746,9 @@ exports[`vue3 should build vue3 app 2`] = `
                       case 0:
                         router_RouterConfig.config = config;
                         handler = new multi_page_MultiPageHandler(config);
-                        launchParam = handler.getQuery();
+                        launchParam = {
+                            \\"query\\": handler.getQuery()
+                        };
                         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
                         app.onError && window.addEventListener(\\"error\\", (function(e) {
                             var _a;
@@ -4404,7 +4406,9 @@ exports[`vue3 should build vue3 app 2`] = `
         var router = new universal_router_module(routes, {
             \\"baseUrl\\": basename || \\"\\"
         });
-        var launchParam = handler.getQuery(stack.length);
+        var launchParam = {
+            \\"query\\": handler.getQuery(stack.length)
+        };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);
         app.onError && window.addEventListener(\\"error\\", (function(e) {
             var _a;

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue3.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue3.spec.ts.snap
@@ -4407,6 +4407,7 @@ exports[`vue3 should build vue3 app 2`] = `
             \\"baseUrl\\": basename || \\"\\"
         });
         var launchParam = {
+            \\"path\\": handler.homePage,
             \\"query\\": handler.getQuery(stack.length)
         };
         (_a = app.onLaunch) === null || _a === void 0 ? void 0 : _a.call(app, launchParam);


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

`onLaunch`的查询参数在微信小程序中的与`h5`不一致, 抹平它.

小程序:
<img width="725" alt="image" src="https://user-images.githubusercontent.com/6134547/191464460-6306e8bb-811d-48fb-a938-a3cda5821eec.png">

H5:
<img width="568" alt="image" src="https://user-images.githubusercontent.com/6134547/191464627-cc9845c9-a48a-4823-9178-53afa9227614.png">



**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [x] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
