### PR TITLE
fix(tt): 抹平部分API

### DIFF
--- a/packages/shared/src/native-apis.ts
+++ b/packages/shared/src/native-apis.ts
@@ -18,6 +18,25 @@ interface IProcessApisIOptions {
   [propName: string]: any
 }
 
+export interface IApiDiff {
+  [key: string]: {
+    /** API重命名 */
+    alias?: string
+    options?: {
+      /** API参数键名修改 */
+      change?: {
+        old: string
+        new: string
+      }[]
+      /** API参数值修改 */
+      set?: {
+        key: string
+        value: ((options: Record<string, any>) => unknown) | unknown
+      }[]
+    }
+  }
+}
+
 const needPromiseApis = new Set<string>([
   'addPhoneContact',
   'authorize',

--- a/packages/taro-alipay/src/apis.ts
+++ b/packages/taro-alipay/src/apis.ts
@@ -1,10 +1,10 @@
-import { processApis } from '@tarojs/shared'
+import { IApiDiff,processApis } from '@tarojs/shared'
 
 import { needPromiseApis } from './apis-list'
 
 declare const my: any
 
-const apiDiff = {
+const apiDiff: IApiDiff = {
   login: {
     alias: 'getAuthCode',
     options: {

--- a/packages/taro-alipay/src/apis.ts
+++ b/packages/taro-alipay/src/apis.ts
@@ -1,6 +1,8 @@
-import { IApiDiff,processApis } from '@tarojs/shared'
+import { processApis } from '@tarojs/shared'
 
 import { needPromiseApis } from './apis-list'
+
+import type { IApiDiff } from '@tarojs/shared'
 
 declare const my: any
 

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/bytedance.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/bytedance.spec.ts.snap
@@ -57,9 +57,51 @@ require(\\"./taro\\");
         function useTabItemTap() {}
         function useScope() {}
         var needPromiseApis = new Set([ \\"checkFollowState\\", \\"exitMiniProgram\\", \\"followOfficialAccount\\", \\"getMenuButtonLayout\\", \\"getUserProfile\\", \\"hideInteractionBar\\", \\"navigateToVideoView\\", \\"openAwemeUserProfile\\", \\"openEcGood\\", \\"pay\\", \\"showInteractionBar\\" ]);
+        var apiDiff = {
+            showToast: {
+                options: {
+                    set: [ {
+                        key: \\"icon\\",
+                        value: function value(options) {
+                            return options.icon === \\"error\\" ? \\"fail\\" : options.icon;
+                        }
+                    } ]
+                }
+            }
+        };
+        function transformMeta(api, options) {
+            var apiAlias = api;
+            Object.keys(apiDiff).forEach((function(item) {
+                var apiItem = apiDiff[item];
+                if (api === item) {
+                    if (apiItem.alias) {
+                        apiAlias = apiItem.alias;
+                    }
+                    if (apiItem.options) {
+                        var change = apiItem.options.change;
+                        var set = apiItem.options.set;
+                        if (change) {
+                            change.forEach((function(changeItem) {
+                                options[changeItem.new] = options[changeItem.old];
+                            }));
+                        }
+                        if (set) {
+                            set.forEach((function(setItem) {
+                                options[setItem.key] = typeof setItem.value === \\"function\\" ? setItem.value(options) : setItem.value;
+                            }));
+                        }
+                    }
+                }
+            }));
+            return {
+                key: apiAlias,
+                options: options
+            };
+        }
         function initNativeApi(taro) {
             processApis(taro, tt, {
-                needPromiseApis: needPromiseApis
+                needPromiseApis: needPromiseApis,
+                transformMeta: transformMeta
             });
         }
         var _true = \\"!0\\";

--- a/packages/taro-swan/src/apis.ts
+++ b/packages/taro-swan/src/apis.ts
@@ -1,6 +1,8 @@
-import { IApiDiff,processApis } from '@tarojs/shared'
+import { processApis } from '@tarojs/shared'
 
 import { needPromiseApis } from './apis-list'
+
+import type { IApiDiff } from '@tarojs/shared'
 
 declare const swan: any
 

--- a/packages/taro-swan/src/apis.ts
+++ b/packages/taro-swan/src/apis.ts
@@ -1,10 +1,10 @@
-import { processApis } from '@tarojs/shared'
+import { IApiDiff,processApis } from '@tarojs/shared'
 
 import { needPromiseApis } from './apis-list'
 
 declare const swan: any
 
-const apiDiff = {
+const apiDiff: IApiDiff = {
   login: {
     alias: 'getLoginCode'
   }

--- a/packages/taro-tt/src/apis.ts
+++ b/packages/taro-tt/src/apis.ts
@@ -1,11 +1,59 @@
-import { processApis } from '@tarojs/shared'
+import { IApiDiff, processApis } from '@tarojs/shared'
 
 import { needPromiseApis } from './apis-list'
 
 declare const tt: any
 
+const apiDiff: IApiDiff = {
+  showToast: {
+    options: {
+      set: [
+        {
+          key: 'icon',
+          value (options) {
+            return options.icon === 'error' ? 'fail' : options.icon
+          }
+        }
+      ]
+    }
+  }
+}
+
+export function transformMeta (api: string, options: Record<string, any>) {
+  let apiAlias = api
+  Object.keys(apiDiff).forEach(item => {
+    const apiItem = apiDiff[item]
+    if (api === item) {
+      if (apiItem.alias) {
+        apiAlias = apiItem.alias
+      }
+      if (apiItem.options) {
+        const change = apiItem.options.change
+        const set = apiItem.options.set
+        if (change) {
+          change.forEach(changeItem => {
+            options[changeItem.new] = options[changeItem.old]
+          })
+        }
+        if (set) {
+          set.forEach(setItem => {
+            options[setItem.key] = typeof setItem.value === 'function' ? setItem.value(options) : setItem.value
+          })
+        }
+      }
+    }
+  })
+  return {
+    key: apiAlias,
+    options
+  }
+}
+
+
+
 export function initNativeApi (taro) {
   processApis(taro, tt, {
-    needPromiseApis
+    needPromiseApis,
+    transformMeta
   })
 }

--- a/packages/taro-tt/src/apis.ts
+++ b/packages/taro-tt/src/apis.ts
@@ -1,6 +1,8 @@
-import { IApiDiff, processApis } from '@tarojs/shared'
+import { processApis } from '@tarojs/shared'
 
 import { needPromiseApis } from './apis-list'
+
+import type { IApiDiff } from '@tarojs/shared'
 
 declare const tt: any
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
#11879
字节小程序存在部分api没有与Taro（或者说微信）对齐，目前只发现一个Taro.showToast比较影响，先修复下，[具体表现见ssues/11879抖音小程序showtoast icon为error时显示错误](https://github.com/NervJS/taro/issues/11879)
TODO：应该还存在部分api有差异，后续想个方案看看怎么能全量对比下


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #11879
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [x] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
