### PR TITLE
feat: revert #4599, 并参照小程序抹平err时字段

### DIFF
--- a/packages/taro-h5/__tests__/network/request.test.ts
+++ b/packages/taro-h5/__tests__/network/request.test.ts
@@ -98,7 +98,7 @@ describe('request', () => {
 
     fetch.mockReject(new Error('fake error message'))
 
-    expect.assertions(4)
+    expect.assertions(5)
     return Taro.request({
       url: 'https://github.com',
       success,
@@ -107,8 +107,36 @@ describe('request', () => {
     })
       .catch(err => {
         expect(err.message).toBe('fake error message')
+        expect(err.errMsg).toBe('fake error message')
         expect(success.mock.calls.length).toBe(0)
         expect(fail.mock.calls.length).toBe(1)
+        expect(complete.mock.calls.length).toBe(1)
+      })
+  })
+
+  test('should no error by status 400', () => {
+    const success = jest.fn()
+    const fail = jest.fn()
+    const complete = jest.fn()
+
+    fetch.mockResponse(null, {
+      counter: 1,
+      status: 400,
+      statusText: 'missing parameter',
+    })
+
+    expect.assertions(5)
+    return Taro.request({
+      url: 'https://github.com',
+      success,
+      fail,
+      complete
+    })
+      .then(res => {
+        expect(res.statusCode).toBe(400)
+        expect(res.data).toBe(null)
+        expect(success.mock.calls.length).toBe(1)
+        expect(fail.mock.calls.length).toBe(0)
         expect(complete.mock.calls.length).toBe(1)
       })
   })

--- a/packages/taro-h5/src/api/network/request/index.ts
+++ b/packages/taro-h5/src/api/network/request/index.ts
@@ -96,9 +96,6 @@ function _request (options) {
       for (const key of response.headers.keys()) {
         res.header[key] = response.headers.get(key)
       }
-      if (!response.ok) {
-        throw response
-      }
       if (options.responseType === 'arraybuffer') {
         return response.arrayBuffer()
       }
@@ -119,9 +116,15 @@ function _request (options) {
       return res
     })
     .catch(err => {
-      typeof fail === 'function' && fail(err)
+      const { status, statusText, ...rest} = err
+      const errRes = {
+        ...rest,
+        statusCode: status,
+        errMsg: statusText
+      }
+      typeof fail === 'function' && fail(errRes)
       typeof complete === 'function' && complete(res)
-      return Promise.reject(err)
+      return Promise.reject(errRes)
     })
 }
 

--- a/packages/taro-h5/src/api/network/request/index.ts
+++ b/packages/taro-h5/src/api/network/request/index.ts
@@ -101,7 +101,9 @@ function _request (options) {
       }
       if (res.statusCode !== 204) {
         if (options.dataType === 'json' || typeof options.dataType === 'undefined') {
-          return response.json()
+          return response.json().catch(() => {
+            return null
+          })
         }
       }
       if (options.responseType === 'text' || options.dataType === 'text') {
@@ -116,15 +118,11 @@ function _request (options) {
       return res
     })
     .catch(err => {
-      const { status, statusText, ...rest} = err
-      const errRes = {
-        ...rest,
-        statusCode: status,
-        errMsg: statusText
-      }
-      typeof fail === 'function' && fail(errRes)
+      typeof fail === 'function' && fail(err)
       typeof complete === 'function' && complete(res)
-      return Promise.reject(errRes)
+      err.statusCode = res.statusCode
+      err.errMsg = err.message
+      return Promise.reject(err)
     })
 }
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

1. revert https://github.com/NervJS/taro/pull/4599, 它造成了与小程序网络处理逻辑不一致; 比如 http 401 在小程序走success, h5走了fail. 其实小程序的`request`本身就是参照web的`Fetch API`的. 没必要再搞差异出来.

无数据就无数据, 和状态应该没关系. #4599 的做法不规范.

2. 再抹平状态和文本字段.

再参照小程序

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #9983
- [ ] 新功能(Feature)
- [x] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
