### PR TITLE
fix(mini): 修复project.config位置

### DIFF
--- a/packages/taro-service/src/platform-plugin-base.ts
+++ b/packages/taro-service/src/platform-plugin-base.ts
@@ -59,8 +59,20 @@ export abstract class TaroPlatformBase {
     this.ctx = ctx
     this.helper = ctx.helper
     this.config = config
+    this.updateOutputPath(config)
     const _compiler = config.compiler
     this.compiler = typeof _compiler === 'object' ? _compiler.type : _compiler
+  }
+
+  /**
+   * 如果分端编译详情webpack配置了output则需更新outputPath位置
+   * 小程序端才能将project.config.json生成到正确的位置
+   */
+  private updateOutputPath (config) {
+    const platformPath = config.output?.path
+    if(platformPath) {
+      this.ctx.paths.outputPath = platformPath
+    }
   }
 
   /**


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

1. 自定义编译配置根据不同端打包输出到不同的目录
```js
  mini: {
    output: {
      path: path.resolve(process.cwd(), 'dist_tt'),
    }
}
```
2. 编译详情重新指定output后小程序的project.config还是输出到的dist
![image](https://user-images.githubusercontent.com/41509493/199172223-8beba52f-ddfc-4094-a691-ec14f7d1abe0.png)

3. 本次修改在初始化平台插件时，重新更新outputPath为对应平台指定的path 

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
