### PR TITLE
#fix(taro-react): 修复taro在小程序会自动为数字类型css变量与部分属性自动添加px后缀

### DIFF
--- a/packages/taro-components/__tests__/style.spec.js
+++ b/packages/taro-components/__tests__/style.spec.js
@@ -44,4 +44,11 @@ describe('style', () => {
     assert(node.style.cssText === '--taro:100px;')
     assert(node.style.getPropertyValue('--taro') === '100px')
   })
+
+  it('should not add "px" suffix for custom properties for numeric types', async () => {
+    const { node } = await mount(<View style={{ '--taro': 100 }} />, scratch)
+
+    assert(node.style.cssText === '--taro:100;')
+    assert(node.style.getPropertyValue('--taro') === '100')
+  })
 })

--- a/packages/taro-react/__tests__/props.spec.js
+++ b/packages/taro-react/__tests__/props.spec.js
@@ -62,6 +62,18 @@ describe('Context', () => {
       expect(container.firstChild.getAttribute('style')).toBe('font-size: 14px;')
     })
 
+    it('set css var as number should not add "px" suffix', () => {
+      const container = document.createElement('div')
+      render(<input type="button" style={{ '--taro': 14 }} />, container)
+      expect(container.firstChild.getAttribute('style')).toBe('--taro: 14;')
+    })
+
+    it('set animation-iteration-count of style as number should not add "px" suffix', async () => {
+      const container = document.createElement('div')
+      render(<view style={{ animationIterationCount: 1 }} />, container)
+      expect(container.firstChild.getAttribute('style')).toBe('animation-iteration-count: 1;')
+    })
+
     it('onClick should work like onTap', () => {
       const container = document.createElement('div')
       const spy = jest.fn()

--- a/packages/taro-react/src/props.ts
+++ b/packages/taro-react/src/props.ts
@@ -7,7 +7,7 @@ function isEventName (s: string) {
   return s[0] === 'o' && s[1] === 'n'
 }
 
-const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord/i
+const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i
 
 export function updateProps (dom: TaroElement, oldProps: Props, newProps: Props) {
   let i: string
@@ -59,6 +59,8 @@ function setEvent (dom: TaroElement, name: string, value: unknown, oldValue?: un
 function setStyle (style: Style, key: string, value: string | number) {
   if (key[0] === '-') {
     style.setProperty(key, value.toString())
+    // css variables need not further judgment
+    return
   }
 
   style[key] =


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复taro在小程序内会自动为数字类型的css变量与部分属性(like: animation-iteration-count)自动添加px后缀，这与原生小程序和web端行为不一致，抹平差距
相关issue: https://github.com/NervJS/taro/issues/12617


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix https://github.com/NervJS/taro/issues/12617
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
