### PR TITLE
feat: 没有配置targets时先探测 browserslist 配置, 仍然没有才设置默认值

### DIFF
--- a/packages/babel-preset-taro/README.md
+++ b/packages/babel-preset-taro/README.md
@@ -102,7 +102,7 @@ module.exports = {
 }
 ```
 
-`@babel/preset-env` 的 [targets](https://babeljs.io/docs/en/babel-preset-env#targets) 配置项。
+`@babel/preset-env` 的 [targets](https://babeljs.io/docs/en/babel-preset-env#targets) 配置项。如果存在 [browserslist](https://github.com/browserslist/browserslist#config-file) 配置, 则优先。
 
 ### useBuiltIns
 

--- a/packages/babel-preset-taro/README.md
+++ b/packages/babel-preset-taro/README.md
@@ -102,7 +102,7 @@ module.exports = {
 }
 ```
 
-`@babel/preset-env` 的 [targets](https://babeljs.io/docs/en/babel-preset-env#targets) 配置项。如果存在 [browserslist](https://github.com/browserslist/browserslist#config-file) 配置, 则优先。
+`@babel/preset-env` 的 [targets](https://babeljs.io/docs/en/babel-preset-env#targets) 配置项。
 
 ### useBuiltIns
 

--- a/packages/babel-preset-taro/index.js
+++ b/packages/babel-preset-taro/index.js
@@ -1,4 +1,24 @@
 const path = require('path')
+const fs = require('fs')
+
+function hasBrowserslist () {
+  const root = process.cwd()
+  try {
+    const package = require(path.resolve(root, 'package.json'))
+    if (package.browserslist) {
+      return true
+    }
+  } catch {
+    //
+  }
+  if (fs.existsSync(path.resolve(root, '.browserslistrc'))) {
+    return true
+  }
+  if (process.env.BROWSERSLIST) {
+    return true
+  }
+  return false
+}
 
 module.exports = (_, options = {}) => {
   if (process.env.TARO_ENV === 'rn') {
@@ -97,14 +117,16 @@ module.exports = (_, options = {}) => {
 
   // resolve targets
   let targets
-  if (rawTargets) {
-    targets = rawTargets
-  } else if (ignoreBrowserslistConfig) {
-    targets = { node: 'current' }
-  } else {
-    targets = {
-      ios: '9',
-      android: '5'
+  if (!hasBrowserslist()) {
+    if (rawTargets) {
+      targets = rawTargets
+    } else if (ignoreBrowserslistConfig) {
+      targets = { node: 'current' }
+    } else {
+      targets = {
+        ios: '9',
+        android: '5'
+      }
     }
   }
 

--- a/packages/babel-preset-taro/index.js
+++ b/packages/babel-preset-taro/index.js
@@ -4,8 +4,8 @@ const fs = require('fs')
 function hasBrowserslist () {
   const root = process.cwd()
   try {
-    const package = require(path.resolve(root, 'package.json'))
-    if (package.browserslist) {
+    const pkg = require(path.resolve(root, 'package.json'))
+    if (pkg.browserslist) {
       return true
     }
   } catch {

--- a/packages/babel-preset-taro/index.js
+++ b/packages/babel-preset-taro/index.js
@@ -117,16 +117,14 @@ module.exports = (_, options = {}) => {
 
   // resolve targets
   let targets
-  if (!hasBrowserslist()) {
-    if (rawTargets) {
-      targets = rawTargets
-    } else if (ignoreBrowserslistConfig) {
-      targets = { node: 'current' }
-    } else {
-      targets = {
-        ios: '9',
-        android: '5'
-      }
+  if (rawTargets) {
+    targets = rawTargets
+  } else if (ignoreBrowserslistConfig) {
+    targets = { node: 'current' }
+  } else if (!hasBrowserslist()) {
+    targets = {
+      ios: '9',
+      android: '5'
     }
   }
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

优先探测 browserslist 配置, 如果没有才设置 targets, 因为设置了targets会优先, 不设置又会默认.

单一配置原则.

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [x] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
