### PR TITLE
fix(taro-plugin-react): 修复3.5小程序中app不会触发首次componentDidShow系列生命周期

### DIFF
--- a/packages/taro-plugin-react/src/runtime/connect.ts
+++ b/packages/taro-plugin-react/src/runtime/connect.ts
@@ -322,14 +322,22 @@ export function createReactApp (
       value (options) {
         setRouterParams(options)
 
-        /**
-         * trigger lifecycle
-         */
-        const app = getAppInstance()
-        // class component, componentDidShow
-        app?.componentDidShow?.(options)
-        // functional component, useDidShow
-        triggerAppHook('onShow', options)
+        const onShow = () => {
+          /**
+          * trigger lifecycle
+          */
+          const app = getAppInstance()
+          // class component, componentDidShow
+          app?.componentDidShow?.(options)
+          // functional component, useDidShow
+          triggerAppHook('onShow', options)
+        }
+
+        if (appWrapper) {
+          onShow()
+        } else {
+          appWrapperPromise.then(onShow)
+        }
       }
     }),
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
因为`React 18`中 `componentDidMount` 比小程序 `onShow` 触发相对较晚，在第一次触发`onShow`事件时，`AppWrapper`尚未挂载，无法取到 `App` 实例，所以第一次的 `componentDidShow` 相关生命周期都无法触发，此PR仿照解决`onLaunch`的
竟态解决方案，等待`App` 实例完全挂载后再触发 `componentDidShow` 相关事件

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #12634
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
