### PR TITLE
fix(h5): 修复H5端路由跳转逻辑和小程序不一致的问题

### DIFF
--- a/packages/taro-router/src/api.ts
+++ b/packages/taro-router/src/api.ts
@@ -50,6 +50,8 @@ async function navigate (option: Option | NavigateBackOption, method: MethodName
     })
 
     try {
+      // isTabbar那里需要拿来判断
+      stacks.method = method
       if ('url' in option) {
         const pathPieces = processNavigateUrl(option)
         const state = { timestamp: Date.now() }

--- a/packages/taro-router/src/router/page.ts
+++ b/packages/taro-router/src/router/page.ts
@@ -225,7 +225,10 @@ export default class PageHandler {
   show (page?: PageInstance | null, pageConfig: Route = {}, stacksIndex = 0) {
     if (!page) return
 
-    const param = this.getQuery(page.$taroParams.stamp, '', page.options)
+    const index = page.path?.indexOf('?') ?? -1
+    const q = index > -1 ? queryString.parse(page.path!.substring(index), { decode: false }) : {}
+    const stamp = q.stamp ? Number(q.stamp) : undefined
+    const param = this.getQuery(stamp, '', page.options)
     let pageEl = this.getPageContainer(page)
     if (pageEl) {
       setDisplay(pageEl)

--- a/packages/taro-router/src/router/page.ts
+++ b/packages/taro-router/src/router/page.ts
@@ -173,7 +173,7 @@ export default class PageHandler {
 
     // NOTE: 页面栈推入太晚可能导致 getCurrentPages 无法获取到当前页面实例
     stacks.push(page)
-    const param = this.getQuery(stacks.length, '', page.options)
+    const param = this.getQuery(Date.now(), '', page.options)
     let pageEl = this.getPageContainer(page)
     if (pageEl) {
       setDisplay(pageEl)
@@ -225,7 +225,7 @@ export default class PageHandler {
   show (page?: PageInstance | null, pageConfig: Route = {}, stacksIndex = 0) {
     if (!page) return
 
-    const param = this.getQuery(stacks.length, '', page.options)
+    const param = this.getQuery(Date.now(), '', page.options)
     let pageEl = this.getPageContainer(page)
     if (pageEl) {
       setDisplay(pageEl)

--- a/packages/taro-router/src/router/page.ts
+++ b/packages/taro-router/src/router/page.ts
@@ -225,7 +225,7 @@ export default class PageHandler {
   show (page?: PageInstance | null, pageConfig: Route = {}, stacksIndex = 0) {
     if (!page) return
 
-    const param = this.getQuery(Date.now(), '', page.options)
+    const param = this.getQuery(page.$taroParams.stamp, '', page.options)
     let pageEl = this.getPageContainer(page)
     if (pageEl) {
       setDisplay(pageEl)

--- a/packages/taro-router/src/router/spa.ts
+++ b/packages/taro-router/src/router/spa.ts
@@ -86,7 +86,10 @@ export function createRouter (
 
     const currentPage = Current.page
     const pathname = handler.pathname
+    const methodName = stacks.method ?? ''
     let shouldLoad = false
+    // 拷贝之后清空掉，因为浏览器左上角的返回前进不会有methodName
+    stacks.method = ''
 
     if (action === 'POP') {
       // NOTE: 浏览器事件退后多次时，该事件只会被触发一次
@@ -102,7 +105,11 @@ export function createRouter (
         }
       }
     } else {
-      if (handler.isTabBar) {
+      // 卸载所有页面，然后重新加载新页面
+      if (methodName === 'reLaunch') {
+        // NOTE: 页面路由记录并不会清空，只是移除掉缓存的 stack 以及页面
+        handler.unload(currentPage, stacks.length)
+      } else if (handler.isTabBar) {
         if (handler.isSamePage(currentPage)) return
         const prevIndex = stacks.getPrevIndex(pathname, 0)
         handler.hide(currentPage)

--- a/packages/taro-router/src/router/spa.ts
+++ b/packages/taro-router/src/router/spa.ts
@@ -132,10 +132,10 @@ export function createRouter (
         if (handler.isTabBar) {
           // 如果当前页和目标页相同，则什么都不做
           if (handler.isSamePage(currentPage)) return
-          const currentIsTab = handler.tabBarList?.some(t => stripTrailing(t.pagePath) === stripTrailing(currentPage.path))
+          const currentIsTabbar = handler.tabBarList?.some(t => stripTrailing(t.pagePath) === stripTrailing(currentPage?.path ?? ''))
           const prevIndex = stacks.getPrevIndex(pathname, 0)
           // 如果当前页是tabbar
-          if (currentIsTab) {
+          if (currentIsTabbar) {
             // 目标页是tabbar，当前页是tabbar，隐藏当前页
             handler.hide(currentPage)
             if (prevIndex > -1) {

--- a/packages/taro-router/src/router/stack.ts
+++ b/packages/taro-router/src/router/stack.ts
@@ -4,6 +4,7 @@ class Stacks {
   stacks: PageInstance[] = []
 
   backDelta = 0
+  methodName = ''
 
   set delta (delta: number) {
     if (delta > 0) {
@@ -17,6 +18,14 @@ class Stacks {
 
   get delta () {
     return this.backDelta
+  }
+
+  set method (methodName: string) {
+    this.methodName = methodName
+  }
+
+  get method () {
+    return this.methodName
   }
 
   get length () {

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/babel.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/babel.spec.ts.snap
@@ -4539,7 +4539,7 @@ exports[`babel should convert do expressions 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, _j, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, currentIsTabbar, _prevIndex2, _delta2, _delta3, _prevIndex3, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -4615,72 +4615,166 @@ exports[`babel should convert do expressions 2`] = `
                             shouldLoad = false;
                             stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 41;
+                                _context.next = 45;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
                             delta = stack.getDelta(pathname);
-                            if (currentPage !== stack.getItem(prevIndex)) {
-                                handler.unload(currentPage, delta, prevIndex > -1);
-                                if (prevIndex > -1) {
-                                    handler.show(stack.getItem(prevIndex), pageConfig, prevIndex);
-                                } else {
-                                    shouldLoad = true;
-                                }
-                            }
-                            _context.next = 56;
-                            break;
-
-                          case 41:
-                            if (!(methodName === \\"reLaunch\\")) {
-                                _context.next = 45;
+                            if (!(currentPage !== stack.getItem(prevIndex))) {
+                                _context.next = 43;
                                 break;
                             }
-                            handler.unload(currentPage, stack.length);
-                            _context.next = 55;
+                            handler.unload(currentPage, delta, prevIndex > -1);
+                            if (!(prevIndex > -1)) {
+                                _context.next = 42;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(prevIndex), pageConfig, prevIndex));
+
+                          case 42:
+                            shouldLoad = true;
+
+                          case 43:
+                            _context.next = 93;
                             break;
 
                           case 45:
+                            if (!(action === \\"REPLACE\\")) {
+                                _context.next = 80;
+                                break;
+                            }
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 51;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            shouldLoad = true;
+                            _context.next = 78;
+                            break;
+
+                          case 51:
+                            if (!(methodName === \\"redirectTo\\")) {
+                                _context.next = 56;
+                                break;
+                            }
+                            _prevIndex = stack.getPrevIndex(pathname);
+                            if (handler.isTabBar && _prevIndex > -1) {
+                                _delta = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta + 1);
+                                shouldLoad = true;
+                            } else {
+                                handler.unload(currentPage);
+                                shouldLoad = true;
+                            }
+                            _context.next = 78;
+                            break;
+
+                          case 56:
+                            if (!(methodName === \\"switchTab\\")) {
+                                _context.next = 75;
+                                break;
+                            }
                             if (!handler.isTabBar) {
-                                _context.next = 54;
+                                _context.next = 72;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 48;
+                                _context.next = 60;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 48:
-                            _prevIndex = stack.getPrevIndex(pathname, 0);
-                            handler.hide(currentPage);
-                            if (!(_prevIndex > -1)) {
-                                _context.next = 52;
+                          case 60:
+                            currentIsTabbar = (_h = handler.tabBarList) === null || _h === void 0 ? void 0 : _h.some((function(t) {
+                                var _a;
+                                return stripTrailing(t.pagePath) === stripTrailing((_a = currentPage === null || currentPage === void 0 ? void 0 : currentPage.path) !== null && _a !== void 0 ? _a : \\"\\");
+                            }));
+                            _prevIndex2 = stack.getPrevIndex(pathname, 0);
+                            if (!currentIsTabbar) {
+                                _context.next = 69;
                                 break;
                             }
-                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
+                            handler.hide(currentPage);
+                            if (!(_prevIndex2 > -1)) {
+                                _context.next = 66;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2));
 
-                          case 52:
-                            _context.next = 55;
+                          case 66:
+                            shouldLoad = true;
+                            _context.next = 70;
                             break;
 
-                          case 54:
-                            if (action === \\"REPLACE\\") {
-                                _delta = stack.getDelta(pathname);
-                                handler.unload(currentPage, _delta);
-                            } else if (action === \\"PUSH\\") {
-                                handler.hide(currentPage);
+                          case 69:
+                            if (_prevIndex2 > -1) {
+                                _delta2 = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta2, _prevIndex2 > -1);
+                                handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2);
+                            } else {
+                                handler.unload(currentPage, stack.length);
+                                shouldLoad = true;
                             }
 
-                          case 55:
+                          case 70:
+                            _context.next = 73;
+                            break;
+
+                          case 72:
+                            return _context.abrupt(\\"return\\", console.error(\\"switchTab:fail can not switch to no-tabBar page\\"));
+
+                          case 73:
+                            _context.next = 78;
+                            break;
+
+                          case 75:
+                            _delta3 = stack.getDelta(pathname);
+                            handler.unload(currentPage, _delta3);
                             shouldLoad = true;
 
-                          case 56:
-                            if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 65;
+                          case 78:
+                            _context.next = 93;
+                            break;
+
+                          case 80:
+                            if (!(action === \\"PUSH\\")) {
+                                _context.next = 93;
                                 break;
                             }
-                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
+                            if (!handler.isTabBar) {
+                                _context.next = 91;
+                                break;
+                            }
+                            if (!handler.isSamePage(currentPage)) {
+                                _context.next = 84;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\");
+
+                          case 84:
+                            _prevIndex3 = stack.getPrevIndex(pathname, 0);
+                            handler.hide(currentPage);
+                            if (!(_prevIndex3 > -1)) {
+                                _context.next = 88;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex3), pageConfig, _prevIndex3));
+
+                          case 88:
+                            shouldLoad = true;
+                            _context.next = 93;
+                            break;
+
+                          case 91:
+                            handler.hide(currentPage);
+                            shouldLoad = true;
+
+                          case 93:
+                            if (!(shouldLoad || stack.length < 1)) {
+                                _context.next = 102;
+                                break;
+                            }
+                            el = (_j = element.default) !== null && _j !== void 0 ? _j : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -4689,7 +4783,7 @@ exports[`babel should convert do expressions 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 65:
+                          case 102:
                           case \\"end\\":
                             return _context.stop();
                         }

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/babel.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/babel.spec.ts.snap
@@ -3252,6 +3252,7 @@ exports[`babel should convert do expressions 2`] = `
             Object(classCallCheck[\\"a\\"])(this, Stacks);
             this.stacks = [];
             this.backDelta = 0;
+            this.methodName = \\"\\";
         }
         Object(createClass[\\"a\\"])(Stacks, [ {
             \\"key\\": \\"delta\\",
@@ -3266,6 +3267,14 @@ exports[`babel should convert do expressions 2`] = `
                 } else {
                     this.backDelta = 0;
                 }
+            }
+        }, {
+            \\"key\\": \\"method\\",
+            \\"get\\": function get() {
+                return this.methodName;
+            },
+            \\"set\\": function set(methodName) {
+                this.methodName = methodName;
             }
         }, {
             \\"key\\": \\"length\\",
@@ -3395,6 +3404,7 @@ exports[`babel should convert do expressions 2`] = `
                                 unListen();
                             }));
                             try {
+                                stack.method = method;
                                 if (\\"url\\" in option) {
                                     var pathPieces = processNavigateUrl(option);
                                     var state = {
@@ -4314,7 +4324,7 @@ exports[`babel should convert do expressions 2`] = `
                 var _a, _b;
                 if (!page) return;
                 stack.push(page);
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var param = this.getQuery(Date.now(), \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
@@ -4373,17 +4383,22 @@ exports[`babel should convert do expressions 2`] = `
                 var _this3 = this;
                 var pageConfig = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
                 var stacksIndex = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
-                var _a, _b;
+                var _a, _b, _c, _d;
                 if (!page) return;
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var index = (_b = (_a = page.path) === null || _a === void 0 ? void 0 : _a.indexOf(\\"?\\")) !== null && _b !== void 0 ? _b : -1;
+                var q = index > -1 ? query_string_default.a.parse(page.path.substring(index), {
+                    \\"decode\\": false
+                }) : {};
+                var stamp = q.stamp ? Number(q.stamp) : undefined;
+                var param = this.getQuery(stamp, \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
                     this.addAnimation(pageEl, stacksIndex === 0);
-                    (_a = page.onShow) === null || _a === void 0 ? void 0 : _a.call(page);
+                    (_c = page.onShow) === null || _c === void 0 ? void 0 : _c.call(page);
                     this.bindPageEvents(page, pageEl, pageConfig);
                 } else {
-                    (_b = page.onLoad) === null || _b === void 0 ? void 0 : _b.call(page, param, (function() {
+                    (_d = page.onLoad) === null || _d === void 0 ? void 0 : _d.call(page, param, (function() {
                         var _a;
                         pageEl = _this3.getPageContainer(page);
                         _this3.addAnimation(pageEl, stacksIndex === 0);
@@ -4524,7 +4539,7 @@ exports[`babel should convert do expressions 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -4596,9 +4611,11 @@ exports[`babel should convert do expressions 2`] = `
                             }
                             currentPage = undefined.page;
                             pathname = handler.pathname;
+                            methodName = (_g = stack.method) !== null && _g !== void 0 ? _g : \\"\\";
                             shouldLoad = false;
+                            stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 39;
+                                _context.next = 41;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
@@ -4611,34 +4628,43 @@ exports[`babel should convert do expressions 2`] = `
                                     shouldLoad = true;
                                 }
                             }
-                            _context.next = 50;
+                            _context.next = 56;
                             break;
 
-                          case 39:
+                          case 41:
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 45;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            _context.next = 55;
+                            break;
+
+                          case 45:
                             if (!handler.isTabBar) {
-                                _context.next = 48;
+                                _context.next = 54;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 42;
+                                _context.next = 48;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 42:
+                          case 48:
                             _prevIndex = stack.getPrevIndex(pathname, 0);
                             handler.hide(currentPage);
                             if (!(_prevIndex > -1)) {
-                                _context.next = 46;
+                                _context.next = 52;
                                 break;
                             }
                             return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
 
-                          case 46:
-                            _context.next = 49;
+                          case 52:
+                            _context.next = 55;
                             break;
 
-                          case 48:
+                          case 54:
                             if (action === \\"REPLACE\\") {
                                 _delta = stack.getDelta(pathname);
                                 handler.unload(currentPage, _delta);
@@ -4646,15 +4672,15 @@ exports[`babel should convert do expressions 2`] = `
                                 handler.hide(currentPage);
                             }
 
-                          case 49:
+                          case 55:
                             shouldLoad = true;
 
-                          case 50:
+                          case 56:
                             if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 59;
+                                _context.next = 65;
                                 break;
                             }
-                            el = (_g = element.default) !== null && _g !== void 0 ? _g : element;
+                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -4663,7 +4689,7 @@ exports[`babel should convert do expressions 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 59:
+                          case 65:
                           case \\"end\\":
                             return _context.stop();
                         }

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/compiler-macros.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/compiler-macros.spec.ts.snap
@@ -3247,6 +3247,7 @@ exports[`compiler-macros - defineAppConfig and definePageConfig should read app 
             Object(classCallCheck[\\"a\\"])(this, Stacks);
             this.stacks = [];
             this.backDelta = 0;
+            this.methodName = \\"\\";
         }
         Object(createClass[\\"a\\"])(Stacks, [ {
             \\"key\\": \\"delta\\",
@@ -3261,6 +3262,14 @@ exports[`compiler-macros - defineAppConfig and definePageConfig should read app 
                 } else {
                     this.backDelta = 0;
                 }
+            }
+        }, {
+            \\"key\\": \\"method\\",
+            \\"get\\": function get() {
+                return this.methodName;
+            },
+            \\"set\\": function set(methodName) {
+                this.methodName = methodName;
             }
         }, {
             \\"key\\": \\"length\\",
@@ -3390,6 +3399,7 @@ exports[`compiler-macros - defineAppConfig and definePageConfig should read app 
                                 unListen();
                             }));
                             try {
+                                stack.method = method;
                                 if (\\"url\\" in option) {
                                     var pathPieces = processNavigateUrl(option);
                                     var state = {
@@ -4309,7 +4319,7 @@ exports[`compiler-macros - defineAppConfig and definePageConfig should read app 
                 var _a, _b;
                 if (!page) return;
                 stack.push(page);
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var param = this.getQuery(Date.now(), \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
@@ -4368,17 +4378,22 @@ exports[`compiler-macros - defineAppConfig and definePageConfig should read app 
                 var _this3 = this;
                 var pageConfig = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
                 var stacksIndex = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
-                var _a, _b;
+                var _a, _b, _c, _d;
                 if (!page) return;
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var index = (_b = (_a = page.path) === null || _a === void 0 ? void 0 : _a.indexOf(\\"?\\")) !== null && _b !== void 0 ? _b : -1;
+                var q = index > -1 ? query_string_default.a.parse(page.path.substring(index), {
+                    \\"decode\\": false
+                }) : {};
+                var stamp = q.stamp ? Number(q.stamp) : undefined;
+                var param = this.getQuery(stamp, \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
                     this.addAnimation(pageEl, stacksIndex === 0);
-                    (_a = page.onShow) === null || _a === void 0 ? void 0 : _a.call(page);
+                    (_c = page.onShow) === null || _c === void 0 ? void 0 : _c.call(page);
                     this.bindPageEvents(page, pageEl, pageConfig);
                 } else {
-                    (_b = page.onLoad) === null || _b === void 0 ? void 0 : _b.call(page, param, (function() {
+                    (_d = page.onLoad) === null || _d === void 0 ? void 0 : _d.call(page, param, (function() {
                         var _a;
                         pageEl = _this3.getPageContainer(page);
                         _this3.addAnimation(pageEl, stacksIndex === 0);
@@ -4519,7 +4534,7 @@ exports[`compiler-macros - defineAppConfig and definePageConfig should read app 
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -4591,9 +4606,11 @@ exports[`compiler-macros - defineAppConfig and definePageConfig should read app 
                             }
                             currentPage = undefined.page;
                             pathname = handler.pathname;
+                            methodName = (_g = stack.method) !== null && _g !== void 0 ? _g : \\"\\";
                             shouldLoad = false;
+                            stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 39;
+                                _context.next = 41;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
@@ -4606,34 +4623,43 @@ exports[`compiler-macros - defineAppConfig and definePageConfig should read app 
                                     shouldLoad = true;
                                 }
                             }
-                            _context.next = 50;
+                            _context.next = 56;
                             break;
 
-                          case 39:
+                          case 41:
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 45;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            _context.next = 55;
+                            break;
+
+                          case 45:
                             if (!handler.isTabBar) {
-                                _context.next = 48;
+                                _context.next = 54;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 42;
+                                _context.next = 48;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 42:
+                          case 48:
                             _prevIndex = stack.getPrevIndex(pathname, 0);
                             handler.hide(currentPage);
                             if (!(_prevIndex > -1)) {
-                                _context.next = 46;
+                                _context.next = 52;
                                 break;
                             }
                             return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
 
-                          case 46:
-                            _context.next = 49;
+                          case 52:
+                            _context.next = 55;
                             break;
 
-                          case 48:
+                          case 54:
                             if (action === \\"REPLACE\\") {
                                 _delta = stack.getDelta(pathname);
                                 handler.unload(currentPage, _delta);
@@ -4641,15 +4667,15 @@ exports[`compiler-macros - defineAppConfig and definePageConfig should read app 
                                 handler.hide(currentPage);
                             }
 
-                          case 49:
+                          case 55:
                             shouldLoad = true;
 
-                          case 50:
+                          case 56:
                             if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 59;
+                                _context.next = 65;
                                 break;
                             }
-                            el = (_g = element.default) !== null && _g !== void 0 ? _g : element;
+                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -4658,7 +4684,7 @@ exports[`compiler-macros - defineAppConfig and definePageConfig should read app 
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 59:
+                          case 65:
                           case \\"end\\":
                             return _context.stop();
                         }

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/compiler-macros.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/compiler-macros.spec.ts.snap
@@ -4534,7 +4534,7 @@ exports[`compiler-macros - defineAppConfig and definePageConfig should read app 
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, _j, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, currentIsTabbar, _prevIndex2, _delta2, _delta3, _prevIndex3, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -4610,72 +4610,166 @@ exports[`compiler-macros - defineAppConfig and definePageConfig should read app 
                             shouldLoad = false;
                             stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 41;
+                                _context.next = 45;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
                             delta = stack.getDelta(pathname);
-                            if (currentPage !== stack.getItem(prevIndex)) {
-                                handler.unload(currentPage, delta, prevIndex > -1);
-                                if (prevIndex > -1) {
-                                    handler.show(stack.getItem(prevIndex), pageConfig, prevIndex);
-                                } else {
-                                    shouldLoad = true;
-                                }
-                            }
-                            _context.next = 56;
-                            break;
-
-                          case 41:
-                            if (!(methodName === \\"reLaunch\\")) {
-                                _context.next = 45;
+                            if (!(currentPage !== stack.getItem(prevIndex))) {
+                                _context.next = 43;
                                 break;
                             }
-                            handler.unload(currentPage, stack.length);
-                            _context.next = 55;
+                            handler.unload(currentPage, delta, prevIndex > -1);
+                            if (!(prevIndex > -1)) {
+                                _context.next = 42;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(prevIndex), pageConfig, prevIndex));
+
+                          case 42:
+                            shouldLoad = true;
+
+                          case 43:
+                            _context.next = 93;
                             break;
 
                           case 45:
+                            if (!(action === \\"REPLACE\\")) {
+                                _context.next = 80;
+                                break;
+                            }
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 51;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            shouldLoad = true;
+                            _context.next = 78;
+                            break;
+
+                          case 51:
+                            if (!(methodName === \\"redirectTo\\")) {
+                                _context.next = 56;
+                                break;
+                            }
+                            _prevIndex = stack.getPrevIndex(pathname);
+                            if (handler.isTabBar && _prevIndex > -1) {
+                                _delta = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta + 1);
+                                shouldLoad = true;
+                            } else {
+                                handler.unload(currentPage);
+                                shouldLoad = true;
+                            }
+                            _context.next = 78;
+                            break;
+
+                          case 56:
+                            if (!(methodName === \\"switchTab\\")) {
+                                _context.next = 75;
+                                break;
+                            }
                             if (!handler.isTabBar) {
-                                _context.next = 54;
+                                _context.next = 72;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 48;
+                                _context.next = 60;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 48:
-                            _prevIndex = stack.getPrevIndex(pathname, 0);
-                            handler.hide(currentPage);
-                            if (!(_prevIndex > -1)) {
-                                _context.next = 52;
+                          case 60:
+                            currentIsTabbar = (_h = handler.tabBarList) === null || _h === void 0 ? void 0 : _h.some((function(t) {
+                                var _a;
+                                return stripTrailing(t.pagePath) === stripTrailing((_a = currentPage === null || currentPage === void 0 ? void 0 : currentPage.path) !== null && _a !== void 0 ? _a : \\"\\");
+                            }));
+                            _prevIndex2 = stack.getPrevIndex(pathname, 0);
+                            if (!currentIsTabbar) {
+                                _context.next = 69;
                                 break;
                             }
-                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
+                            handler.hide(currentPage);
+                            if (!(_prevIndex2 > -1)) {
+                                _context.next = 66;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2));
 
-                          case 52:
-                            _context.next = 55;
+                          case 66:
+                            shouldLoad = true;
+                            _context.next = 70;
                             break;
 
-                          case 54:
-                            if (action === \\"REPLACE\\") {
-                                _delta = stack.getDelta(pathname);
-                                handler.unload(currentPage, _delta);
-                            } else if (action === \\"PUSH\\") {
-                                handler.hide(currentPage);
+                          case 69:
+                            if (_prevIndex2 > -1) {
+                                _delta2 = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta2, _prevIndex2 > -1);
+                                handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2);
+                            } else {
+                                handler.unload(currentPage, stack.length);
+                                shouldLoad = true;
                             }
 
-                          case 55:
+                          case 70:
+                            _context.next = 73;
+                            break;
+
+                          case 72:
+                            return _context.abrupt(\\"return\\", console.error(\\"switchTab:fail can not switch to no-tabBar page\\"));
+
+                          case 73:
+                            _context.next = 78;
+                            break;
+
+                          case 75:
+                            _delta3 = stack.getDelta(pathname);
+                            handler.unload(currentPage, _delta3);
                             shouldLoad = true;
 
-                          case 56:
-                            if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 65;
+                          case 78:
+                            _context.next = 93;
+                            break;
+
+                          case 80:
+                            if (!(action === \\"PUSH\\")) {
+                                _context.next = 93;
                                 break;
                             }
-                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
+                            if (!handler.isTabBar) {
+                                _context.next = 91;
+                                break;
+                            }
+                            if (!handler.isSamePage(currentPage)) {
+                                _context.next = 84;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\");
+
+                          case 84:
+                            _prevIndex3 = stack.getPrevIndex(pathname, 0);
+                            handler.hide(currentPage);
+                            if (!(_prevIndex3 > -1)) {
+                                _context.next = 88;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex3), pageConfig, _prevIndex3));
+
+                          case 88:
+                            shouldLoad = true;
+                            _context.next = 93;
+                            break;
+
+                          case 91:
+                            handler.hide(currentPage);
+                            shouldLoad = true;
+
+                          case 93:
+                            if (!(shouldLoad || stack.length < 1)) {
+                                _context.next = 102;
+                                break;
+                            }
+                            el = (_j = element.default) !== null && _j !== void 0 ? _j : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -4684,7 +4778,7 @@ exports[`compiler-macros - defineAppConfig and definePageConfig should read app 
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 65:
+                          case 102:
                           case \\"end\\":
                             return _context.stop();
                         }

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/config.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/config.spec.ts.snap
@@ -3259,6 +3259,7 @@ exports[`config should build from origin and pipe to output 2`] = `
             Object(classCallCheck[\\"a\\"])(this, Stacks);
             this.stacks = [];
             this.backDelta = 0;
+            this.methodName = \\"\\";
         }
         Object(createClass[\\"a\\"])(Stacks, [ {
             \\"key\\": \\"delta\\",
@@ -3273,6 +3274,14 @@ exports[`config should build from origin and pipe to output 2`] = `
                 } else {
                     this.backDelta = 0;
                 }
+            }
+        }, {
+            \\"key\\": \\"method\\",
+            \\"get\\": function get() {
+                return this.methodName;
+            },
+            \\"set\\": function set(methodName) {
+                this.methodName = methodName;
             }
         }, {
             \\"key\\": \\"length\\",
@@ -3402,6 +3411,7 @@ exports[`config should build from origin and pipe to output 2`] = `
                                 unListen();
                             }));
                             try {
+                                stack.method = method;
                                 if (\\"url\\" in option) {
                                     var pathPieces = processNavigateUrl(option);
                                     var state = {
@@ -4321,7 +4331,7 @@ exports[`config should build from origin and pipe to output 2`] = `
                 var _a, _b;
                 if (!page) return;
                 stack.push(page);
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var param = this.getQuery(Date.now(), \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
@@ -4380,17 +4390,22 @@ exports[`config should build from origin and pipe to output 2`] = `
                 var _this3 = this;
                 var pageConfig = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
                 var stacksIndex = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
-                var _a, _b;
+                var _a, _b, _c, _d;
                 if (!page) return;
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var index = (_b = (_a = page.path) === null || _a === void 0 ? void 0 : _a.indexOf(\\"?\\")) !== null && _b !== void 0 ? _b : -1;
+                var q = index > -1 ? query_string_default.a.parse(page.path.substring(index), {
+                    \\"decode\\": false
+                }) : {};
+                var stamp = q.stamp ? Number(q.stamp) : undefined;
+                var param = this.getQuery(stamp, \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
                     this.addAnimation(pageEl, stacksIndex === 0);
-                    (_a = page.onShow) === null || _a === void 0 ? void 0 : _a.call(page);
+                    (_c = page.onShow) === null || _c === void 0 ? void 0 : _c.call(page);
                     this.bindPageEvents(page, pageEl, pageConfig);
                 } else {
-                    (_b = page.onLoad) === null || _b === void 0 ? void 0 : _b.call(page, param, (function() {
+                    (_d = page.onLoad) === null || _d === void 0 ? void 0 : _d.call(page, param, (function() {
                         var _a;
                         pageEl = _this3.getPageContainer(page);
                         _this3.addAnimation(pageEl, stacksIndex === 0);
@@ -4531,7 +4546,7 @@ exports[`config should build from origin and pipe to output 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -4603,9 +4618,11 @@ exports[`config should build from origin and pipe to output 2`] = `
                             }
                             currentPage = undefined.page;
                             pathname = handler.pathname;
+                            methodName = (_g = stack.method) !== null && _g !== void 0 ? _g : \\"\\";
                             shouldLoad = false;
+                            stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 39;
+                                _context.next = 41;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
@@ -4618,34 +4635,43 @@ exports[`config should build from origin and pipe to output 2`] = `
                                     shouldLoad = true;
                                 }
                             }
-                            _context.next = 50;
+                            _context.next = 56;
                             break;
 
-                          case 39:
+                          case 41:
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 45;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            _context.next = 55;
+                            break;
+
+                          case 45:
                             if (!handler.isTabBar) {
-                                _context.next = 48;
+                                _context.next = 54;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 42;
+                                _context.next = 48;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 42:
+                          case 48:
                             _prevIndex = stack.getPrevIndex(pathname, 0);
                             handler.hide(currentPage);
                             if (!(_prevIndex > -1)) {
-                                _context.next = 46;
+                                _context.next = 52;
                                 break;
                             }
                             return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
 
-                          case 46:
-                            _context.next = 49;
+                          case 52:
+                            _context.next = 55;
                             break;
 
-                          case 48:
+                          case 54:
                             if (action === \\"REPLACE\\") {
                                 _delta = stack.getDelta(pathname);
                                 handler.unload(currentPage, _delta);
@@ -4653,15 +4679,15 @@ exports[`config should build from origin and pipe to output 2`] = `
                                 handler.hide(currentPage);
                             }
 
-                          case 49:
+                          case 55:
                             shouldLoad = true;
 
-                          case 50:
+                          case 56:
                             if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 59;
+                                _context.next = 65;
                                 break;
                             }
-                            el = (_g = element.default) !== null && _g !== void 0 ? _g : element;
+                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -4670,7 +4696,7 @@ exports[`config should build from origin and pipe to output 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 59:
+                          case 65:
                           case \\"end\\":
                             return _context.stop();
                         }
@@ -8050,6 +8076,7 @@ I m irrelevant.
             Object(classCallCheck[\\"a\\"])(this, Stacks);
             this.stacks = [];
             this.backDelta = 0;
+            this.methodName = \\"\\";
         }
         Object(createClass[\\"a\\"])(Stacks, [ {
             \\"key\\": \\"delta\\",
@@ -8064,6 +8091,14 @@ I m irrelevant.
                 } else {
                     this.backDelta = 0;
                 }
+            }
+        }, {
+            \\"key\\": \\"method\\",
+            \\"get\\": function get() {
+                return this.methodName;
+            },
+            \\"set\\": function set(methodName) {
+                this.methodName = methodName;
             }
         }, {
             \\"key\\": \\"length\\",
@@ -8193,6 +8228,7 @@ I m irrelevant.
                                 unListen();
                             }));
                             try {
+                                stack.method = method;
                                 if (\\"url\\" in option) {
                                     var pathPieces = processNavigateUrl(option);
                                     var state = {
@@ -9112,7 +9148,7 @@ I m irrelevant.
                 var _a, _b;
                 if (!page) return;
                 stack.push(page);
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var param = this.getQuery(Date.now(), \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
@@ -9171,17 +9207,22 @@ I m irrelevant.
                 var _this3 = this;
                 var pageConfig = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
                 var stacksIndex = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
-                var _a, _b;
+                var _a, _b, _c, _d;
                 if (!page) return;
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var index = (_b = (_a = page.path) === null || _a === void 0 ? void 0 : _a.indexOf(\\"?\\")) !== null && _b !== void 0 ? _b : -1;
+                var q = index > -1 ? query_string_default.a.parse(page.path.substring(index), {
+                    \\"decode\\": false
+                }) : {};
+                var stamp = q.stamp ? Number(q.stamp) : undefined;
+                var param = this.getQuery(stamp, \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
                     this.addAnimation(pageEl, stacksIndex === 0);
-                    (_a = page.onShow) === null || _a === void 0 ? void 0 : _a.call(page);
+                    (_c = page.onShow) === null || _c === void 0 ? void 0 : _c.call(page);
                     this.bindPageEvents(page, pageEl, pageConfig);
                 } else {
-                    (_b = page.onLoad) === null || _b === void 0 ? void 0 : _b.call(page, param, (function() {
+                    (_d = page.onLoad) === null || _d === void 0 ? void 0 : _d.call(page, param, (function() {
                         var _a;
                         pageEl = _this3.getPageContainer(page);
                         _this3.addAnimation(pageEl, stacksIndex === 0);
@@ -9322,7 +9363,7 @@ I m irrelevant.
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -9394,9 +9435,11 @@ I m irrelevant.
                             }
                             currentPage = undefined.page;
                             pathname = handler.pathname;
+                            methodName = (_g = stack.method) !== null && _g !== void 0 ? _g : \\"\\";
                             shouldLoad = false;
+                            stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 39;
+                                _context.next = 41;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
@@ -9409,34 +9452,43 @@ I m irrelevant.
                                     shouldLoad = true;
                                 }
                             }
-                            _context.next = 50;
+                            _context.next = 56;
                             break;
 
-                          case 39:
+                          case 41:
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 45;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            _context.next = 55;
+                            break;
+
+                          case 45:
                             if (!handler.isTabBar) {
-                                _context.next = 48;
+                                _context.next = 54;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 42;
+                                _context.next = 48;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 42:
+                          case 48:
                             _prevIndex = stack.getPrevIndex(pathname, 0);
                             handler.hide(currentPage);
                             if (!(_prevIndex > -1)) {
-                                _context.next = 46;
+                                _context.next = 52;
                                 break;
                             }
                             return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
 
-                          case 46:
-                            _context.next = 49;
+                          case 52:
+                            _context.next = 55;
                             break;
 
-                          case 48:
+                          case 54:
                             if (action === \\"REPLACE\\") {
                                 _delta = stack.getDelta(pathname);
                                 handler.unload(currentPage, _delta);
@@ -9444,15 +9496,15 @@ I m irrelevant.
                                 handler.hide(currentPage);
                             }
 
-                          case 49:
+                          case 55:
                             shouldLoad = true;
 
-                          case 50:
+                          case 56:
                             if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 59;
+                                _context.next = 65;
                                 break;
                             }
-                            el = (_g = element.default) !== null && _g !== void 0 ? _g : element;
+                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -9461,7 +9513,7 @@ I m irrelevant.
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 59:
+                          case 65:
                           case \\"end\\":
                             return _context.stop();
                         }
@@ -12841,6 +12893,7 @@ exports[`config should resolved alias 2`] = `
             Object(classCallCheck[\\"a\\"])(this, Stacks);
             this.stacks = [];
             this.backDelta = 0;
+            this.methodName = \\"\\";
         }
         Object(createClass[\\"a\\"])(Stacks, [ {
             \\"key\\": \\"delta\\",
@@ -12855,6 +12908,14 @@ exports[`config should resolved alias 2`] = `
                 } else {
                     this.backDelta = 0;
                 }
+            }
+        }, {
+            \\"key\\": \\"method\\",
+            \\"get\\": function get() {
+                return this.methodName;
+            },
+            \\"set\\": function set(methodName) {
+                this.methodName = methodName;
             }
         }, {
             \\"key\\": \\"length\\",
@@ -12984,6 +13045,7 @@ exports[`config should resolved alias 2`] = `
                                 unListen();
                             }));
                             try {
+                                stack.method = method;
                                 if (\\"url\\" in option) {
                                     var pathPieces = processNavigateUrl(option);
                                     var state = {
@@ -13903,7 +13965,7 @@ exports[`config should resolved alias 2`] = `
                 var _a, _b;
                 if (!page) return;
                 stack.push(page);
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var param = this.getQuery(Date.now(), \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
@@ -13962,17 +14024,22 @@ exports[`config should resolved alias 2`] = `
                 var _this3 = this;
                 var pageConfig = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
                 var stacksIndex = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
-                var _a, _b;
+                var _a, _b, _c, _d;
                 if (!page) return;
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var index = (_b = (_a = page.path) === null || _a === void 0 ? void 0 : _a.indexOf(\\"?\\")) !== null && _b !== void 0 ? _b : -1;
+                var q = index > -1 ? query_string_default.a.parse(page.path.substring(index), {
+                    \\"decode\\": false
+                }) : {};
+                var stamp = q.stamp ? Number(q.stamp) : undefined;
+                var param = this.getQuery(stamp, \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
                     this.addAnimation(pageEl, stacksIndex === 0);
-                    (_a = page.onShow) === null || _a === void 0 ? void 0 : _a.call(page);
+                    (_c = page.onShow) === null || _c === void 0 ? void 0 : _c.call(page);
                     this.bindPageEvents(page, pageEl, pageConfig);
                 } else {
-                    (_b = page.onLoad) === null || _b === void 0 ? void 0 : _b.call(page, param, (function() {
+                    (_d = page.onLoad) === null || _d === void 0 ? void 0 : _d.call(page, param, (function() {
                         var _a;
                         pageEl = _this3.getPageContainer(page);
                         _this3.addAnimation(pageEl, stacksIndex === 0);
@@ -14113,7 +14180,7 @@ exports[`config should resolved alias 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -14185,9 +14252,11 @@ exports[`config should resolved alias 2`] = `
                             }
                             currentPage = undefined.page;
                             pathname = handler.pathname;
+                            methodName = (_g = stack.method) !== null && _g !== void 0 ? _g : \\"\\";
                             shouldLoad = false;
+                            stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 39;
+                                _context.next = 41;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
@@ -14200,34 +14269,43 @@ exports[`config should resolved alias 2`] = `
                                     shouldLoad = true;
                                 }
                             }
-                            _context.next = 50;
+                            _context.next = 56;
                             break;
 
-                          case 39:
+                          case 41:
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 45;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            _context.next = 55;
+                            break;
+
+                          case 45:
                             if (!handler.isTabBar) {
-                                _context.next = 48;
+                                _context.next = 54;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 42;
+                                _context.next = 48;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 42:
+                          case 48:
                             _prevIndex = stack.getPrevIndex(pathname, 0);
                             handler.hide(currentPage);
                             if (!(_prevIndex > -1)) {
-                                _context.next = 46;
+                                _context.next = 52;
                                 break;
                             }
                             return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
 
-                          case 46:
-                            _context.next = 49;
+                          case 52:
+                            _context.next = 55;
                             break;
 
-                          case 48:
+                          case 54:
                             if (action === \\"REPLACE\\") {
                                 _delta = stack.getDelta(pathname);
                                 handler.unload(currentPage, _delta);
@@ -14235,15 +14313,15 @@ exports[`config should resolved alias 2`] = `
                                 handler.hide(currentPage);
                             }
 
-                          case 49:
+                          case 55:
                             shouldLoad = true;
 
-                          case 50:
+                          case 56:
                             if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 59;
+                                _context.next = 65;
                                 break;
                             }
-                            el = (_g = element.default) !== null && _g !== void 0 ? _g : element;
+                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -14252,7 +14330,7 @@ exports[`config should resolved alias 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 59:
+                          case 65:
                           case \\"end\\":
                             return _context.stop();
                         }

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/config.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/config.spec.ts.snap
@@ -4546,7 +4546,7 @@ exports[`config should build from origin and pipe to output 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, _j, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, currentIsTabbar, _prevIndex2, _delta2, _delta3, _prevIndex3, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -4622,72 +4622,166 @@ exports[`config should build from origin and pipe to output 2`] = `
                             shouldLoad = false;
                             stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 41;
+                                _context.next = 45;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
                             delta = stack.getDelta(pathname);
-                            if (currentPage !== stack.getItem(prevIndex)) {
-                                handler.unload(currentPage, delta, prevIndex > -1);
-                                if (prevIndex > -1) {
-                                    handler.show(stack.getItem(prevIndex), pageConfig, prevIndex);
-                                } else {
-                                    shouldLoad = true;
-                                }
-                            }
-                            _context.next = 56;
-                            break;
-
-                          case 41:
-                            if (!(methodName === \\"reLaunch\\")) {
-                                _context.next = 45;
+                            if (!(currentPage !== stack.getItem(prevIndex))) {
+                                _context.next = 43;
                                 break;
                             }
-                            handler.unload(currentPage, stack.length);
-                            _context.next = 55;
+                            handler.unload(currentPage, delta, prevIndex > -1);
+                            if (!(prevIndex > -1)) {
+                                _context.next = 42;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(prevIndex), pageConfig, prevIndex));
+
+                          case 42:
+                            shouldLoad = true;
+
+                          case 43:
+                            _context.next = 93;
                             break;
 
                           case 45:
+                            if (!(action === \\"REPLACE\\")) {
+                                _context.next = 80;
+                                break;
+                            }
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 51;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            shouldLoad = true;
+                            _context.next = 78;
+                            break;
+
+                          case 51:
+                            if (!(methodName === \\"redirectTo\\")) {
+                                _context.next = 56;
+                                break;
+                            }
+                            _prevIndex = stack.getPrevIndex(pathname);
+                            if (handler.isTabBar && _prevIndex > -1) {
+                                _delta = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta + 1);
+                                shouldLoad = true;
+                            } else {
+                                handler.unload(currentPage);
+                                shouldLoad = true;
+                            }
+                            _context.next = 78;
+                            break;
+
+                          case 56:
+                            if (!(methodName === \\"switchTab\\")) {
+                                _context.next = 75;
+                                break;
+                            }
                             if (!handler.isTabBar) {
-                                _context.next = 54;
+                                _context.next = 72;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 48;
+                                _context.next = 60;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 48:
-                            _prevIndex = stack.getPrevIndex(pathname, 0);
-                            handler.hide(currentPage);
-                            if (!(_prevIndex > -1)) {
-                                _context.next = 52;
+                          case 60:
+                            currentIsTabbar = (_h = handler.tabBarList) === null || _h === void 0 ? void 0 : _h.some((function(t) {
+                                var _a;
+                                return stripTrailing(t.pagePath) === stripTrailing((_a = currentPage === null || currentPage === void 0 ? void 0 : currentPage.path) !== null && _a !== void 0 ? _a : \\"\\");
+                            }));
+                            _prevIndex2 = stack.getPrevIndex(pathname, 0);
+                            if (!currentIsTabbar) {
+                                _context.next = 69;
                                 break;
                             }
-                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
+                            handler.hide(currentPage);
+                            if (!(_prevIndex2 > -1)) {
+                                _context.next = 66;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2));
 
-                          case 52:
-                            _context.next = 55;
+                          case 66:
+                            shouldLoad = true;
+                            _context.next = 70;
                             break;
 
-                          case 54:
-                            if (action === \\"REPLACE\\") {
-                                _delta = stack.getDelta(pathname);
-                                handler.unload(currentPage, _delta);
-                            } else if (action === \\"PUSH\\") {
-                                handler.hide(currentPage);
+                          case 69:
+                            if (_prevIndex2 > -1) {
+                                _delta2 = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta2, _prevIndex2 > -1);
+                                handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2);
+                            } else {
+                                handler.unload(currentPage, stack.length);
+                                shouldLoad = true;
                             }
 
-                          case 55:
+                          case 70:
+                            _context.next = 73;
+                            break;
+
+                          case 72:
+                            return _context.abrupt(\\"return\\", console.error(\\"switchTab:fail can not switch to no-tabBar page\\"));
+
+                          case 73:
+                            _context.next = 78;
+                            break;
+
+                          case 75:
+                            _delta3 = stack.getDelta(pathname);
+                            handler.unload(currentPage, _delta3);
                             shouldLoad = true;
 
-                          case 56:
-                            if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 65;
+                          case 78:
+                            _context.next = 93;
+                            break;
+
+                          case 80:
+                            if (!(action === \\"PUSH\\")) {
+                                _context.next = 93;
                                 break;
                             }
-                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
+                            if (!handler.isTabBar) {
+                                _context.next = 91;
+                                break;
+                            }
+                            if (!handler.isSamePage(currentPage)) {
+                                _context.next = 84;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\");
+
+                          case 84:
+                            _prevIndex3 = stack.getPrevIndex(pathname, 0);
+                            handler.hide(currentPage);
+                            if (!(_prevIndex3 > -1)) {
+                                _context.next = 88;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex3), pageConfig, _prevIndex3));
+
+                          case 88:
+                            shouldLoad = true;
+                            _context.next = 93;
+                            break;
+
+                          case 91:
+                            handler.hide(currentPage);
+                            shouldLoad = true;
+
+                          case 93:
+                            if (!(shouldLoad || stack.length < 1)) {
+                                _context.next = 102;
+                                break;
+                            }
+                            el = (_j = element.default) !== null && _j !== void 0 ? _j : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -4696,7 +4790,7 @@ exports[`config should build from origin and pipe to output 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 65:
+                          case 102:
                           case \\"end\\":
                             return _context.stop();
                         }
@@ -9363,7 +9457,7 @@ I m irrelevant.
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, _j, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, currentIsTabbar, _prevIndex2, _delta2, _delta3, _prevIndex3, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -9439,72 +9533,166 @@ I m irrelevant.
                             shouldLoad = false;
                             stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 41;
+                                _context.next = 45;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
                             delta = stack.getDelta(pathname);
-                            if (currentPage !== stack.getItem(prevIndex)) {
-                                handler.unload(currentPage, delta, prevIndex > -1);
-                                if (prevIndex > -1) {
-                                    handler.show(stack.getItem(prevIndex), pageConfig, prevIndex);
-                                } else {
-                                    shouldLoad = true;
-                                }
-                            }
-                            _context.next = 56;
-                            break;
-
-                          case 41:
-                            if (!(methodName === \\"reLaunch\\")) {
-                                _context.next = 45;
+                            if (!(currentPage !== stack.getItem(prevIndex))) {
+                                _context.next = 43;
                                 break;
                             }
-                            handler.unload(currentPage, stack.length);
-                            _context.next = 55;
+                            handler.unload(currentPage, delta, prevIndex > -1);
+                            if (!(prevIndex > -1)) {
+                                _context.next = 42;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(prevIndex), pageConfig, prevIndex));
+
+                          case 42:
+                            shouldLoad = true;
+
+                          case 43:
+                            _context.next = 93;
                             break;
 
                           case 45:
+                            if (!(action === \\"REPLACE\\")) {
+                                _context.next = 80;
+                                break;
+                            }
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 51;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            shouldLoad = true;
+                            _context.next = 78;
+                            break;
+
+                          case 51:
+                            if (!(methodName === \\"redirectTo\\")) {
+                                _context.next = 56;
+                                break;
+                            }
+                            _prevIndex = stack.getPrevIndex(pathname);
+                            if (handler.isTabBar && _prevIndex > -1) {
+                                _delta = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta + 1);
+                                shouldLoad = true;
+                            } else {
+                                handler.unload(currentPage);
+                                shouldLoad = true;
+                            }
+                            _context.next = 78;
+                            break;
+
+                          case 56:
+                            if (!(methodName === \\"switchTab\\")) {
+                                _context.next = 75;
+                                break;
+                            }
                             if (!handler.isTabBar) {
-                                _context.next = 54;
+                                _context.next = 72;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 48;
+                                _context.next = 60;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 48:
-                            _prevIndex = stack.getPrevIndex(pathname, 0);
-                            handler.hide(currentPage);
-                            if (!(_prevIndex > -1)) {
-                                _context.next = 52;
+                          case 60:
+                            currentIsTabbar = (_h = handler.tabBarList) === null || _h === void 0 ? void 0 : _h.some((function(t) {
+                                var _a;
+                                return stripTrailing(t.pagePath) === stripTrailing((_a = currentPage === null || currentPage === void 0 ? void 0 : currentPage.path) !== null && _a !== void 0 ? _a : \\"\\");
+                            }));
+                            _prevIndex2 = stack.getPrevIndex(pathname, 0);
+                            if (!currentIsTabbar) {
+                                _context.next = 69;
                                 break;
                             }
-                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
+                            handler.hide(currentPage);
+                            if (!(_prevIndex2 > -1)) {
+                                _context.next = 66;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2));
 
-                          case 52:
-                            _context.next = 55;
+                          case 66:
+                            shouldLoad = true;
+                            _context.next = 70;
                             break;
 
-                          case 54:
-                            if (action === \\"REPLACE\\") {
-                                _delta = stack.getDelta(pathname);
-                                handler.unload(currentPage, _delta);
-                            } else if (action === \\"PUSH\\") {
-                                handler.hide(currentPage);
+                          case 69:
+                            if (_prevIndex2 > -1) {
+                                _delta2 = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta2, _prevIndex2 > -1);
+                                handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2);
+                            } else {
+                                handler.unload(currentPage, stack.length);
+                                shouldLoad = true;
                             }
 
-                          case 55:
+                          case 70:
+                            _context.next = 73;
+                            break;
+
+                          case 72:
+                            return _context.abrupt(\\"return\\", console.error(\\"switchTab:fail can not switch to no-tabBar page\\"));
+
+                          case 73:
+                            _context.next = 78;
+                            break;
+
+                          case 75:
+                            _delta3 = stack.getDelta(pathname);
+                            handler.unload(currentPage, _delta3);
                             shouldLoad = true;
 
-                          case 56:
-                            if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 65;
+                          case 78:
+                            _context.next = 93;
+                            break;
+
+                          case 80:
+                            if (!(action === \\"PUSH\\")) {
+                                _context.next = 93;
                                 break;
                             }
-                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
+                            if (!handler.isTabBar) {
+                                _context.next = 91;
+                                break;
+                            }
+                            if (!handler.isSamePage(currentPage)) {
+                                _context.next = 84;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\");
+
+                          case 84:
+                            _prevIndex3 = stack.getPrevIndex(pathname, 0);
+                            handler.hide(currentPage);
+                            if (!(_prevIndex3 > -1)) {
+                                _context.next = 88;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex3), pageConfig, _prevIndex3));
+
+                          case 88:
+                            shouldLoad = true;
+                            _context.next = 93;
+                            break;
+
+                          case 91:
+                            handler.hide(currentPage);
+                            shouldLoad = true;
+
+                          case 93:
+                            if (!(shouldLoad || stack.length < 1)) {
+                                _context.next = 102;
+                                break;
+                            }
+                            el = (_j = element.default) !== null && _j !== void 0 ? _j : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -9513,7 +9701,7 @@ I m irrelevant.
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 65:
+                          case 102:
                           case \\"end\\":
                             return _context.stop();
                         }
@@ -14180,7 +14368,7 @@ exports[`config should resolved alias 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, _j, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, currentIsTabbar, _prevIndex2, _delta2, _delta3, _prevIndex3, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -14256,72 +14444,166 @@ exports[`config should resolved alias 2`] = `
                             shouldLoad = false;
                             stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 41;
+                                _context.next = 45;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
                             delta = stack.getDelta(pathname);
-                            if (currentPage !== stack.getItem(prevIndex)) {
-                                handler.unload(currentPage, delta, prevIndex > -1);
-                                if (prevIndex > -1) {
-                                    handler.show(stack.getItem(prevIndex), pageConfig, prevIndex);
-                                } else {
-                                    shouldLoad = true;
-                                }
-                            }
-                            _context.next = 56;
-                            break;
-
-                          case 41:
-                            if (!(methodName === \\"reLaunch\\")) {
-                                _context.next = 45;
+                            if (!(currentPage !== stack.getItem(prevIndex))) {
+                                _context.next = 43;
                                 break;
                             }
-                            handler.unload(currentPage, stack.length);
-                            _context.next = 55;
+                            handler.unload(currentPage, delta, prevIndex > -1);
+                            if (!(prevIndex > -1)) {
+                                _context.next = 42;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(prevIndex), pageConfig, prevIndex));
+
+                          case 42:
+                            shouldLoad = true;
+
+                          case 43:
+                            _context.next = 93;
                             break;
 
                           case 45:
+                            if (!(action === \\"REPLACE\\")) {
+                                _context.next = 80;
+                                break;
+                            }
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 51;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            shouldLoad = true;
+                            _context.next = 78;
+                            break;
+
+                          case 51:
+                            if (!(methodName === \\"redirectTo\\")) {
+                                _context.next = 56;
+                                break;
+                            }
+                            _prevIndex = stack.getPrevIndex(pathname);
+                            if (handler.isTabBar && _prevIndex > -1) {
+                                _delta = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta + 1);
+                                shouldLoad = true;
+                            } else {
+                                handler.unload(currentPage);
+                                shouldLoad = true;
+                            }
+                            _context.next = 78;
+                            break;
+
+                          case 56:
+                            if (!(methodName === \\"switchTab\\")) {
+                                _context.next = 75;
+                                break;
+                            }
                             if (!handler.isTabBar) {
-                                _context.next = 54;
+                                _context.next = 72;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 48;
+                                _context.next = 60;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 48:
-                            _prevIndex = stack.getPrevIndex(pathname, 0);
-                            handler.hide(currentPage);
-                            if (!(_prevIndex > -1)) {
-                                _context.next = 52;
+                          case 60:
+                            currentIsTabbar = (_h = handler.tabBarList) === null || _h === void 0 ? void 0 : _h.some((function(t) {
+                                var _a;
+                                return stripTrailing(t.pagePath) === stripTrailing((_a = currentPage === null || currentPage === void 0 ? void 0 : currentPage.path) !== null && _a !== void 0 ? _a : \\"\\");
+                            }));
+                            _prevIndex2 = stack.getPrevIndex(pathname, 0);
+                            if (!currentIsTabbar) {
+                                _context.next = 69;
                                 break;
                             }
-                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
+                            handler.hide(currentPage);
+                            if (!(_prevIndex2 > -1)) {
+                                _context.next = 66;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2));
 
-                          case 52:
-                            _context.next = 55;
+                          case 66:
+                            shouldLoad = true;
+                            _context.next = 70;
                             break;
 
-                          case 54:
-                            if (action === \\"REPLACE\\") {
-                                _delta = stack.getDelta(pathname);
-                                handler.unload(currentPage, _delta);
-                            } else if (action === \\"PUSH\\") {
-                                handler.hide(currentPage);
+                          case 69:
+                            if (_prevIndex2 > -1) {
+                                _delta2 = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta2, _prevIndex2 > -1);
+                                handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2);
+                            } else {
+                                handler.unload(currentPage, stack.length);
+                                shouldLoad = true;
                             }
 
-                          case 55:
+                          case 70:
+                            _context.next = 73;
+                            break;
+
+                          case 72:
+                            return _context.abrupt(\\"return\\", console.error(\\"switchTab:fail can not switch to no-tabBar page\\"));
+
+                          case 73:
+                            _context.next = 78;
+                            break;
+
+                          case 75:
+                            _delta3 = stack.getDelta(pathname);
+                            handler.unload(currentPage, _delta3);
                             shouldLoad = true;
 
-                          case 56:
-                            if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 65;
+                          case 78:
+                            _context.next = 93;
+                            break;
+
+                          case 80:
+                            if (!(action === \\"PUSH\\")) {
+                                _context.next = 93;
                                 break;
                             }
-                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
+                            if (!handler.isTabBar) {
+                                _context.next = 91;
+                                break;
+                            }
+                            if (!handler.isSamePage(currentPage)) {
+                                _context.next = 84;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\");
+
+                          case 84:
+                            _prevIndex3 = stack.getPrevIndex(pathname, 0);
+                            handler.hide(currentPage);
+                            if (!(_prevIndex3 > -1)) {
+                                _context.next = 88;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex3), pageConfig, _prevIndex3));
+
+                          case 88:
+                            shouldLoad = true;
+                            _context.next = 93;
+                            break;
+
+                          case 91:
+                            handler.hide(currentPage);
+                            shouldLoad = true;
+
+                          case 93:
+                            if (!(shouldLoad || stack.length < 1)) {
+                                _context.next = 102;
+                                break;
+                            }
+                            el = (_j = element.default) !== null && _j !== void 0 ? _j : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -14330,7 +14612,7 @@ exports[`config should resolved alias 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 65:
+                          case 102:
                           case \\"end\\":
                             return _context.stop();
                         }

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/css-modules.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/css-modules.spec.ts.snap
@@ -4563,7 +4563,7 @@ exports[`css modules should use css modules with global mode 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, _j, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, currentIsTabbar, _prevIndex2, _delta2, _delta3, _prevIndex3, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -4639,72 +4639,166 @@ exports[`css modules should use css modules with global mode 2`] = `
                             shouldLoad = false;
                             stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 41;
+                                _context.next = 45;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
                             delta = stack.getDelta(pathname);
-                            if (currentPage !== stack.getItem(prevIndex)) {
-                                handler.unload(currentPage, delta, prevIndex > -1);
-                                if (prevIndex > -1) {
-                                    handler.show(stack.getItem(prevIndex), pageConfig, prevIndex);
-                                } else {
-                                    shouldLoad = true;
-                                }
-                            }
-                            _context.next = 56;
-                            break;
-
-                          case 41:
-                            if (!(methodName === \\"reLaunch\\")) {
-                                _context.next = 45;
+                            if (!(currentPage !== stack.getItem(prevIndex))) {
+                                _context.next = 43;
                                 break;
                             }
-                            handler.unload(currentPage, stack.length);
-                            _context.next = 55;
+                            handler.unload(currentPage, delta, prevIndex > -1);
+                            if (!(prevIndex > -1)) {
+                                _context.next = 42;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(prevIndex), pageConfig, prevIndex));
+
+                          case 42:
+                            shouldLoad = true;
+
+                          case 43:
+                            _context.next = 93;
                             break;
 
                           case 45:
+                            if (!(action === \\"REPLACE\\")) {
+                                _context.next = 80;
+                                break;
+                            }
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 51;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            shouldLoad = true;
+                            _context.next = 78;
+                            break;
+
+                          case 51:
+                            if (!(methodName === \\"redirectTo\\")) {
+                                _context.next = 56;
+                                break;
+                            }
+                            _prevIndex = stack.getPrevIndex(pathname);
+                            if (handler.isTabBar && _prevIndex > -1) {
+                                _delta = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta + 1);
+                                shouldLoad = true;
+                            } else {
+                                handler.unload(currentPage);
+                                shouldLoad = true;
+                            }
+                            _context.next = 78;
+                            break;
+
+                          case 56:
+                            if (!(methodName === \\"switchTab\\")) {
+                                _context.next = 75;
+                                break;
+                            }
                             if (!handler.isTabBar) {
-                                _context.next = 54;
+                                _context.next = 72;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 48;
+                                _context.next = 60;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 48:
-                            _prevIndex = stack.getPrevIndex(pathname, 0);
-                            handler.hide(currentPage);
-                            if (!(_prevIndex > -1)) {
-                                _context.next = 52;
+                          case 60:
+                            currentIsTabbar = (_h = handler.tabBarList) === null || _h === void 0 ? void 0 : _h.some((function(t) {
+                                var _a;
+                                return stripTrailing(t.pagePath) === stripTrailing((_a = currentPage === null || currentPage === void 0 ? void 0 : currentPage.path) !== null && _a !== void 0 ? _a : \\"\\");
+                            }));
+                            _prevIndex2 = stack.getPrevIndex(pathname, 0);
+                            if (!currentIsTabbar) {
+                                _context.next = 69;
                                 break;
                             }
-                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
+                            handler.hide(currentPage);
+                            if (!(_prevIndex2 > -1)) {
+                                _context.next = 66;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2));
 
-                          case 52:
-                            _context.next = 55;
+                          case 66:
+                            shouldLoad = true;
+                            _context.next = 70;
                             break;
 
-                          case 54:
-                            if (action === \\"REPLACE\\") {
-                                _delta = stack.getDelta(pathname);
-                                handler.unload(currentPage, _delta);
-                            } else if (action === \\"PUSH\\") {
-                                handler.hide(currentPage);
+                          case 69:
+                            if (_prevIndex2 > -1) {
+                                _delta2 = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta2, _prevIndex2 > -1);
+                                handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2);
+                            } else {
+                                handler.unload(currentPage, stack.length);
+                                shouldLoad = true;
                             }
 
-                          case 55:
+                          case 70:
+                            _context.next = 73;
+                            break;
+
+                          case 72:
+                            return _context.abrupt(\\"return\\", console.error(\\"switchTab:fail can not switch to no-tabBar page\\"));
+
+                          case 73:
+                            _context.next = 78;
+                            break;
+
+                          case 75:
+                            _delta3 = stack.getDelta(pathname);
+                            handler.unload(currentPage, _delta3);
                             shouldLoad = true;
 
-                          case 56:
-                            if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 65;
+                          case 78:
+                            _context.next = 93;
+                            break;
+
+                          case 80:
+                            if (!(action === \\"PUSH\\")) {
+                                _context.next = 93;
                                 break;
                             }
-                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
+                            if (!handler.isTabBar) {
+                                _context.next = 91;
+                                break;
+                            }
+                            if (!handler.isSamePage(currentPage)) {
+                                _context.next = 84;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\");
+
+                          case 84:
+                            _prevIndex3 = stack.getPrevIndex(pathname, 0);
+                            handler.hide(currentPage);
+                            if (!(_prevIndex3 > -1)) {
+                                _context.next = 88;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex3), pageConfig, _prevIndex3));
+
+                          case 88:
+                            shouldLoad = true;
+                            _context.next = 93;
+                            break;
+
+                          case 91:
+                            handler.hide(currentPage);
+                            shouldLoad = true;
+
+                          case 93:
+                            if (!(shouldLoad || stack.length < 1)) {
+                                _context.next = 102;
+                                break;
+                            }
+                            el = (_j = element.default) !== null && _j !== void 0 ? _j : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -4713,7 +4807,7 @@ exports[`css modules should use css modules with global mode 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 65:
+                          case 102:
                           case \\"end\\":
                             return _context.stop();
                         }
@@ -9389,7 +9483,7 @@ exports[`css modules should use css modules with module mode 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, _j, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, currentIsTabbar, _prevIndex2, _delta2, _delta3, _prevIndex3, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -9465,72 +9559,166 @@ exports[`css modules should use css modules with module mode 2`] = `
                             shouldLoad = false;
                             stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 41;
+                                _context.next = 45;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
                             delta = stack.getDelta(pathname);
-                            if (currentPage !== stack.getItem(prevIndex)) {
-                                handler.unload(currentPage, delta, prevIndex > -1);
-                                if (prevIndex > -1) {
-                                    handler.show(stack.getItem(prevIndex), pageConfig, prevIndex);
-                                } else {
-                                    shouldLoad = true;
-                                }
-                            }
-                            _context.next = 56;
-                            break;
-
-                          case 41:
-                            if (!(methodName === \\"reLaunch\\")) {
-                                _context.next = 45;
+                            if (!(currentPage !== stack.getItem(prevIndex))) {
+                                _context.next = 43;
                                 break;
                             }
-                            handler.unload(currentPage, stack.length);
-                            _context.next = 55;
+                            handler.unload(currentPage, delta, prevIndex > -1);
+                            if (!(prevIndex > -1)) {
+                                _context.next = 42;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(prevIndex), pageConfig, prevIndex));
+
+                          case 42:
+                            shouldLoad = true;
+
+                          case 43:
+                            _context.next = 93;
                             break;
 
                           case 45:
+                            if (!(action === \\"REPLACE\\")) {
+                                _context.next = 80;
+                                break;
+                            }
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 51;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            shouldLoad = true;
+                            _context.next = 78;
+                            break;
+
+                          case 51:
+                            if (!(methodName === \\"redirectTo\\")) {
+                                _context.next = 56;
+                                break;
+                            }
+                            _prevIndex = stack.getPrevIndex(pathname);
+                            if (handler.isTabBar && _prevIndex > -1) {
+                                _delta = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta + 1);
+                                shouldLoad = true;
+                            } else {
+                                handler.unload(currentPage);
+                                shouldLoad = true;
+                            }
+                            _context.next = 78;
+                            break;
+
+                          case 56:
+                            if (!(methodName === \\"switchTab\\")) {
+                                _context.next = 75;
+                                break;
+                            }
                             if (!handler.isTabBar) {
-                                _context.next = 54;
+                                _context.next = 72;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 48;
+                                _context.next = 60;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 48:
-                            _prevIndex = stack.getPrevIndex(pathname, 0);
-                            handler.hide(currentPage);
-                            if (!(_prevIndex > -1)) {
-                                _context.next = 52;
+                          case 60:
+                            currentIsTabbar = (_h = handler.tabBarList) === null || _h === void 0 ? void 0 : _h.some((function(t) {
+                                var _a;
+                                return stripTrailing(t.pagePath) === stripTrailing((_a = currentPage === null || currentPage === void 0 ? void 0 : currentPage.path) !== null && _a !== void 0 ? _a : \\"\\");
+                            }));
+                            _prevIndex2 = stack.getPrevIndex(pathname, 0);
+                            if (!currentIsTabbar) {
+                                _context.next = 69;
                                 break;
                             }
-                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
+                            handler.hide(currentPage);
+                            if (!(_prevIndex2 > -1)) {
+                                _context.next = 66;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2));
 
-                          case 52:
-                            _context.next = 55;
+                          case 66:
+                            shouldLoad = true;
+                            _context.next = 70;
                             break;
 
-                          case 54:
-                            if (action === \\"REPLACE\\") {
-                                _delta = stack.getDelta(pathname);
-                                handler.unload(currentPage, _delta);
-                            } else if (action === \\"PUSH\\") {
-                                handler.hide(currentPage);
+                          case 69:
+                            if (_prevIndex2 > -1) {
+                                _delta2 = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta2, _prevIndex2 > -1);
+                                handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2);
+                            } else {
+                                handler.unload(currentPage, stack.length);
+                                shouldLoad = true;
                             }
 
-                          case 55:
+                          case 70:
+                            _context.next = 73;
+                            break;
+
+                          case 72:
+                            return _context.abrupt(\\"return\\", console.error(\\"switchTab:fail can not switch to no-tabBar page\\"));
+
+                          case 73:
+                            _context.next = 78;
+                            break;
+
+                          case 75:
+                            _delta3 = stack.getDelta(pathname);
+                            handler.unload(currentPage, _delta3);
                             shouldLoad = true;
 
-                          case 56:
-                            if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 65;
+                          case 78:
+                            _context.next = 93;
+                            break;
+
+                          case 80:
+                            if (!(action === \\"PUSH\\")) {
+                                _context.next = 93;
                                 break;
                             }
-                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
+                            if (!handler.isTabBar) {
+                                _context.next = 91;
+                                break;
+                            }
+                            if (!handler.isSamePage(currentPage)) {
+                                _context.next = 84;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\");
+
+                          case 84:
+                            _prevIndex3 = stack.getPrevIndex(pathname, 0);
+                            handler.hide(currentPage);
+                            if (!(_prevIndex3 > -1)) {
+                                _context.next = 88;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex3), pageConfig, _prevIndex3));
+
+                          case 88:
+                            shouldLoad = true;
+                            _context.next = 93;
+                            break;
+
+                          case 91:
+                            handler.hide(currentPage);
+                            shouldLoad = true;
+
+                          case 93:
+                            if (!(shouldLoad || stack.length < 1)) {
+                                _context.next = 102;
+                                break;
+                            }
+                            el = (_j = element.default) !== null && _j !== void 0 ? _j : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -9539,7 +9727,7 @@ exports[`css modules should use css modules with module mode 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 65:
+                          case 102:
                           case \\"end\\":
                             return _context.stop();
                         }

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/css-modules.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/css-modules.spec.ts.snap
@@ -3276,6 +3276,7 @@ exports[`css modules should use css modules with global mode 2`] = `
             Object(classCallCheck[\\"a\\"])(this, Stacks);
             this.stacks = [];
             this.backDelta = 0;
+            this.methodName = \\"\\";
         }
         Object(createClass[\\"a\\"])(Stacks, [ {
             \\"key\\": \\"delta\\",
@@ -3290,6 +3291,14 @@ exports[`css modules should use css modules with global mode 2`] = `
                 } else {
                     this.backDelta = 0;
                 }
+            }
+        }, {
+            \\"key\\": \\"method\\",
+            \\"get\\": function get() {
+                return this.methodName;
+            },
+            \\"set\\": function set(methodName) {
+                this.methodName = methodName;
             }
         }, {
             \\"key\\": \\"length\\",
@@ -3419,6 +3428,7 @@ exports[`css modules should use css modules with global mode 2`] = `
                                 unListen();
                             }));
                             try {
+                                stack.method = method;
                                 if (\\"url\\" in option) {
                                     var pathPieces = processNavigateUrl(option);
                                     var state = {
@@ -4338,7 +4348,7 @@ exports[`css modules should use css modules with global mode 2`] = `
                 var _a, _b;
                 if (!page) return;
                 stack.push(page);
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var param = this.getQuery(Date.now(), \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
@@ -4397,17 +4407,22 @@ exports[`css modules should use css modules with global mode 2`] = `
                 var _this3 = this;
                 var pageConfig = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
                 var stacksIndex = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
-                var _a, _b;
+                var _a, _b, _c, _d;
                 if (!page) return;
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var index = (_b = (_a = page.path) === null || _a === void 0 ? void 0 : _a.indexOf(\\"?\\")) !== null && _b !== void 0 ? _b : -1;
+                var q = index > -1 ? query_string_default.a.parse(page.path.substring(index), {
+                    \\"decode\\": false
+                }) : {};
+                var stamp = q.stamp ? Number(q.stamp) : undefined;
+                var param = this.getQuery(stamp, \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
                     this.addAnimation(pageEl, stacksIndex === 0);
-                    (_a = page.onShow) === null || _a === void 0 ? void 0 : _a.call(page);
+                    (_c = page.onShow) === null || _c === void 0 ? void 0 : _c.call(page);
                     this.bindPageEvents(page, pageEl, pageConfig);
                 } else {
-                    (_b = page.onLoad) === null || _b === void 0 ? void 0 : _b.call(page, param, (function() {
+                    (_d = page.onLoad) === null || _d === void 0 ? void 0 : _d.call(page, param, (function() {
                         var _a;
                         pageEl = _this3.getPageContainer(page);
                         _this3.addAnimation(pageEl, stacksIndex === 0);
@@ -4548,7 +4563,7 @@ exports[`css modules should use css modules with global mode 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -4620,9 +4635,11 @@ exports[`css modules should use css modules with global mode 2`] = `
                             }
                             currentPage = undefined.page;
                             pathname = handler.pathname;
+                            methodName = (_g = stack.method) !== null && _g !== void 0 ? _g : \\"\\";
                             shouldLoad = false;
+                            stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 39;
+                                _context.next = 41;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
@@ -4635,34 +4652,43 @@ exports[`css modules should use css modules with global mode 2`] = `
                                     shouldLoad = true;
                                 }
                             }
-                            _context.next = 50;
+                            _context.next = 56;
                             break;
 
-                          case 39:
+                          case 41:
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 45;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            _context.next = 55;
+                            break;
+
+                          case 45:
                             if (!handler.isTabBar) {
-                                _context.next = 48;
+                                _context.next = 54;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 42;
+                                _context.next = 48;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 42:
+                          case 48:
                             _prevIndex = stack.getPrevIndex(pathname, 0);
                             handler.hide(currentPage);
                             if (!(_prevIndex > -1)) {
-                                _context.next = 46;
+                                _context.next = 52;
                                 break;
                             }
                             return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
 
-                          case 46:
-                            _context.next = 49;
+                          case 52:
+                            _context.next = 55;
                             break;
 
-                          case 48:
+                          case 54:
                             if (action === \\"REPLACE\\") {
                                 _delta = stack.getDelta(pathname);
                                 handler.unload(currentPage, _delta);
@@ -4670,15 +4696,15 @@ exports[`css modules should use css modules with global mode 2`] = `
                                 handler.hide(currentPage);
                             }
 
-                          case 49:
+                          case 55:
                             shouldLoad = true;
 
-                          case 50:
+                          case 56:
                             if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 59;
+                                _context.next = 65;
                                 break;
                             }
-                            el = (_g = element.default) !== null && _g !== void 0 ? _g : element;
+                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -4687,7 +4713,7 @@ exports[`css modules should use css modules with global mode 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 59:
+                          case 65:
                           case \\"end\\":
                             return _context.stop();
                         }
@@ -8076,6 +8102,7 @@ exports[`css modules should use css modules with module mode 2`] = `
             Object(classCallCheck[\\"a\\"])(this, Stacks);
             this.stacks = [];
             this.backDelta = 0;
+            this.methodName = \\"\\";
         }
         Object(createClass[\\"a\\"])(Stacks, [ {
             \\"key\\": \\"delta\\",
@@ -8090,6 +8117,14 @@ exports[`css modules should use css modules with module mode 2`] = `
                 } else {
                     this.backDelta = 0;
                 }
+            }
+        }, {
+            \\"key\\": \\"method\\",
+            \\"get\\": function get() {
+                return this.methodName;
+            },
+            \\"set\\": function set(methodName) {
+                this.methodName = methodName;
             }
         }, {
             \\"key\\": \\"length\\",
@@ -8219,6 +8254,7 @@ exports[`css modules should use css modules with module mode 2`] = `
                                 unListen();
                             }));
                             try {
+                                stack.method = method;
                                 if (\\"url\\" in option) {
                                     var pathPieces = processNavigateUrl(option);
                                     var state = {
@@ -9138,7 +9174,7 @@ exports[`css modules should use css modules with module mode 2`] = `
                 var _a, _b;
                 if (!page) return;
                 stack.push(page);
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var param = this.getQuery(Date.now(), \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
@@ -9197,17 +9233,22 @@ exports[`css modules should use css modules with module mode 2`] = `
                 var _this3 = this;
                 var pageConfig = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
                 var stacksIndex = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
-                var _a, _b;
+                var _a, _b, _c, _d;
                 if (!page) return;
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var index = (_b = (_a = page.path) === null || _a === void 0 ? void 0 : _a.indexOf(\\"?\\")) !== null && _b !== void 0 ? _b : -1;
+                var q = index > -1 ? query_string_default.a.parse(page.path.substring(index), {
+                    \\"decode\\": false
+                }) : {};
+                var stamp = q.stamp ? Number(q.stamp) : undefined;
+                var param = this.getQuery(stamp, \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
                     this.addAnimation(pageEl, stacksIndex === 0);
-                    (_a = page.onShow) === null || _a === void 0 ? void 0 : _a.call(page);
+                    (_c = page.onShow) === null || _c === void 0 ? void 0 : _c.call(page);
                     this.bindPageEvents(page, pageEl, pageConfig);
                 } else {
-                    (_b = page.onLoad) === null || _b === void 0 ? void 0 : _b.call(page, param, (function() {
+                    (_d = page.onLoad) === null || _d === void 0 ? void 0 : _d.call(page, param, (function() {
                         var _a;
                         pageEl = _this3.getPageContainer(page);
                         _this3.addAnimation(pageEl, stacksIndex === 0);
@@ -9348,7 +9389,7 @@ exports[`css modules should use css modules with module mode 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -9420,9 +9461,11 @@ exports[`css modules should use css modules with module mode 2`] = `
                             }
                             currentPage = undefined.page;
                             pathname = handler.pathname;
+                            methodName = (_g = stack.method) !== null && _g !== void 0 ? _g : \\"\\";
                             shouldLoad = false;
+                            stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 39;
+                                _context.next = 41;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
@@ -9435,34 +9478,43 @@ exports[`css modules should use css modules with module mode 2`] = `
                                     shouldLoad = true;
                                 }
                             }
-                            _context.next = 50;
+                            _context.next = 56;
                             break;
 
-                          case 39:
+                          case 41:
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 45;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            _context.next = 55;
+                            break;
+
+                          case 45:
                             if (!handler.isTabBar) {
-                                _context.next = 48;
+                                _context.next = 54;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 42;
+                                _context.next = 48;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 42:
+                          case 48:
                             _prevIndex = stack.getPrevIndex(pathname, 0);
                             handler.hide(currentPage);
                             if (!(_prevIndex > -1)) {
-                                _context.next = 46;
+                                _context.next = 52;
                                 break;
                             }
                             return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
 
-                          case 46:
-                            _context.next = 49;
+                          case 52:
+                            _context.next = 55;
                             break;
 
-                          case 48:
+                          case 54:
                             if (action === \\"REPLACE\\") {
                                 _delta = stack.getDelta(pathname);
                                 handler.unload(currentPage, _delta);
@@ -9470,15 +9522,15 @@ exports[`css modules should use css modules with module mode 2`] = `
                                 handler.hide(currentPage);
                             }
 
-                          case 49:
+                          case 55:
                             shouldLoad = true;
 
-                          case 50:
+                          case 56:
                             if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 59;
+                                _context.next = 65;
                                 break;
                             }
-                            el = (_g = element.default) !== null && _g !== void 0 ? _g : element;
+                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -9487,7 +9539,7 @@ exports[`css modules should use css modules with module mode 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 59:
+                          case 65:
                           case \\"end\\":
                             return _context.stop();
                         }

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/nerv.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/nerv.spec.ts.snap
@@ -4545,7 +4545,7 @@ exports[`nerv should build nerv app 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, _j, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, currentIsTabbar, _prevIndex2, _delta2, _delta3, _prevIndex3, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -4621,72 +4621,166 @@ exports[`nerv should build nerv app 2`] = `
                             shouldLoad = false;
                             stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 41;
+                                _context.next = 45;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
                             delta = stack.getDelta(pathname);
-                            if (currentPage !== stack.getItem(prevIndex)) {
-                                handler.unload(currentPage, delta, prevIndex > -1);
-                                if (prevIndex > -1) {
-                                    handler.show(stack.getItem(prevIndex), pageConfig, prevIndex);
-                                } else {
-                                    shouldLoad = true;
-                                }
-                            }
-                            _context.next = 56;
-                            break;
-
-                          case 41:
-                            if (!(methodName === \\"reLaunch\\")) {
-                                _context.next = 45;
+                            if (!(currentPage !== stack.getItem(prevIndex))) {
+                                _context.next = 43;
                                 break;
                             }
-                            handler.unload(currentPage, stack.length);
-                            _context.next = 55;
+                            handler.unload(currentPage, delta, prevIndex > -1);
+                            if (!(prevIndex > -1)) {
+                                _context.next = 42;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(prevIndex), pageConfig, prevIndex));
+
+                          case 42:
+                            shouldLoad = true;
+
+                          case 43:
+                            _context.next = 93;
                             break;
 
                           case 45:
+                            if (!(action === \\"REPLACE\\")) {
+                                _context.next = 80;
+                                break;
+                            }
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 51;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            shouldLoad = true;
+                            _context.next = 78;
+                            break;
+
+                          case 51:
+                            if (!(methodName === \\"redirectTo\\")) {
+                                _context.next = 56;
+                                break;
+                            }
+                            _prevIndex = stack.getPrevIndex(pathname);
+                            if (handler.isTabBar && _prevIndex > -1) {
+                                _delta = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta + 1);
+                                shouldLoad = true;
+                            } else {
+                                handler.unload(currentPage);
+                                shouldLoad = true;
+                            }
+                            _context.next = 78;
+                            break;
+
+                          case 56:
+                            if (!(methodName === \\"switchTab\\")) {
+                                _context.next = 75;
+                                break;
+                            }
                             if (!handler.isTabBar) {
-                                _context.next = 54;
+                                _context.next = 72;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 48;
+                                _context.next = 60;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 48:
-                            _prevIndex = stack.getPrevIndex(pathname, 0);
-                            handler.hide(currentPage);
-                            if (!(_prevIndex > -1)) {
-                                _context.next = 52;
+                          case 60:
+                            currentIsTabbar = (_h = handler.tabBarList) === null || _h === void 0 ? void 0 : _h.some((function(t) {
+                                var _a;
+                                return stripTrailing(t.pagePath) === stripTrailing((_a = currentPage === null || currentPage === void 0 ? void 0 : currentPage.path) !== null && _a !== void 0 ? _a : \\"\\");
+                            }));
+                            _prevIndex2 = stack.getPrevIndex(pathname, 0);
+                            if (!currentIsTabbar) {
+                                _context.next = 69;
                                 break;
                             }
-                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
+                            handler.hide(currentPage);
+                            if (!(_prevIndex2 > -1)) {
+                                _context.next = 66;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2));
 
-                          case 52:
-                            _context.next = 55;
+                          case 66:
+                            shouldLoad = true;
+                            _context.next = 70;
                             break;
 
-                          case 54:
-                            if (action === \\"REPLACE\\") {
-                                _delta = stack.getDelta(pathname);
-                                handler.unload(currentPage, _delta);
-                            } else if (action === \\"PUSH\\") {
-                                handler.hide(currentPage);
+                          case 69:
+                            if (_prevIndex2 > -1) {
+                                _delta2 = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta2, _prevIndex2 > -1);
+                                handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2);
+                            } else {
+                                handler.unload(currentPage, stack.length);
+                                shouldLoad = true;
                             }
 
-                          case 55:
+                          case 70:
+                            _context.next = 73;
+                            break;
+
+                          case 72:
+                            return _context.abrupt(\\"return\\", console.error(\\"switchTab:fail can not switch to no-tabBar page\\"));
+
+                          case 73:
+                            _context.next = 78;
+                            break;
+
+                          case 75:
+                            _delta3 = stack.getDelta(pathname);
+                            handler.unload(currentPage, _delta3);
                             shouldLoad = true;
 
-                          case 56:
-                            if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 65;
+                          case 78:
+                            _context.next = 93;
+                            break;
+
+                          case 80:
+                            if (!(action === \\"PUSH\\")) {
+                                _context.next = 93;
                                 break;
                             }
-                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
+                            if (!handler.isTabBar) {
+                                _context.next = 91;
+                                break;
+                            }
+                            if (!handler.isSamePage(currentPage)) {
+                                _context.next = 84;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\");
+
+                          case 84:
+                            _prevIndex3 = stack.getPrevIndex(pathname, 0);
+                            handler.hide(currentPage);
+                            if (!(_prevIndex3 > -1)) {
+                                _context.next = 88;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex3), pageConfig, _prevIndex3));
+
+                          case 88:
+                            shouldLoad = true;
+                            _context.next = 93;
+                            break;
+
+                          case 91:
+                            handler.hide(currentPage);
+                            shouldLoad = true;
+
+                          case 93:
+                            if (!(shouldLoad || stack.length < 1)) {
+                                _context.next = 102;
+                                break;
+                            }
+                            el = (_j = element.default) !== null && _j !== void 0 ? _j : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -4695,7 +4789,7 @@ exports[`nerv should build nerv app 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 65:
+                          case 102:
                           case \\"end\\":
                             return _context.stop();
                         }

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/nerv.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/nerv.spec.ts.snap
@@ -3258,6 +3258,7 @@ exports[`nerv should build nerv app 2`] = `
             Object(classCallCheck[\\"a\\"])(this, Stacks);
             this.stacks = [];
             this.backDelta = 0;
+            this.methodName = \\"\\";
         }
         Object(createClass[\\"a\\"])(Stacks, [ {
             \\"key\\": \\"delta\\",
@@ -3272,6 +3273,14 @@ exports[`nerv should build nerv app 2`] = `
                 } else {
                     this.backDelta = 0;
                 }
+            }
+        }, {
+            \\"key\\": \\"method\\",
+            \\"get\\": function get() {
+                return this.methodName;
+            },
+            \\"set\\": function set(methodName) {
+                this.methodName = methodName;
             }
         }, {
             \\"key\\": \\"length\\",
@@ -3401,6 +3410,7 @@ exports[`nerv should build nerv app 2`] = `
                                 unListen();
                             }));
                             try {
+                                stack.method = method;
                                 if (\\"url\\" in option) {
                                     var pathPieces = processNavigateUrl(option);
                                     var state = {
@@ -4320,7 +4330,7 @@ exports[`nerv should build nerv app 2`] = `
                 var _a, _b;
                 if (!page) return;
                 stack.push(page);
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var param = this.getQuery(Date.now(), \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
@@ -4379,17 +4389,22 @@ exports[`nerv should build nerv app 2`] = `
                 var _this3 = this;
                 var pageConfig = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
                 var stacksIndex = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
-                var _a, _b;
+                var _a, _b, _c, _d;
                 if (!page) return;
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var index = (_b = (_a = page.path) === null || _a === void 0 ? void 0 : _a.indexOf(\\"?\\")) !== null && _b !== void 0 ? _b : -1;
+                var q = index > -1 ? query_string_default.a.parse(page.path.substring(index), {
+                    \\"decode\\": false
+                }) : {};
+                var stamp = q.stamp ? Number(q.stamp) : undefined;
+                var param = this.getQuery(stamp, \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
                     this.addAnimation(pageEl, stacksIndex === 0);
-                    (_a = page.onShow) === null || _a === void 0 ? void 0 : _a.call(page);
+                    (_c = page.onShow) === null || _c === void 0 ? void 0 : _c.call(page);
                     this.bindPageEvents(page, pageEl, pageConfig);
                 } else {
-                    (_b = page.onLoad) === null || _b === void 0 ? void 0 : _b.call(page, param, (function() {
+                    (_d = page.onLoad) === null || _d === void 0 ? void 0 : _d.call(page, param, (function() {
                         var _a;
                         pageEl = _this3.getPageContainer(page);
                         _this3.addAnimation(pageEl, stacksIndex === 0);
@@ -4530,7 +4545,7 @@ exports[`nerv should build nerv app 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -4602,9 +4617,11 @@ exports[`nerv should build nerv app 2`] = `
                             }
                             currentPage = undefined.page;
                             pathname = handler.pathname;
+                            methodName = (_g = stack.method) !== null && _g !== void 0 ? _g : \\"\\";
                             shouldLoad = false;
+                            stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 39;
+                                _context.next = 41;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
@@ -4617,34 +4634,43 @@ exports[`nerv should build nerv app 2`] = `
                                     shouldLoad = true;
                                 }
                             }
-                            _context.next = 50;
+                            _context.next = 56;
                             break;
 
-                          case 39:
+                          case 41:
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 45;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            _context.next = 55;
+                            break;
+
+                          case 45:
                             if (!handler.isTabBar) {
-                                _context.next = 48;
+                                _context.next = 54;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 42;
+                                _context.next = 48;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 42:
+                          case 48:
                             _prevIndex = stack.getPrevIndex(pathname, 0);
                             handler.hide(currentPage);
                             if (!(_prevIndex > -1)) {
-                                _context.next = 46;
+                                _context.next = 52;
                                 break;
                             }
                             return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
 
-                          case 46:
-                            _context.next = 49;
+                          case 52:
+                            _context.next = 55;
                             break;
 
-                          case 48:
+                          case 54:
                             if (action === \\"REPLACE\\") {
                                 _delta = stack.getDelta(pathname);
                                 handler.unload(currentPage, _delta);
@@ -4652,15 +4678,15 @@ exports[`nerv should build nerv app 2`] = `
                                 handler.hide(currentPage);
                             }
 
-                          case 49:
+                          case 55:
                             shouldLoad = true;
 
-                          case 50:
+                          case 56:
                             if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 59;
+                                _context.next = 65;
                                 break;
                             }
-                            el = (_g = element.default) !== null && _g !== void 0 ? _g : element;
+                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -4669,7 +4695,7 @@ exports[`nerv should build nerv app 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 59:
+                          case 65:
                           case \\"end\\":
                             return _context.stop();
                         }

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/react.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/react.spec.ts.snap
@@ -3259,6 +3259,7 @@ exports[`react should build react app 2`] = `
             Object(classCallCheck[\\"a\\"])(this, Stacks);
             this.stacks = [];
             this.backDelta = 0;
+            this.methodName = \\"\\";
         }
         Object(createClass[\\"a\\"])(Stacks, [ {
             \\"key\\": \\"delta\\",
@@ -3273,6 +3274,14 @@ exports[`react should build react app 2`] = `
                 } else {
                     this.backDelta = 0;
                 }
+            }
+        }, {
+            \\"key\\": \\"method\\",
+            \\"get\\": function get() {
+                return this.methodName;
+            },
+            \\"set\\": function set(methodName) {
+                this.methodName = methodName;
             }
         }, {
             \\"key\\": \\"length\\",
@@ -3402,6 +3411,7 @@ exports[`react should build react app 2`] = `
                                 unListen();
                             }));
                             try {
+                                stack.method = method;
                                 if (\\"url\\" in option) {
                                     var pathPieces = processNavigateUrl(option);
                                     var state = {
@@ -4321,7 +4331,7 @@ exports[`react should build react app 2`] = `
                 var _a, _b;
                 if (!page) return;
                 stack.push(page);
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var param = this.getQuery(Date.now(), \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
@@ -4380,17 +4390,22 @@ exports[`react should build react app 2`] = `
                 var _this3 = this;
                 var pageConfig = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
                 var stacksIndex = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
-                var _a, _b;
+                var _a, _b, _c, _d;
                 if (!page) return;
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var index = (_b = (_a = page.path) === null || _a === void 0 ? void 0 : _a.indexOf(\\"?\\")) !== null && _b !== void 0 ? _b : -1;
+                var q = index > -1 ? query_string_default.a.parse(page.path.substring(index), {
+                    \\"decode\\": false
+                }) : {};
+                var stamp = q.stamp ? Number(q.stamp) : undefined;
+                var param = this.getQuery(stamp, \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
                     this.addAnimation(pageEl, stacksIndex === 0);
-                    (_a = page.onShow) === null || _a === void 0 ? void 0 : _a.call(page);
+                    (_c = page.onShow) === null || _c === void 0 ? void 0 : _c.call(page);
                     this.bindPageEvents(page, pageEl, pageConfig);
                 } else {
-                    (_b = page.onLoad) === null || _b === void 0 ? void 0 : _b.call(page, param, (function() {
+                    (_d = page.onLoad) === null || _d === void 0 ? void 0 : _d.call(page, param, (function() {
                         var _a;
                         pageEl = _this3.getPageContainer(page);
                         _this3.addAnimation(pageEl, stacksIndex === 0);
@@ -4531,7 +4546,7 @@ exports[`react should build react app 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -4603,9 +4618,11 @@ exports[`react should build react app 2`] = `
                             }
                             currentPage = undefined.page;
                             pathname = handler.pathname;
+                            methodName = (_g = stack.method) !== null && _g !== void 0 ? _g : \\"\\";
                             shouldLoad = false;
+                            stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 39;
+                                _context.next = 41;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
@@ -4618,34 +4635,43 @@ exports[`react should build react app 2`] = `
                                     shouldLoad = true;
                                 }
                             }
-                            _context.next = 50;
+                            _context.next = 56;
                             break;
 
-                          case 39:
+                          case 41:
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 45;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            _context.next = 55;
+                            break;
+
+                          case 45:
                             if (!handler.isTabBar) {
-                                _context.next = 48;
+                                _context.next = 54;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 42;
+                                _context.next = 48;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 42:
+                          case 48:
                             _prevIndex = stack.getPrevIndex(pathname, 0);
                             handler.hide(currentPage);
                             if (!(_prevIndex > -1)) {
-                                _context.next = 46;
+                                _context.next = 52;
                                 break;
                             }
                             return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
 
-                          case 46:
-                            _context.next = 49;
+                          case 52:
+                            _context.next = 55;
                             break;
 
-                          case 48:
+                          case 54:
                             if (action === \\"REPLACE\\") {
                                 _delta = stack.getDelta(pathname);
                                 handler.unload(currentPage, _delta);
@@ -4653,15 +4679,15 @@ exports[`react should build react app 2`] = `
                                 handler.hide(currentPage);
                             }
 
-                          case 49:
+                          case 55:
                             shouldLoad = true;
 
-                          case 50:
+                          case 56:
                             if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 59;
+                                _context.next = 65;
                                 break;
                             }
-                            el = (_g = element.default) !== null && _g !== void 0 ? _g : element;
+                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -4670,7 +4696,7 @@ exports[`react should build react app 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 59:
+                          case 65:
                           case \\"end\\":
                             return _context.stop();
                         }

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/react.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/react.spec.ts.snap
@@ -4546,7 +4546,7 @@ exports[`react should build react app 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, _j, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, currentIsTabbar, _prevIndex2, _delta2, _delta3, _prevIndex3, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -4622,72 +4622,166 @@ exports[`react should build react app 2`] = `
                             shouldLoad = false;
                             stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 41;
+                                _context.next = 45;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
                             delta = stack.getDelta(pathname);
-                            if (currentPage !== stack.getItem(prevIndex)) {
-                                handler.unload(currentPage, delta, prevIndex > -1);
-                                if (prevIndex > -1) {
-                                    handler.show(stack.getItem(prevIndex), pageConfig, prevIndex);
-                                } else {
-                                    shouldLoad = true;
-                                }
-                            }
-                            _context.next = 56;
-                            break;
-
-                          case 41:
-                            if (!(methodName === \\"reLaunch\\")) {
-                                _context.next = 45;
+                            if (!(currentPage !== stack.getItem(prevIndex))) {
+                                _context.next = 43;
                                 break;
                             }
-                            handler.unload(currentPage, stack.length);
-                            _context.next = 55;
+                            handler.unload(currentPage, delta, prevIndex > -1);
+                            if (!(prevIndex > -1)) {
+                                _context.next = 42;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(prevIndex), pageConfig, prevIndex));
+
+                          case 42:
+                            shouldLoad = true;
+
+                          case 43:
+                            _context.next = 93;
                             break;
 
                           case 45:
+                            if (!(action === \\"REPLACE\\")) {
+                                _context.next = 80;
+                                break;
+                            }
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 51;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            shouldLoad = true;
+                            _context.next = 78;
+                            break;
+
+                          case 51:
+                            if (!(methodName === \\"redirectTo\\")) {
+                                _context.next = 56;
+                                break;
+                            }
+                            _prevIndex = stack.getPrevIndex(pathname);
+                            if (handler.isTabBar && _prevIndex > -1) {
+                                _delta = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta + 1);
+                                shouldLoad = true;
+                            } else {
+                                handler.unload(currentPage);
+                                shouldLoad = true;
+                            }
+                            _context.next = 78;
+                            break;
+
+                          case 56:
+                            if (!(methodName === \\"switchTab\\")) {
+                                _context.next = 75;
+                                break;
+                            }
                             if (!handler.isTabBar) {
-                                _context.next = 54;
+                                _context.next = 72;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 48;
+                                _context.next = 60;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 48:
-                            _prevIndex = stack.getPrevIndex(pathname, 0);
-                            handler.hide(currentPage);
-                            if (!(_prevIndex > -1)) {
-                                _context.next = 52;
+                          case 60:
+                            currentIsTabbar = (_h = handler.tabBarList) === null || _h === void 0 ? void 0 : _h.some((function(t) {
+                                var _a;
+                                return stripTrailing(t.pagePath) === stripTrailing((_a = currentPage === null || currentPage === void 0 ? void 0 : currentPage.path) !== null && _a !== void 0 ? _a : \\"\\");
+                            }));
+                            _prevIndex2 = stack.getPrevIndex(pathname, 0);
+                            if (!currentIsTabbar) {
+                                _context.next = 69;
                                 break;
                             }
-                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
+                            handler.hide(currentPage);
+                            if (!(_prevIndex2 > -1)) {
+                                _context.next = 66;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2));
 
-                          case 52:
-                            _context.next = 55;
+                          case 66:
+                            shouldLoad = true;
+                            _context.next = 70;
                             break;
 
-                          case 54:
-                            if (action === \\"REPLACE\\") {
-                                _delta = stack.getDelta(pathname);
-                                handler.unload(currentPage, _delta);
-                            } else if (action === \\"PUSH\\") {
-                                handler.hide(currentPage);
+                          case 69:
+                            if (_prevIndex2 > -1) {
+                                _delta2 = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta2, _prevIndex2 > -1);
+                                handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2);
+                            } else {
+                                handler.unload(currentPage, stack.length);
+                                shouldLoad = true;
                             }
 
-                          case 55:
+                          case 70:
+                            _context.next = 73;
+                            break;
+
+                          case 72:
+                            return _context.abrupt(\\"return\\", console.error(\\"switchTab:fail can not switch to no-tabBar page\\"));
+
+                          case 73:
+                            _context.next = 78;
+                            break;
+
+                          case 75:
+                            _delta3 = stack.getDelta(pathname);
+                            handler.unload(currentPage, _delta3);
                             shouldLoad = true;
 
-                          case 56:
-                            if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 65;
+                          case 78:
+                            _context.next = 93;
+                            break;
+
+                          case 80:
+                            if (!(action === \\"PUSH\\")) {
+                                _context.next = 93;
                                 break;
                             }
-                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
+                            if (!handler.isTabBar) {
+                                _context.next = 91;
+                                break;
+                            }
+                            if (!handler.isSamePage(currentPage)) {
+                                _context.next = 84;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\");
+
+                          case 84:
+                            _prevIndex3 = stack.getPrevIndex(pathname, 0);
+                            handler.hide(currentPage);
+                            if (!(_prevIndex3 > -1)) {
+                                _context.next = 88;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex3), pageConfig, _prevIndex3));
+
+                          case 88:
+                            shouldLoad = true;
+                            _context.next = 93;
+                            break;
+
+                          case 91:
+                            handler.hide(currentPage);
+                            shouldLoad = true;
+
+                          case 93:
+                            if (!(shouldLoad || stack.length < 1)) {
+                                _context.next = 102;
+                                break;
+                            }
+                            el = (_j = element.default) !== null && _j !== void 0 ? _j : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -4696,7 +4790,7 @@ exports[`react should build react app 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 65:
+                          case 102:
                           case \\"end\\":
                             return _context.stop();
                         }

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/sass.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/sass.spec.ts.snap
@@ -3244,6 +3244,7 @@ exports[`sass should build app with sass 2`] = `
             Object(classCallCheck[\\"a\\"])(this, Stacks);
             this.stacks = [];
             this.backDelta = 0;
+            this.methodName = \\"\\";
         }
         Object(createClass[\\"a\\"])(Stacks, [ {
             \\"key\\": \\"delta\\",
@@ -3258,6 +3259,14 @@ exports[`sass should build app with sass 2`] = `
                 } else {
                     this.backDelta = 0;
                 }
+            }
+        }, {
+            \\"key\\": \\"method\\",
+            \\"get\\": function get() {
+                return this.methodName;
+            },
+            \\"set\\": function set(methodName) {
+                this.methodName = methodName;
             }
         }, {
             \\"key\\": \\"length\\",
@@ -3387,6 +3396,7 @@ exports[`sass should build app with sass 2`] = `
                                 unListen();
                             }));
                             try {
+                                stack.method = method;
                                 if (\\"url\\" in option) {
                                     var pathPieces = processNavigateUrl(option);
                                     var state = {
@@ -4306,7 +4316,7 @@ exports[`sass should build app with sass 2`] = `
                 var _a, _b;
                 if (!page) return;
                 stack.push(page);
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var param = this.getQuery(Date.now(), \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
@@ -4365,17 +4375,22 @@ exports[`sass should build app with sass 2`] = `
                 var _this3 = this;
                 var pageConfig = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
                 var stacksIndex = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
-                var _a, _b;
+                var _a, _b, _c, _d;
                 if (!page) return;
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var index = (_b = (_a = page.path) === null || _a === void 0 ? void 0 : _a.indexOf(\\"?\\")) !== null && _b !== void 0 ? _b : -1;
+                var q = index > -1 ? query_string_default.a.parse(page.path.substring(index), {
+                    \\"decode\\": false
+                }) : {};
+                var stamp = q.stamp ? Number(q.stamp) : undefined;
+                var param = this.getQuery(stamp, \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
                     this.addAnimation(pageEl, stacksIndex === 0);
-                    (_a = page.onShow) === null || _a === void 0 ? void 0 : _a.call(page);
+                    (_c = page.onShow) === null || _c === void 0 ? void 0 : _c.call(page);
                     this.bindPageEvents(page, pageEl, pageConfig);
                 } else {
-                    (_b = page.onLoad) === null || _b === void 0 ? void 0 : _b.call(page, param, (function() {
+                    (_d = page.onLoad) === null || _d === void 0 ? void 0 : _d.call(page, param, (function() {
                         var _a;
                         pageEl = _this3.getPageContainer(page);
                         _this3.addAnimation(pageEl, stacksIndex === 0);
@@ -4516,7 +4531,7 @@ exports[`sass should build app with sass 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -4588,9 +4603,11 @@ exports[`sass should build app with sass 2`] = `
                             }
                             currentPage = undefined.page;
                             pathname = handler.pathname;
+                            methodName = (_g = stack.method) !== null && _g !== void 0 ? _g : \\"\\";
                             shouldLoad = false;
+                            stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 39;
+                                _context.next = 41;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
@@ -4603,34 +4620,43 @@ exports[`sass should build app with sass 2`] = `
                                     shouldLoad = true;
                                 }
                             }
-                            _context.next = 50;
+                            _context.next = 56;
                             break;
 
-                          case 39:
+                          case 41:
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 45;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            _context.next = 55;
+                            break;
+
+                          case 45:
                             if (!handler.isTabBar) {
-                                _context.next = 48;
+                                _context.next = 54;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 42;
+                                _context.next = 48;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 42:
+                          case 48:
                             _prevIndex = stack.getPrevIndex(pathname, 0);
                             handler.hide(currentPage);
                             if (!(_prevIndex > -1)) {
-                                _context.next = 46;
+                                _context.next = 52;
                                 break;
                             }
                             return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
 
-                          case 46:
-                            _context.next = 49;
+                          case 52:
+                            _context.next = 55;
                             break;
 
-                          case 48:
+                          case 54:
                             if (action === \\"REPLACE\\") {
                                 _delta = stack.getDelta(pathname);
                                 handler.unload(currentPage, _delta);
@@ -4638,15 +4664,15 @@ exports[`sass should build app with sass 2`] = `
                                 handler.hide(currentPage);
                             }
 
-                          case 49:
+                          case 55:
                             shouldLoad = true;
 
-                          case 50:
+                          case 56:
                             if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 59;
+                                _context.next = 65;
                                 break;
                             }
-                            el = (_g = element.default) !== null && _g !== void 0 ? _g : element;
+                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -4655,7 +4681,7 @@ exports[`sass should build app with sass 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 59:
+                          case 65:
                           case \\"end\\":
                             return _context.stop();
                         }
@@ -8021,6 +8047,7 @@ exports[`sass should build app with scss 2`] = `
             Object(classCallCheck[\\"a\\"])(this, Stacks);
             this.stacks = [];
             this.backDelta = 0;
+            this.methodName = \\"\\";
         }
         Object(createClass[\\"a\\"])(Stacks, [ {
             \\"key\\": \\"delta\\",
@@ -8035,6 +8062,14 @@ exports[`sass should build app with scss 2`] = `
                 } else {
                     this.backDelta = 0;
                 }
+            }
+        }, {
+            \\"key\\": \\"method\\",
+            \\"get\\": function get() {
+                return this.methodName;
+            },
+            \\"set\\": function set(methodName) {
+                this.methodName = methodName;
             }
         }, {
             \\"key\\": \\"length\\",
@@ -8164,6 +8199,7 @@ exports[`sass should build app with scss 2`] = `
                                 unListen();
                             }));
                             try {
+                                stack.method = method;
                                 if (\\"url\\" in option) {
                                     var pathPieces = processNavigateUrl(option);
                                     var state = {
@@ -9083,7 +9119,7 @@ exports[`sass should build app with scss 2`] = `
                 var _a, _b;
                 if (!page) return;
                 stack.push(page);
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var param = this.getQuery(Date.now(), \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
@@ -9142,17 +9178,22 @@ exports[`sass should build app with scss 2`] = `
                 var _this3 = this;
                 var pageConfig = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
                 var stacksIndex = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
-                var _a, _b;
+                var _a, _b, _c, _d;
                 if (!page) return;
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var index = (_b = (_a = page.path) === null || _a === void 0 ? void 0 : _a.indexOf(\\"?\\")) !== null && _b !== void 0 ? _b : -1;
+                var q = index > -1 ? query_string_default.a.parse(page.path.substring(index), {
+                    \\"decode\\": false
+                }) : {};
+                var stamp = q.stamp ? Number(q.stamp) : undefined;
+                var param = this.getQuery(stamp, \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
                     this.addAnimation(pageEl, stacksIndex === 0);
-                    (_a = page.onShow) === null || _a === void 0 ? void 0 : _a.call(page);
+                    (_c = page.onShow) === null || _c === void 0 ? void 0 : _c.call(page);
                     this.bindPageEvents(page, pageEl, pageConfig);
                 } else {
-                    (_b = page.onLoad) === null || _b === void 0 ? void 0 : _b.call(page, param, (function() {
+                    (_d = page.onLoad) === null || _d === void 0 ? void 0 : _d.call(page, param, (function() {
                         var _a;
                         pageEl = _this3.getPageContainer(page);
                         _this3.addAnimation(pageEl, stacksIndex === 0);
@@ -9293,7 +9334,7 @@ exports[`sass should build app with scss 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -9365,9 +9406,11 @@ exports[`sass should build app with scss 2`] = `
                             }
                             currentPage = undefined.page;
                             pathname = handler.pathname;
+                            methodName = (_g = stack.method) !== null && _g !== void 0 ? _g : \\"\\";
                             shouldLoad = false;
+                            stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 39;
+                                _context.next = 41;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
@@ -9380,34 +9423,43 @@ exports[`sass should build app with scss 2`] = `
                                     shouldLoad = true;
                                 }
                             }
-                            _context.next = 50;
+                            _context.next = 56;
                             break;
 
-                          case 39:
+                          case 41:
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 45;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            _context.next = 55;
+                            break;
+
+                          case 45:
                             if (!handler.isTabBar) {
-                                _context.next = 48;
+                                _context.next = 54;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 42;
+                                _context.next = 48;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 42:
+                          case 48:
                             _prevIndex = stack.getPrevIndex(pathname, 0);
                             handler.hide(currentPage);
                             if (!(_prevIndex > -1)) {
-                                _context.next = 46;
+                                _context.next = 52;
                                 break;
                             }
                             return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
 
-                          case 46:
-                            _context.next = 49;
+                          case 52:
+                            _context.next = 55;
                             break;
 
-                          case 48:
+                          case 54:
                             if (action === \\"REPLACE\\") {
                                 _delta = stack.getDelta(pathname);
                                 handler.unload(currentPage, _delta);
@@ -9415,15 +9467,15 @@ exports[`sass should build app with scss 2`] = `
                                 handler.hide(currentPage);
                             }
 
-                          case 49:
+                          case 55:
                             shouldLoad = true;
 
-                          case 50:
+                          case 56:
                             if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 59;
+                                _context.next = 65;
                                 break;
                             }
-                            el = (_g = element.default) !== null && _g !== void 0 ? _g : element;
+                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -9432,7 +9484,7 @@ exports[`sass should build app with scss 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 59:
+                          case 65:
                           case \\"end\\":
                             return _context.stop();
                         }
@@ -12808,6 +12860,7 @@ exports[`sass should set global sass content with data 2`] = `
             Object(classCallCheck[\\"a\\"])(this, Stacks);
             this.stacks = [];
             this.backDelta = 0;
+            this.methodName = \\"\\";
         }
         Object(createClass[\\"a\\"])(Stacks, [ {
             \\"key\\": \\"delta\\",
@@ -12822,6 +12875,14 @@ exports[`sass should set global sass content with data 2`] = `
                 } else {
                     this.backDelta = 0;
                 }
+            }
+        }, {
+            \\"key\\": \\"method\\",
+            \\"get\\": function get() {
+                return this.methodName;
+            },
+            \\"set\\": function set(methodName) {
+                this.methodName = methodName;
             }
         }, {
             \\"key\\": \\"length\\",
@@ -12951,6 +13012,7 @@ exports[`sass should set global sass content with data 2`] = `
                                 unListen();
                             }));
                             try {
+                                stack.method = method;
                                 if (\\"url\\" in option) {
                                     var pathPieces = processNavigateUrl(option);
                                     var state = {
@@ -13870,7 +13932,7 @@ exports[`sass should set global sass content with data 2`] = `
                 var _a, _b;
                 if (!page) return;
                 stack.push(page);
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var param = this.getQuery(Date.now(), \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
@@ -13929,17 +13991,22 @@ exports[`sass should set global sass content with data 2`] = `
                 var _this3 = this;
                 var pageConfig = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
                 var stacksIndex = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
-                var _a, _b;
+                var _a, _b, _c, _d;
                 if (!page) return;
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var index = (_b = (_a = page.path) === null || _a === void 0 ? void 0 : _a.indexOf(\\"?\\")) !== null && _b !== void 0 ? _b : -1;
+                var q = index > -1 ? query_string_default.a.parse(page.path.substring(index), {
+                    \\"decode\\": false
+                }) : {};
+                var stamp = q.stamp ? Number(q.stamp) : undefined;
+                var param = this.getQuery(stamp, \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
                     this.addAnimation(pageEl, stacksIndex === 0);
-                    (_a = page.onShow) === null || _a === void 0 ? void 0 : _a.call(page);
+                    (_c = page.onShow) === null || _c === void 0 ? void 0 : _c.call(page);
                     this.bindPageEvents(page, pageEl, pageConfig);
                 } else {
-                    (_b = page.onLoad) === null || _b === void 0 ? void 0 : _b.call(page, param, (function() {
+                    (_d = page.onLoad) === null || _d === void 0 ? void 0 : _d.call(page, param, (function() {
                         var _a;
                         pageEl = _this3.getPageContainer(page);
                         _this3.addAnimation(pageEl, stacksIndex === 0);
@@ -14080,7 +14147,7 @@ exports[`sass should set global sass content with data 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -14152,9 +14219,11 @@ exports[`sass should set global sass content with data 2`] = `
                             }
                             currentPage = undefined.page;
                             pathname = handler.pathname;
+                            methodName = (_g = stack.method) !== null && _g !== void 0 ? _g : \\"\\";
                             shouldLoad = false;
+                            stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 39;
+                                _context.next = 41;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
@@ -14167,34 +14236,43 @@ exports[`sass should set global sass content with data 2`] = `
                                     shouldLoad = true;
                                 }
                             }
-                            _context.next = 50;
+                            _context.next = 56;
                             break;
 
-                          case 39:
+                          case 41:
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 45;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            _context.next = 55;
+                            break;
+
+                          case 45:
                             if (!handler.isTabBar) {
-                                _context.next = 48;
+                                _context.next = 54;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 42;
+                                _context.next = 48;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 42:
+                          case 48:
                             _prevIndex = stack.getPrevIndex(pathname, 0);
                             handler.hide(currentPage);
                             if (!(_prevIndex > -1)) {
-                                _context.next = 46;
+                                _context.next = 52;
                                 break;
                             }
                             return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
 
-                          case 46:
-                            _context.next = 49;
+                          case 52:
+                            _context.next = 55;
                             break;
 
-                          case 48:
+                          case 54:
                             if (action === \\"REPLACE\\") {
                                 _delta = stack.getDelta(pathname);
                                 handler.unload(currentPage, _delta);
@@ -14202,15 +14280,15 @@ exports[`sass should set global sass content with data 2`] = `
                                 handler.hide(currentPage);
                             }
 
-                          case 49:
+                          case 55:
                             shouldLoad = true;
 
-                          case 50:
+                          case 56:
                             if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 59;
+                                _context.next = 65;
                                 break;
                             }
-                            el = (_g = element.default) !== null && _g !== void 0 ? _g : element;
+                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -14219,7 +14297,7 @@ exports[`sass should set global sass content with data 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 59:
+                          case 65:
                           case \\"end\\":
                             return _context.stop();
                         }
@@ -17595,6 +17673,7 @@ exports[`sass should set global sass content with source & dir 2`] = `
             Object(classCallCheck[\\"a\\"])(this, Stacks);
             this.stacks = [];
             this.backDelta = 0;
+            this.methodName = \\"\\";
         }
         Object(createClass[\\"a\\"])(Stacks, [ {
             \\"key\\": \\"delta\\",
@@ -17609,6 +17688,14 @@ exports[`sass should set global sass content with source & dir 2`] = `
                 } else {
                     this.backDelta = 0;
                 }
+            }
+        }, {
+            \\"key\\": \\"method\\",
+            \\"get\\": function get() {
+                return this.methodName;
+            },
+            \\"set\\": function set(methodName) {
+                this.methodName = methodName;
             }
         }, {
             \\"key\\": \\"length\\",
@@ -17738,6 +17825,7 @@ exports[`sass should set global sass content with source & dir 2`] = `
                                 unListen();
                             }));
                             try {
+                                stack.method = method;
                                 if (\\"url\\" in option) {
                                     var pathPieces = processNavigateUrl(option);
                                     var state = {
@@ -18657,7 +18745,7 @@ exports[`sass should set global sass content with source & dir 2`] = `
                 var _a, _b;
                 if (!page) return;
                 stack.push(page);
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var param = this.getQuery(Date.now(), \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
@@ -18716,17 +18804,22 @@ exports[`sass should set global sass content with source & dir 2`] = `
                 var _this3 = this;
                 var pageConfig = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
                 var stacksIndex = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
-                var _a, _b;
+                var _a, _b, _c, _d;
                 if (!page) return;
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var index = (_b = (_a = page.path) === null || _a === void 0 ? void 0 : _a.indexOf(\\"?\\")) !== null && _b !== void 0 ? _b : -1;
+                var q = index > -1 ? query_string_default.a.parse(page.path.substring(index), {
+                    \\"decode\\": false
+                }) : {};
+                var stamp = q.stamp ? Number(q.stamp) : undefined;
+                var param = this.getQuery(stamp, \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
                     this.addAnimation(pageEl, stacksIndex === 0);
-                    (_a = page.onShow) === null || _a === void 0 ? void 0 : _a.call(page);
+                    (_c = page.onShow) === null || _c === void 0 ? void 0 : _c.call(page);
                     this.bindPageEvents(page, pageEl, pageConfig);
                 } else {
-                    (_b = page.onLoad) === null || _b === void 0 ? void 0 : _b.call(page, param, (function() {
+                    (_d = page.onLoad) === null || _d === void 0 ? void 0 : _d.call(page, param, (function() {
                         var _a;
                         pageEl = _this3.getPageContainer(page);
                         _this3.addAnimation(pageEl, stacksIndex === 0);
@@ -18867,7 +18960,7 @@ exports[`sass should set global sass content with source & dir 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -18939,9 +19032,11 @@ exports[`sass should set global sass content with source & dir 2`] = `
                             }
                             currentPage = undefined.page;
                             pathname = handler.pathname;
+                            methodName = (_g = stack.method) !== null && _g !== void 0 ? _g : \\"\\";
                             shouldLoad = false;
+                            stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 39;
+                                _context.next = 41;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
@@ -18954,34 +19049,43 @@ exports[`sass should set global sass content with source & dir 2`] = `
                                     shouldLoad = true;
                                 }
                             }
-                            _context.next = 50;
+                            _context.next = 56;
                             break;
 
-                          case 39:
+                          case 41:
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 45;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            _context.next = 55;
+                            break;
+
+                          case 45:
                             if (!handler.isTabBar) {
-                                _context.next = 48;
+                                _context.next = 54;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 42;
+                                _context.next = 48;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 42:
+                          case 48:
                             _prevIndex = stack.getPrevIndex(pathname, 0);
                             handler.hide(currentPage);
                             if (!(_prevIndex > -1)) {
-                                _context.next = 46;
+                                _context.next = 52;
                                 break;
                             }
                             return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
 
-                          case 46:
-                            _context.next = 49;
+                          case 52:
+                            _context.next = 55;
                             break;
 
-                          case 48:
+                          case 54:
                             if (action === \\"REPLACE\\") {
                                 _delta = stack.getDelta(pathname);
                                 handler.unload(currentPage, _delta);
@@ -18989,15 +19093,15 @@ exports[`sass should set global sass content with source & dir 2`] = `
                                 handler.hide(currentPage);
                             }
 
-                          case 49:
+                          case 55:
                             shouldLoad = true;
 
-                          case 50:
+                          case 56:
                             if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 59;
+                                _context.next = 65;
                                 break;
                             }
-                            el = (_g = element.default) !== null && _g !== void 0 ? _g : element;
+                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -19006,7 +19110,7 @@ exports[`sass should set global sass content with source & dir 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 59:
+                          case 65:
                           case \\"end\\":
                             return _context.stop();
                         }
@@ -22382,6 +22486,7 @@ exports[`sass should set global sass content with source 2`] = `
             Object(classCallCheck[\\"a\\"])(this, Stacks);
             this.stacks = [];
             this.backDelta = 0;
+            this.methodName = \\"\\";
         }
         Object(createClass[\\"a\\"])(Stacks, [ {
             \\"key\\": \\"delta\\",
@@ -22396,6 +22501,14 @@ exports[`sass should set global sass content with source 2`] = `
                 } else {
                     this.backDelta = 0;
                 }
+            }
+        }, {
+            \\"key\\": \\"method\\",
+            \\"get\\": function get() {
+                return this.methodName;
+            },
+            \\"set\\": function set(methodName) {
+                this.methodName = methodName;
             }
         }, {
             \\"key\\": \\"length\\",
@@ -22525,6 +22638,7 @@ exports[`sass should set global sass content with source 2`] = `
                                 unListen();
                             }));
                             try {
+                                stack.method = method;
                                 if (\\"url\\" in option) {
                                     var pathPieces = processNavigateUrl(option);
                                     var state = {
@@ -23444,7 +23558,7 @@ exports[`sass should set global sass content with source 2`] = `
                 var _a, _b;
                 if (!page) return;
                 stack.push(page);
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var param = this.getQuery(Date.now(), \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
@@ -23503,17 +23617,22 @@ exports[`sass should set global sass content with source 2`] = `
                 var _this3 = this;
                 var pageConfig = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
                 var stacksIndex = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
-                var _a, _b;
+                var _a, _b, _c, _d;
                 if (!page) return;
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var index = (_b = (_a = page.path) === null || _a === void 0 ? void 0 : _a.indexOf(\\"?\\")) !== null && _b !== void 0 ? _b : -1;
+                var q = index > -1 ? query_string_default.a.parse(page.path.substring(index), {
+                    \\"decode\\": false
+                }) : {};
+                var stamp = q.stamp ? Number(q.stamp) : undefined;
+                var param = this.getQuery(stamp, \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
                     this.addAnimation(pageEl, stacksIndex === 0);
-                    (_a = page.onShow) === null || _a === void 0 ? void 0 : _a.call(page);
+                    (_c = page.onShow) === null || _c === void 0 ? void 0 : _c.call(page);
                     this.bindPageEvents(page, pageEl, pageConfig);
                 } else {
-                    (_b = page.onLoad) === null || _b === void 0 ? void 0 : _b.call(page, param, (function() {
+                    (_d = page.onLoad) === null || _d === void 0 ? void 0 : _d.call(page, param, (function() {
                         var _a;
                         pageEl = _this3.getPageContainer(page);
                         _this3.addAnimation(pageEl, stacksIndex === 0);
@@ -23654,7 +23773,7 @@ exports[`sass should set global sass content with source 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -23726,9 +23845,11 @@ exports[`sass should set global sass content with source 2`] = `
                             }
                             currentPage = undefined.page;
                             pathname = handler.pathname;
+                            methodName = (_g = stack.method) !== null && _g !== void 0 ? _g : \\"\\";
                             shouldLoad = false;
+                            stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 39;
+                                _context.next = 41;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
@@ -23741,34 +23862,43 @@ exports[`sass should set global sass content with source 2`] = `
                                     shouldLoad = true;
                                 }
                             }
-                            _context.next = 50;
+                            _context.next = 56;
                             break;
 
-                          case 39:
+                          case 41:
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 45;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            _context.next = 55;
+                            break;
+
+                          case 45:
                             if (!handler.isTabBar) {
-                                _context.next = 48;
+                                _context.next = 54;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 42;
+                                _context.next = 48;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 42:
+                          case 48:
                             _prevIndex = stack.getPrevIndex(pathname, 0);
                             handler.hide(currentPage);
                             if (!(_prevIndex > -1)) {
-                                _context.next = 46;
+                                _context.next = 52;
                                 break;
                             }
                             return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
 
-                          case 46:
-                            _context.next = 49;
+                          case 52:
+                            _context.next = 55;
                             break;
 
-                          case 48:
+                          case 54:
                             if (action === \\"REPLACE\\") {
                                 _delta = stack.getDelta(pathname);
                                 handler.unload(currentPage, _delta);
@@ -23776,15 +23906,15 @@ exports[`sass should set global sass content with source 2`] = `
                                 handler.hide(currentPage);
                             }
 
-                          case 49:
+                          case 55:
                             shouldLoad = true;
 
-                          case 50:
+                          case 56:
                             if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 59;
+                                _context.next = 65;
                                 break;
                             }
-                            el = (_g = element.default) !== null && _g !== void 0 ? _g : element;
+                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -23793,7 +23923,7 @@ exports[`sass should set global sass content with source 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 59:
+                          case 65:
                           case \\"end\\":
                             return _context.stop();
                         }

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/sass.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/sass.spec.ts.snap
@@ -4531,7 +4531,7 @@ exports[`sass should build app with sass 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, _j, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, currentIsTabbar, _prevIndex2, _delta2, _delta3, _prevIndex3, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -4607,72 +4607,166 @@ exports[`sass should build app with sass 2`] = `
                             shouldLoad = false;
                             stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 41;
+                                _context.next = 45;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
                             delta = stack.getDelta(pathname);
-                            if (currentPage !== stack.getItem(prevIndex)) {
-                                handler.unload(currentPage, delta, prevIndex > -1);
-                                if (prevIndex > -1) {
-                                    handler.show(stack.getItem(prevIndex), pageConfig, prevIndex);
-                                } else {
-                                    shouldLoad = true;
-                                }
-                            }
-                            _context.next = 56;
-                            break;
-
-                          case 41:
-                            if (!(methodName === \\"reLaunch\\")) {
-                                _context.next = 45;
+                            if (!(currentPage !== stack.getItem(prevIndex))) {
+                                _context.next = 43;
                                 break;
                             }
-                            handler.unload(currentPage, stack.length);
-                            _context.next = 55;
+                            handler.unload(currentPage, delta, prevIndex > -1);
+                            if (!(prevIndex > -1)) {
+                                _context.next = 42;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(prevIndex), pageConfig, prevIndex));
+
+                          case 42:
+                            shouldLoad = true;
+
+                          case 43:
+                            _context.next = 93;
                             break;
 
                           case 45:
+                            if (!(action === \\"REPLACE\\")) {
+                                _context.next = 80;
+                                break;
+                            }
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 51;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            shouldLoad = true;
+                            _context.next = 78;
+                            break;
+
+                          case 51:
+                            if (!(methodName === \\"redirectTo\\")) {
+                                _context.next = 56;
+                                break;
+                            }
+                            _prevIndex = stack.getPrevIndex(pathname);
+                            if (handler.isTabBar && _prevIndex > -1) {
+                                _delta = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta + 1);
+                                shouldLoad = true;
+                            } else {
+                                handler.unload(currentPage);
+                                shouldLoad = true;
+                            }
+                            _context.next = 78;
+                            break;
+
+                          case 56:
+                            if (!(methodName === \\"switchTab\\")) {
+                                _context.next = 75;
+                                break;
+                            }
                             if (!handler.isTabBar) {
-                                _context.next = 54;
+                                _context.next = 72;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 48;
+                                _context.next = 60;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 48:
-                            _prevIndex = stack.getPrevIndex(pathname, 0);
-                            handler.hide(currentPage);
-                            if (!(_prevIndex > -1)) {
-                                _context.next = 52;
+                          case 60:
+                            currentIsTabbar = (_h = handler.tabBarList) === null || _h === void 0 ? void 0 : _h.some((function(t) {
+                                var _a;
+                                return stripTrailing(t.pagePath) === stripTrailing((_a = currentPage === null || currentPage === void 0 ? void 0 : currentPage.path) !== null && _a !== void 0 ? _a : \\"\\");
+                            }));
+                            _prevIndex2 = stack.getPrevIndex(pathname, 0);
+                            if (!currentIsTabbar) {
+                                _context.next = 69;
                                 break;
                             }
-                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
+                            handler.hide(currentPage);
+                            if (!(_prevIndex2 > -1)) {
+                                _context.next = 66;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2));
 
-                          case 52:
-                            _context.next = 55;
+                          case 66:
+                            shouldLoad = true;
+                            _context.next = 70;
                             break;
 
-                          case 54:
-                            if (action === \\"REPLACE\\") {
-                                _delta = stack.getDelta(pathname);
-                                handler.unload(currentPage, _delta);
-                            } else if (action === \\"PUSH\\") {
-                                handler.hide(currentPage);
+                          case 69:
+                            if (_prevIndex2 > -1) {
+                                _delta2 = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta2, _prevIndex2 > -1);
+                                handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2);
+                            } else {
+                                handler.unload(currentPage, stack.length);
+                                shouldLoad = true;
                             }
 
-                          case 55:
+                          case 70:
+                            _context.next = 73;
+                            break;
+
+                          case 72:
+                            return _context.abrupt(\\"return\\", console.error(\\"switchTab:fail can not switch to no-tabBar page\\"));
+
+                          case 73:
+                            _context.next = 78;
+                            break;
+
+                          case 75:
+                            _delta3 = stack.getDelta(pathname);
+                            handler.unload(currentPage, _delta3);
                             shouldLoad = true;
 
-                          case 56:
-                            if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 65;
+                          case 78:
+                            _context.next = 93;
+                            break;
+
+                          case 80:
+                            if (!(action === \\"PUSH\\")) {
+                                _context.next = 93;
                                 break;
                             }
-                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
+                            if (!handler.isTabBar) {
+                                _context.next = 91;
+                                break;
+                            }
+                            if (!handler.isSamePage(currentPage)) {
+                                _context.next = 84;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\");
+
+                          case 84:
+                            _prevIndex3 = stack.getPrevIndex(pathname, 0);
+                            handler.hide(currentPage);
+                            if (!(_prevIndex3 > -1)) {
+                                _context.next = 88;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex3), pageConfig, _prevIndex3));
+
+                          case 88:
+                            shouldLoad = true;
+                            _context.next = 93;
+                            break;
+
+                          case 91:
+                            handler.hide(currentPage);
+                            shouldLoad = true;
+
+                          case 93:
+                            if (!(shouldLoad || stack.length < 1)) {
+                                _context.next = 102;
+                                break;
+                            }
+                            el = (_j = element.default) !== null && _j !== void 0 ? _j : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -4681,7 +4775,7 @@ exports[`sass should build app with sass 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 65:
+                          case 102:
                           case \\"end\\":
                             return _context.stop();
                         }
@@ -9334,7 +9428,7 @@ exports[`sass should build app with scss 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, _j, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, currentIsTabbar, _prevIndex2, _delta2, _delta3, _prevIndex3, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -9410,72 +9504,166 @@ exports[`sass should build app with scss 2`] = `
                             shouldLoad = false;
                             stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 41;
+                                _context.next = 45;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
                             delta = stack.getDelta(pathname);
-                            if (currentPage !== stack.getItem(prevIndex)) {
-                                handler.unload(currentPage, delta, prevIndex > -1);
-                                if (prevIndex > -1) {
-                                    handler.show(stack.getItem(prevIndex), pageConfig, prevIndex);
-                                } else {
-                                    shouldLoad = true;
-                                }
-                            }
-                            _context.next = 56;
-                            break;
-
-                          case 41:
-                            if (!(methodName === \\"reLaunch\\")) {
-                                _context.next = 45;
+                            if (!(currentPage !== stack.getItem(prevIndex))) {
+                                _context.next = 43;
                                 break;
                             }
-                            handler.unload(currentPage, stack.length);
-                            _context.next = 55;
+                            handler.unload(currentPage, delta, prevIndex > -1);
+                            if (!(prevIndex > -1)) {
+                                _context.next = 42;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(prevIndex), pageConfig, prevIndex));
+
+                          case 42:
+                            shouldLoad = true;
+
+                          case 43:
+                            _context.next = 93;
                             break;
 
                           case 45:
+                            if (!(action === \\"REPLACE\\")) {
+                                _context.next = 80;
+                                break;
+                            }
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 51;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            shouldLoad = true;
+                            _context.next = 78;
+                            break;
+
+                          case 51:
+                            if (!(methodName === \\"redirectTo\\")) {
+                                _context.next = 56;
+                                break;
+                            }
+                            _prevIndex = stack.getPrevIndex(pathname);
+                            if (handler.isTabBar && _prevIndex > -1) {
+                                _delta = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta + 1);
+                                shouldLoad = true;
+                            } else {
+                                handler.unload(currentPage);
+                                shouldLoad = true;
+                            }
+                            _context.next = 78;
+                            break;
+
+                          case 56:
+                            if (!(methodName === \\"switchTab\\")) {
+                                _context.next = 75;
+                                break;
+                            }
                             if (!handler.isTabBar) {
-                                _context.next = 54;
+                                _context.next = 72;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 48;
+                                _context.next = 60;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 48:
-                            _prevIndex = stack.getPrevIndex(pathname, 0);
-                            handler.hide(currentPage);
-                            if (!(_prevIndex > -1)) {
-                                _context.next = 52;
+                          case 60:
+                            currentIsTabbar = (_h = handler.tabBarList) === null || _h === void 0 ? void 0 : _h.some((function(t) {
+                                var _a;
+                                return stripTrailing(t.pagePath) === stripTrailing((_a = currentPage === null || currentPage === void 0 ? void 0 : currentPage.path) !== null && _a !== void 0 ? _a : \\"\\");
+                            }));
+                            _prevIndex2 = stack.getPrevIndex(pathname, 0);
+                            if (!currentIsTabbar) {
+                                _context.next = 69;
                                 break;
                             }
-                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
+                            handler.hide(currentPage);
+                            if (!(_prevIndex2 > -1)) {
+                                _context.next = 66;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2));
 
-                          case 52:
-                            _context.next = 55;
+                          case 66:
+                            shouldLoad = true;
+                            _context.next = 70;
                             break;
 
-                          case 54:
-                            if (action === \\"REPLACE\\") {
-                                _delta = stack.getDelta(pathname);
-                                handler.unload(currentPage, _delta);
-                            } else if (action === \\"PUSH\\") {
-                                handler.hide(currentPage);
+                          case 69:
+                            if (_prevIndex2 > -1) {
+                                _delta2 = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta2, _prevIndex2 > -1);
+                                handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2);
+                            } else {
+                                handler.unload(currentPage, stack.length);
+                                shouldLoad = true;
                             }
 
-                          case 55:
+                          case 70:
+                            _context.next = 73;
+                            break;
+
+                          case 72:
+                            return _context.abrupt(\\"return\\", console.error(\\"switchTab:fail can not switch to no-tabBar page\\"));
+
+                          case 73:
+                            _context.next = 78;
+                            break;
+
+                          case 75:
+                            _delta3 = stack.getDelta(pathname);
+                            handler.unload(currentPage, _delta3);
                             shouldLoad = true;
 
-                          case 56:
-                            if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 65;
+                          case 78:
+                            _context.next = 93;
+                            break;
+
+                          case 80:
+                            if (!(action === \\"PUSH\\")) {
+                                _context.next = 93;
                                 break;
                             }
-                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
+                            if (!handler.isTabBar) {
+                                _context.next = 91;
+                                break;
+                            }
+                            if (!handler.isSamePage(currentPage)) {
+                                _context.next = 84;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\");
+
+                          case 84:
+                            _prevIndex3 = stack.getPrevIndex(pathname, 0);
+                            handler.hide(currentPage);
+                            if (!(_prevIndex3 > -1)) {
+                                _context.next = 88;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex3), pageConfig, _prevIndex3));
+
+                          case 88:
+                            shouldLoad = true;
+                            _context.next = 93;
+                            break;
+
+                          case 91:
+                            handler.hide(currentPage);
+                            shouldLoad = true;
+
+                          case 93:
+                            if (!(shouldLoad || stack.length < 1)) {
+                                _context.next = 102;
+                                break;
+                            }
+                            el = (_j = element.default) !== null && _j !== void 0 ? _j : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -9484,7 +9672,7 @@ exports[`sass should build app with scss 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 65:
+                          case 102:
                           case \\"end\\":
                             return _context.stop();
                         }
@@ -14147,7 +14335,7 @@ exports[`sass should set global sass content with data 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, _j, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, currentIsTabbar, _prevIndex2, _delta2, _delta3, _prevIndex3, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -14223,72 +14411,166 @@ exports[`sass should set global sass content with data 2`] = `
                             shouldLoad = false;
                             stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 41;
+                                _context.next = 45;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
                             delta = stack.getDelta(pathname);
-                            if (currentPage !== stack.getItem(prevIndex)) {
-                                handler.unload(currentPage, delta, prevIndex > -1);
-                                if (prevIndex > -1) {
-                                    handler.show(stack.getItem(prevIndex), pageConfig, prevIndex);
-                                } else {
-                                    shouldLoad = true;
-                                }
-                            }
-                            _context.next = 56;
-                            break;
-
-                          case 41:
-                            if (!(methodName === \\"reLaunch\\")) {
-                                _context.next = 45;
+                            if (!(currentPage !== stack.getItem(prevIndex))) {
+                                _context.next = 43;
                                 break;
                             }
-                            handler.unload(currentPage, stack.length);
-                            _context.next = 55;
+                            handler.unload(currentPage, delta, prevIndex > -1);
+                            if (!(prevIndex > -1)) {
+                                _context.next = 42;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(prevIndex), pageConfig, prevIndex));
+
+                          case 42:
+                            shouldLoad = true;
+
+                          case 43:
+                            _context.next = 93;
                             break;
 
                           case 45:
+                            if (!(action === \\"REPLACE\\")) {
+                                _context.next = 80;
+                                break;
+                            }
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 51;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            shouldLoad = true;
+                            _context.next = 78;
+                            break;
+
+                          case 51:
+                            if (!(methodName === \\"redirectTo\\")) {
+                                _context.next = 56;
+                                break;
+                            }
+                            _prevIndex = stack.getPrevIndex(pathname);
+                            if (handler.isTabBar && _prevIndex > -1) {
+                                _delta = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta + 1);
+                                shouldLoad = true;
+                            } else {
+                                handler.unload(currentPage);
+                                shouldLoad = true;
+                            }
+                            _context.next = 78;
+                            break;
+
+                          case 56:
+                            if (!(methodName === \\"switchTab\\")) {
+                                _context.next = 75;
+                                break;
+                            }
                             if (!handler.isTabBar) {
-                                _context.next = 54;
+                                _context.next = 72;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 48;
+                                _context.next = 60;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 48:
-                            _prevIndex = stack.getPrevIndex(pathname, 0);
-                            handler.hide(currentPage);
-                            if (!(_prevIndex > -1)) {
-                                _context.next = 52;
+                          case 60:
+                            currentIsTabbar = (_h = handler.tabBarList) === null || _h === void 0 ? void 0 : _h.some((function(t) {
+                                var _a;
+                                return stripTrailing(t.pagePath) === stripTrailing((_a = currentPage === null || currentPage === void 0 ? void 0 : currentPage.path) !== null && _a !== void 0 ? _a : \\"\\");
+                            }));
+                            _prevIndex2 = stack.getPrevIndex(pathname, 0);
+                            if (!currentIsTabbar) {
+                                _context.next = 69;
                                 break;
                             }
-                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
+                            handler.hide(currentPage);
+                            if (!(_prevIndex2 > -1)) {
+                                _context.next = 66;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2));
 
-                          case 52:
-                            _context.next = 55;
+                          case 66:
+                            shouldLoad = true;
+                            _context.next = 70;
                             break;
 
-                          case 54:
-                            if (action === \\"REPLACE\\") {
-                                _delta = stack.getDelta(pathname);
-                                handler.unload(currentPage, _delta);
-                            } else if (action === \\"PUSH\\") {
-                                handler.hide(currentPage);
+                          case 69:
+                            if (_prevIndex2 > -1) {
+                                _delta2 = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta2, _prevIndex2 > -1);
+                                handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2);
+                            } else {
+                                handler.unload(currentPage, stack.length);
+                                shouldLoad = true;
                             }
 
-                          case 55:
+                          case 70:
+                            _context.next = 73;
+                            break;
+
+                          case 72:
+                            return _context.abrupt(\\"return\\", console.error(\\"switchTab:fail can not switch to no-tabBar page\\"));
+
+                          case 73:
+                            _context.next = 78;
+                            break;
+
+                          case 75:
+                            _delta3 = stack.getDelta(pathname);
+                            handler.unload(currentPage, _delta3);
                             shouldLoad = true;
 
-                          case 56:
-                            if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 65;
+                          case 78:
+                            _context.next = 93;
+                            break;
+
+                          case 80:
+                            if (!(action === \\"PUSH\\")) {
+                                _context.next = 93;
                                 break;
                             }
-                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
+                            if (!handler.isTabBar) {
+                                _context.next = 91;
+                                break;
+                            }
+                            if (!handler.isSamePage(currentPage)) {
+                                _context.next = 84;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\");
+
+                          case 84:
+                            _prevIndex3 = stack.getPrevIndex(pathname, 0);
+                            handler.hide(currentPage);
+                            if (!(_prevIndex3 > -1)) {
+                                _context.next = 88;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex3), pageConfig, _prevIndex3));
+
+                          case 88:
+                            shouldLoad = true;
+                            _context.next = 93;
+                            break;
+
+                          case 91:
+                            handler.hide(currentPage);
+                            shouldLoad = true;
+
+                          case 93:
+                            if (!(shouldLoad || stack.length < 1)) {
+                                _context.next = 102;
+                                break;
+                            }
+                            el = (_j = element.default) !== null && _j !== void 0 ? _j : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -14297,7 +14579,7 @@ exports[`sass should set global sass content with data 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 65:
+                          case 102:
                           case \\"end\\":
                             return _context.stop();
                         }
@@ -18960,7 +19242,7 @@ exports[`sass should set global sass content with source & dir 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, _j, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, currentIsTabbar, _prevIndex2, _delta2, _delta3, _prevIndex3, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -19036,72 +19318,166 @@ exports[`sass should set global sass content with source & dir 2`] = `
                             shouldLoad = false;
                             stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 41;
+                                _context.next = 45;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
                             delta = stack.getDelta(pathname);
-                            if (currentPage !== stack.getItem(prevIndex)) {
-                                handler.unload(currentPage, delta, prevIndex > -1);
-                                if (prevIndex > -1) {
-                                    handler.show(stack.getItem(prevIndex), pageConfig, prevIndex);
-                                } else {
-                                    shouldLoad = true;
-                                }
-                            }
-                            _context.next = 56;
-                            break;
-
-                          case 41:
-                            if (!(methodName === \\"reLaunch\\")) {
-                                _context.next = 45;
+                            if (!(currentPage !== stack.getItem(prevIndex))) {
+                                _context.next = 43;
                                 break;
                             }
-                            handler.unload(currentPage, stack.length);
-                            _context.next = 55;
+                            handler.unload(currentPage, delta, prevIndex > -1);
+                            if (!(prevIndex > -1)) {
+                                _context.next = 42;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(prevIndex), pageConfig, prevIndex));
+
+                          case 42:
+                            shouldLoad = true;
+
+                          case 43:
+                            _context.next = 93;
                             break;
 
                           case 45:
+                            if (!(action === \\"REPLACE\\")) {
+                                _context.next = 80;
+                                break;
+                            }
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 51;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            shouldLoad = true;
+                            _context.next = 78;
+                            break;
+
+                          case 51:
+                            if (!(methodName === \\"redirectTo\\")) {
+                                _context.next = 56;
+                                break;
+                            }
+                            _prevIndex = stack.getPrevIndex(pathname);
+                            if (handler.isTabBar && _prevIndex > -1) {
+                                _delta = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta + 1);
+                                shouldLoad = true;
+                            } else {
+                                handler.unload(currentPage);
+                                shouldLoad = true;
+                            }
+                            _context.next = 78;
+                            break;
+
+                          case 56:
+                            if (!(methodName === \\"switchTab\\")) {
+                                _context.next = 75;
+                                break;
+                            }
                             if (!handler.isTabBar) {
-                                _context.next = 54;
+                                _context.next = 72;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 48;
+                                _context.next = 60;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 48:
-                            _prevIndex = stack.getPrevIndex(pathname, 0);
-                            handler.hide(currentPage);
-                            if (!(_prevIndex > -1)) {
-                                _context.next = 52;
+                          case 60:
+                            currentIsTabbar = (_h = handler.tabBarList) === null || _h === void 0 ? void 0 : _h.some((function(t) {
+                                var _a;
+                                return stripTrailing(t.pagePath) === stripTrailing((_a = currentPage === null || currentPage === void 0 ? void 0 : currentPage.path) !== null && _a !== void 0 ? _a : \\"\\");
+                            }));
+                            _prevIndex2 = stack.getPrevIndex(pathname, 0);
+                            if (!currentIsTabbar) {
+                                _context.next = 69;
                                 break;
                             }
-                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
+                            handler.hide(currentPage);
+                            if (!(_prevIndex2 > -1)) {
+                                _context.next = 66;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2));
 
-                          case 52:
-                            _context.next = 55;
+                          case 66:
+                            shouldLoad = true;
+                            _context.next = 70;
                             break;
 
-                          case 54:
-                            if (action === \\"REPLACE\\") {
-                                _delta = stack.getDelta(pathname);
-                                handler.unload(currentPage, _delta);
-                            } else if (action === \\"PUSH\\") {
-                                handler.hide(currentPage);
+                          case 69:
+                            if (_prevIndex2 > -1) {
+                                _delta2 = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta2, _prevIndex2 > -1);
+                                handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2);
+                            } else {
+                                handler.unload(currentPage, stack.length);
+                                shouldLoad = true;
                             }
 
-                          case 55:
+                          case 70:
+                            _context.next = 73;
+                            break;
+
+                          case 72:
+                            return _context.abrupt(\\"return\\", console.error(\\"switchTab:fail can not switch to no-tabBar page\\"));
+
+                          case 73:
+                            _context.next = 78;
+                            break;
+
+                          case 75:
+                            _delta3 = stack.getDelta(pathname);
+                            handler.unload(currentPage, _delta3);
                             shouldLoad = true;
 
-                          case 56:
-                            if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 65;
+                          case 78:
+                            _context.next = 93;
+                            break;
+
+                          case 80:
+                            if (!(action === \\"PUSH\\")) {
+                                _context.next = 93;
                                 break;
                             }
-                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
+                            if (!handler.isTabBar) {
+                                _context.next = 91;
+                                break;
+                            }
+                            if (!handler.isSamePage(currentPage)) {
+                                _context.next = 84;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\");
+
+                          case 84:
+                            _prevIndex3 = stack.getPrevIndex(pathname, 0);
+                            handler.hide(currentPage);
+                            if (!(_prevIndex3 > -1)) {
+                                _context.next = 88;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex3), pageConfig, _prevIndex3));
+
+                          case 88:
+                            shouldLoad = true;
+                            _context.next = 93;
+                            break;
+
+                          case 91:
+                            handler.hide(currentPage);
+                            shouldLoad = true;
+
+                          case 93:
+                            if (!(shouldLoad || stack.length < 1)) {
+                                _context.next = 102;
+                                break;
+                            }
+                            el = (_j = element.default) !== null && _j !== void 0 ? _j : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -19110,7 +19486,7 @@ exports[`sass should set global sass content with source & dir 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 65:
+                          case 102:
                           case \\"end\\":
                             return _context.stop();
                         }
@@ -23773,7 +24149,7 @@ exports[`sass should set global sass content with source 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, _j, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, currentIsTabbar, _prevIndex2, _delta2, _delta3, _prevIndex3, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -23849,72 +24225,166 @@ exports[`sass should set global sass content with source 2`] = `
                             shouldLoad = false;
                             stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 41;
+                                _context.next = 45;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
                             delta = stack.getDelta(pathname);
-                            if (currentPage !== stack.getItem(prevIndex)) {
-                                handler.unload(currentPage, delta, prevIndex > -1);
-                                if (prevIndex > -1) {
-                                    handler.show(stack.getItem(prevIndex), pageConfig, prevIndex);
-                                } else {
-                                    shouldLoad = true;
-                                }
-                            }
-                            _context.next = 56;
-                            break;
-
-                          case 41:
-                            if (!(methodName === \\"reLaunch\\")) {
-                                _context.next = 45;
+                            if (!(currentPage !== stack.getItem(prevIndex))) {
+                                _context.next = 43;
                                 break;
                             }
-                            handler.unload(currentPage, stack.length);
-                            _context.next = 55;
+                            handler.unload(currentPage, delta, prevIndex > -1);
+                            if (!(prevIndex > -1)) {
+                                _context.next = 42;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(prevIndex), pageConfig, prevIndex));
+
+                          case 42:
+                            shouldLoad = true;
+
+                          case 43:
+                            _context.next = 93;
                             break;
 
                           case 45:
+                            if (!(action === \\"REPLACE\\")) {
+                                _context.next = 80;
+                                break;
+                            }
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 51;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            shouldLoad = true;
+                            _context.next = 78;
+                            break;
+
+                          case 51:
+                            if (!(methodName === \\"redirectTo\\")) {
+                                _context.next = 56;
+                                break;
+                            }
+                            _prevIndex = stack.getPrevIndex(pathname);
+                            if (handler.isTabBar && _prevIndex > -1) {
+                                _delta = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta + 1);
+                                shouldLoad = true;
+                            } else {
+                                handler.unload(currentPage);
+                                shouldLoad = true;
+                            }
+                            _context.next = 78;
+                            break;
+
+                          case 56:
+                            if (!(methodName === \\"switchTab\\")) {
+                                _context.next = 75;
+                                break;
+                            }
                             if (!handler.isTabBar) {
-                                _context.next = 54;
+                                _context.next = 72;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 48;
+                                _context.next = 60;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 48:
-                            _prevIndex = stack.getPrevIndex(pathname, 0);
-                            handler.hide(currentPage);
-                            if (!(_prevIndex > -1)) {
-                                _context.next = 52;
+                          case 60:
+                            currentIsTabbar = (_h = handler.tabBarList) === null || _h === void 0 ? void 0 : _h.some((function(t) {
+                                var _a;
+                                return stripTrailing(t.pagePath) === stripTrailing((_a = currentPage === null || currentPage === void 0 ? void 0 : currentPage.path) !== null && _a !== void 0 ? _a : \\"\\");
+                            }));
+                            _prevIndex2 = stack.getPrevIndex(pathname, 0);
+                            if (!currentIsTabbar) {
+                                _context.next = 69;
                                 break;
                             }
-                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
+                            handler.hide(currentPage);
+                            if (!(_prevIndex2 > -1)) {
+                                _context.next = 66;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2));
 
-                          case 52:
-                            _context.next = 55;
+                          case 66:
+                            shouldLoad = true;
+                            _context.next = 70;
                             break;
 
-                          case 54:
-                            if (action === \\"REPLACE\\") {
-                                _delta = stack.getDelta(pathname);
-                                handler.unload(currentPage, _delta);
-                            } else if (action === \\"PUSH\\") {
-                                handler.hide(currentPage);
+                          case 69:
+                            if (_prevIndex2 > -1) {
+                                _delta2 = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta2, _prevIndex2 > -1);
+                                handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2);
+                            } else {
+                                handler.unload(currentPage, stack.length);
+                                shouldLoad = true;
                             }
 
-                          case 55:
+                          case 70:
+                            _context.next = 73;
+                            break;
+
+                          case 72:
+                            return _context.abrupt(\\"return\\", console.error(\\"switchTab:fail can not switch to no-tabBar page\\"));
+
+                          case 73:
+                            _context.next = 78;
+                            break;
+
+                          case 75:
+                            _delta3 = stack.getDelta(pathname);
+                            handler.unload(currentPage, _delta3);
                             shouldLoad = true;
 
-                          case 56:
-                            if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 65;
+                          case 78:
+                            _context.next = 93;
+                            break;
+
+                          case 80:
+                            if (!(action === \\"PUSH\\")) {
+                                _context.next = 93;
                                 break;
                             }
-                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
+                            if (!handler.isTabBar) {
+                                _context.next = 91;
+                                break;
+                            }
+                            if (!handler.isSamePage(currentPage)) {
+                                _context.next = 84;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\");
+
+                          case 84:
+                            _prevIndex3 = stack.getPrevIndex(pathname, 0);
+                            handler.hide(currentPage);
+                            if (!(_prevIndex3 > -1)) {
+                                _context.next = 88;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex3), pageConfig, _prevIndex3));
+
+                          case 88:
+                            shouldLoad = true;
+                            _context.next = 93;
+                            break;
+
+                          case 91:
+                            handler.hide(currentPage);
+                            shouldLoad = true;
+
+                          case 93:
+                            if (!(shouldLoad || stack.length < 1)) {
+                                _context.next = 102;
+                                break;
+                            }
+                            el = (_j = element.default) !== null && _j !== void 0 ? _j : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -23923,7 +24393,7 @@ exports[`sass should set global sass content with source 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 65:
+                          case 102:
                           case \\"end\\":
                             return _context.stop();
                         }

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/subpackages.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/subpackages.spec.ts.snap
@@ -68,7 +68,7 @@ exports[`subpackages should process subpackages 2`] = `
         var _babel_runtime_helpers_esm_createSuper__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(10);
         var react__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(3);
         var _tarojs_components__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(8);
-        var _tarojs_taro__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(4);
+        var _tarojs_taro__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(5);
         var _index_css__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(36);
         var _index_css__WEBPACK_IMPORTED_MODULE_7___default = __webpack_require__.n(_index_css__WEBPACK_IMPORTED_MODULE_7__);
         var Index = function(_Component) {
@@ -365,9 +365,6 @@ exports[`subpackages should process subpackages 2`] = `
     \\"use strict\\";
     __webpack_require__.r(__webpack_exports__);
     __webpack_exports__[\\"default\\"] = \\"react-mock\\";
-}, function(module, __webpack_exports__, __webpack_require__) {
-    \\"use strict\\";
-    function initPxTransform() {}
 }, function(module, exports, __webpack_require__) {
     \\"use strict\\";
     var _defineProperty = __webpack_require__(16).default;
@@ -765,6 +762,9 @@ exports[`subpackages should process subpackages 2`] = `
         };
         return exports.pick(input, exclusionFilter, options);
     };
+}, function(module, __webpack_exports__, __webpack_require__) {
+    \\"use strict\\";
+    function initPxTransform() {}
 }, function(module, exports, __webpack_require__) {
     var arrayLikeToArray = __webpack_require__(12);
     function _unsupportedIterableToArray(o, minLen) {
@@ -2184,7 +2184,7 @@ exports[`subpackages should process subpackages 2`] = `
 }, function(module, __webpack_exports__, __webpack_require__) {
     \\"use strict\\";
     __webpack_require__.r(__webpack_exports__);
-    var taro_h5 = __webpack_require__(4);
+    var taro_h5 = __webpack_require__(5);
     var esm_typeof = __webpack_require__(2);
     function _regeneratorRuntime() {
         \\"use strict\\";
@@ -3322,6 +3322,7 @@ exports[`subpackages should process subpackages 2`] = `
             Object(classCallCheck[\\"a\\"])(this, Stacks);
             this.stacks = [];
             this.backDelta = 0;
+            this.methodName = \\"\\";
         }
         Object(createClass[\\"a\\"])(Stacks, [ {
             \\"key\\": \\"delta\\",
@@ -3336,6 +3337,14 @@ exports[`subpackages should process subpackages 2`] = `
                 } else {
                     this.backDelta = 0;
                 }
+            }
+        }, {
+            \\"key\\": \\"method\\",
+            \\"get\\": function get() {
+                return this.methodName;
+            },
+            \\"set\\": function set(methodName) {
+                this.methodName = methodName;
             }
         }, {
             \\"key\\": \\"length\\",
@@ -3465,6 +3474,7 @@ exports[`subpackages should process subpackages 2`] = `
                                 unListen();
                             }));
                             try {
+                                stack.method = method;
                                 if (\\"url\\" in option) {
                                     var pathPieces = processNavigateUrl(option);
                                     var state = {
@@ -3641,7 +3651,7 @@ exports[`subpackages should process subpackages 2`] = `
     function _slicedToArray(arr, i) {
         return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest();
     }
-    var query_string = __webpack_require__(5);
+    var query_string = __webpack_require__(4);
     var query_string_default = __webpack_require__.n(query_string);
     var pageResizeFn;
     function bindPageResize(page) {
@@ -4384,7 +4394,7 @@ exports[`subpackages should process subpackages 2`] = `
                 var _a, _b;
                 if (!page) return;
                 stack.push(page);
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var param = this.getQuery(Date.now(), \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
@@ -4443,17 +4453,22 @@ exports[`subpackages should process subpackages 2`] = `
                 var _this3 = this;
                 var pageConfig = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
                 var stacksIndex = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
-                var _a, _b;
+                var _a, _b, _c, _d;
                 if (!page) return;
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var index = (_b = (_a = page.path) === null || _a === void 0 ? void 0 : _a.indexOf(\\"?\\")) !== null && _b !== void 0 ? _b : -1;
+                var q = index > -1 ? query_string_default.a.parse(page.path.substring(index), {
+                    \\"decode\\": false
+                }) : {};
+                var stamp = q.stamp ? Number(q.stamp) : undefined;
+                var param = this.getQuery(stamp, \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
                     this.addAnimation(pageEl, stacksIndex === 0);
-                    (_a = page.onShow) === null || _a === void 0 ? void 0 : _a.call(page);
+                    (_c = page.onShow) === null || _c === void 0 ? void 0 : _c.call(page);
                     this.bindPageEvents(page, pageEl, pageConfig);
                 } else {
-                    (_b = page.onLoad) === null || _b === void 0 ? void 0 : _b.call(page, param, (function() {
+                    (_d = page.onLoad) === null || _d === void 0 ? void 0 : _d.call(page, param, (function() {
                         var _a;
                         pageEl = _this3.getPageContainer(page);
                         _this3.addAnimation(pageEl, stacksIndex === 0);
@@ -4594,7 +4609,7 @@ exports[`subpackages should process subpackages 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -4666,9 +4681,11 @@ exports[`subpackages should process subpackages 2`] = `
                             }
                             currentPage = undefined.page;
                             pathname = handler.pathname;
+                            methodName = (_g = stack.method) !== null && _g !== void 0 ? _g : \\"\\";
                             shouldLoad = false;
+                            stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 39;
+                                _context.next = 41;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
@@ -4681,34 +4698,43 @@ exports[`subpackages should process subpackages 2`] = `
                                     shouldLoad = true;
                                 }
                             }
-                            _context.next = 50;
+                            _context.next = 56;
                             break;
 
-                          case 39:
+                          case 41:
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 45;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            _context.next = 55;
+                            break;
+
+                          case 45:
                             if (!handler.isTabBar) {
-                                _context.next = 48;
+                                _context.next = 54;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 42;
+                                _context.next = 48;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 42:
+                          case 48:
                             _prevIndex = stack.getPrevIndex(pathname, 0);
                             handler.hide(currentPage);
                             if (!(_prevIndex > -1)) {
-                                _context.next = 46;
+                                _context.next = 52;
                                 break;
                             }
                             return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
 
-                          case 46:
-                            _context.next = 49;
+                          case 52:
+                            _context.next = 55;
                             break;
 
-                          case 48:
+                          case 54:
                             if (action === \\"REPLACE\\") {
                                 _delta = stack.getDelta(pathname);
                                 handler.unload(currentPage, _delta);
@@ -4716,15 +4742,15 @@ exports[`subpackages should process subpackages 2`] = `
                                 handler.hide(currentPage);
                             }
 
-                          case 49:
+                          case 55:
                             shouldLoad = true;
 
-                          case 50:
+                          case 56:
                             if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 59;
+                                _context.next = 65;
                                 break;
                             }
-                            el = (_g = element.default) !== null && _g !== void 0 ? _g : element;
+                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -4733,7 +4759,7 @@ exports[`subpackages should process subpackages 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 59:
+                          case 65:
                           case \\"end\\":
                             return _context.stop();
                         }

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/subpackages.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/subpackages.spec.ts.snap
@@ -4609,7 +4609,7 @@ exports[`subpackages should process subpackages 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, _j, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, currentIsTabbar, _prevIndex2, _delta2, _delta3, _prevIndex3, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -4685,72 +4685,166 @@ exports[`subpackages should process subpackages 2`] = `
                             shouldLoad = false;
                             stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 41;
+                                _context.next = 45;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
                             delta = stack.getDelta(pathname);
-                            if (currentPage !== stack.getItem(prevIndex)) {
-                                handler.unload(currentPage, delta, prevIndex > -1);
-                                if (prevIndex > -1) {
-                                    handler.show(stack.getItem(prevIndex), pageConfig, prevIndex);
-                                } else {
-                                    shouldLoad = true;
-                                }
-                            }
-                            _context.next = 56;
-                            break;
-
-                          case 41:
-                            if (!(methodName === \\"reLaunch\\")) {
-                                _context.next = 45;
+                            if (!(currentPage !== stack.getItem(prevIndex))) {
+                                _context.next = 43;
                                 break;
                             }
-                            handler.unload(currentPage, stack.length);
-                            _context.next = 55;
+                            handler.unload(currentPage, delta, prevIndex > -1);
+                            if (!(prevIndex > -1)) {
+                                _context.next = 42;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(prevIndex), pageConfig, prevIndex));
+
+                          case 42:
+                            shouldLoad = true;
+
+                          case 43:
+                            _context.next = 93;
                             break;
 
                           case 45:
+                            if (!(action === \\"REPLACE\\")) {
+                                _context.next = 80;
+                                break;
+                            }
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 51;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            shouldLoad = true;
+                            _context.next = 78;
+                            break;
+
+                          case 51:
+                            if (!(methodName === \\"redirectTo\\")) {
+                                _context.next = 56;
+                                break;
+                            }
+                            _prevIndex = stack.getPrevIndex(pathname);
+                            if (handler.isTabBar && _prevIndex > -1) {
+                                _delta = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta + 1);
+                                shouldLoad = true;
+                            } else {
+                                handler.unload(currentPage);
+                                shouldLoad = true;
+                            }
+                            _context.next = 78;
+                            break;
+
+                          case 56:
+                            if (!(methodName === \\"switchTab\\")) {
+                                _context.next = 75;
+                                break;
+                            }
                             if (!handler.isTabBar) {
-                                _context.next = 54;
+                                _context.next = 72;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 48;
+                                _context.next = 60;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 48:
-                            _prevIndex = stack.getPrevIndex(pathname, 0);
-                            handler.hide(currentPage);
-                            if (!(_prevIndex > -1)) {
-                                _context.next = 52;
+                          case 60:
+                            currentIsTabbar = (_h = handler.tabBarList) === null || _h === void 0 ? void 0 : _h.some((function(t) {
+                                var _a;
+                                return stripTrailing(t.pagePath) === stripTrailing((_a = currentPage === null || currentPage === void 0 ? void 0 : currentPage.path) !== null && _a !== void 0 ? _a : \\"\\");
+                            }));
+                            _prevIndex2 = stack.getPrevIndex(pathname, 0);
+                            if (!currentIsTabbar) {
+                                _context.next = 69;
                                 break;
                             }
-                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
+                            handler.hide(currentPage);
+                            if (!(_prevIndex2 > -1)) {
+                                _context.next = 66;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2));
 
-                          case 52:
-                            _context.next = 55;
+                          case 66:
+                            shouldLoad = true;
+                            _context.next = 70;
                             break;
 
-                          case 54:
-                            if (action === \\"REPLACE\\") {
-                                _delta = stack.getDelta(pathname);
-                                handler.unload(currentPage, _delta);
-                            } else if (action === \\"PUSH\\") {
-                                handler.hide(currentPage);
+                          case 69:
+                            if (_prevIndex2 > -1) {
+                                _delta2 = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta2, _prevIndex2 > -1);
+                                handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2);
+                            } else {
+                                handler.unload(currentPage, stack.length);
+                                shouldLoad = true;
                             }
 
-                          case 55:
+                          case 70:
+                            _context.next = 73;
+                            break;
+
+                          case 72:
+                            return _context.abrupt(\\"return\\", console.error(\\"switchTab:fail can not switch to no-tabBar page\\"));
+
+                          case 73:
+                            _context.next = 78;
+                            break;
+
+                          case 75:
+                            _delta3 = stack.getDelta(pathname);
+                            handler.unload(currentPage, _delta3);
                             shouldLoad = true;
 
-                          case 56:
-                            if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 65;
+                          case 78:
+                            _context.next = 93;
+                            break;
+
+                          case 80:
+                            if (!(action === \\"PUSH\\")) {
+                                _context.next = 93;
                                 break;
                             }
-                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
+                            if (!handler.isTabBar) {
+                                _context.next = 91;
+                                break;
+                            }
+                            if (!handler.isSamePage(currentPage)) {
+                                _context.next = 84;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\");
+
+                          case 84:
+                            _prevIndex3 = stack.getPrevIndex(pathname, 0);
+                            handler.hide(currentPage);
+                            if (!(_prevIndex3 > -1)) {
+                                _context.next = 88;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex3), pageConfig, _prevIndex3));
+
+                          case 88:
+                            shouldLoad = true;
+                            _context.next = 93;
+                            break;
+
+                          case 91:
+                            handler.hide(currentPage);
+                            shouldLoad = true;
+
+                          case 93:
+                            if (!(shouldLoad || stack.length < 1)) {
+                                _context.next = 102;
+                                break;
+                            }
+                            el = (_j = element.default) !== null && _j !== void 0 ? _j : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -4759,7 +4853,7 @@ exports[`subpackages should process subpackages 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 65:
+                          case 102:
                           case \\"end\\":
                             return _context.stop();
                         }

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/ts.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/ts.spec.ts.snap
@@ -3262,6 +3262,7 @@ exports[`typescript should build project with ts 2`] = `
             Object(classCallCheck[\\"a\\"])(this, Stacks);
             this.stacks = [];
             this.backDelta = 0;
+            this.methodName = \\"\\";
         }
         Object(createClass[\\"a\\"])(Stacks, [ {
             \\"key\\": \\"delta\\",
@@ -3276,6 +3277,14 @@ exports[`typescript should build project with ts 2`] = `
                 } else {
                     this.backDelta = 0;
                 }
+            }
+        }, {
+            \\"key\\": \\"method\\",
+            \\"get\\": function get() {
+                return this.methodName;
+            },
+            \\"set\\": function set(methodName) {
+                this.methodName = methodName;
             }
         }, {
             \\"key\\": \\"length\\",
@@ -3405,6 +3414,7 @@ exports[`typescript should build project with ts 2`] = `
                                 unListen();
                             }));
                             try {
+                                stack.method = method;
                                 if (\\"url\\" in option) {
                                     var pathPieces = processNavigateUrl(option);
                                     var state = {
@@ -4324,7 +4334,7 @@ exports[`typescript should build project with ts 2`] = `
                 var _a, _b;
                 if (!page) return;
                 stack.push(page);
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var param = this.getQuery(Date.now(), \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
@@ -4383,17 +4393,22 @@ exports[`typescript should build project with ts 2`] = `
                 var _this3 = this;
                 var pageConfig = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
                 var stacksIndex = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
-                var _a, _b;
+                var _a, _b, _c, _d;
                 if (!page) return;
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var index = (_b = (_a = page.path) === null || _a === void 0 ? void 0 : _a.indexOf(\\"?\\")) !== null && _b !== void 0 ? _b : -1;
+                var q = index > -1 ? query_string_default.a.parse(page.path.substring(index), {
+                    \\"decode\\": false
+                }) : {};
+                var stamp = q.stamp ? Number(q.stamp) : undefined;
+                var param = this.getQuery(stamp, \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
                     this.addAnimation(pageEl, stacksIndex === 0);
-                    (_a = page.onShow) === null || _a === void 0 ? void 0 : _a.call(page);
+                    (_c = page.onShow) === null || _c === void 0 ? void 0 : _c.call(page);
                     this.bindPageEvents(page, pageEl, pageConfig);
                 } else {
-                    (_b = page.onLoad) === null || _b === void 0 ? void 0 : _b.call(page, param, (function() {
+                    (_d = page.onLoad) === null || _d === void 0 ? void 0 : _d.call(page, param, (function() {
                         var _a;
                         pageEl = _this3.getPageContainer(page);
                         _this3.addAnimation(pageEl, stacksIndex === 0);
@@ -4534,7 +4549,7 @@ exports[`typescript should build project with ts 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -4606,9 +4621,11 @@ exports[`typescript should build project with ts 2`] = `
                             }
                             currentPage = undefined.page;
                             pathname = handler.pathname;
+                            methodName = (_g = stack.method) !== null && _g !== void 0 ? _g : \\"\\";
                             shouldLoad = false;
+                            stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 39;
+                                _context.next = 41;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
@@ -4621,34 +4638,43 @@ exports[`typescript should build project with ts 2`] = `
                                     shouldLoad = true;
                                 }
                             }
-                            _context.next = 50;
+                            _context.next = 56;
                             break;
 
-                          case 39:
+                          case 41:
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 45;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            _context.next = 55;
+                            break;
+
+                          case 45:
                             if (!handler.isTabBar) {
-                                _context.next = 48;
+                                _context.next = 54;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 42;
+                                _context.next = 48;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 42:
+                          case 48:
                             _prevIndex = stack.getPrevIndex(pathname, 0);
                             handler.hide(currentPage);
                             if (!(_prevIndex > -1)) {
-                                _context.next = 46;
+                                _context.next = 52;
                                 break;
                             }
                             return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
 
-                          case 46:
-                            _context.next = 49;
+                          case 52:
+                            _context.next = 55;
                             break;
 
-                          case 48:
+                          case 54:
                             if (action === \\"REPLACE\\") {
                                 _delta = stack.getDelta(pathname);
                                 handler.unload(currentPage, _delta);
@@ -4656,15 +4682,15 @@ exports[`typescript should build project with ts 2`] = `
                                 handler.hide(currentPage);
                             }
 
-                          case 49:
+                          case 55:
                             shouldLoad = true;
 
-                          case 50:
+                          case 56:
                             if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 59;
+                                _context.next = 65;
                                 break;
                             }
-                            el = (_g = element.default) !== null && _g !== void 0 ? _g : element;
+                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -4673,7 +4699,7 @@ exports[`typescript should build project with ts 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 59:
+                          case 65:
                           case \\"end\\":
                             return _context.stop();
                         }

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/ts.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/ts.spec.ts.snap
@@ -4549,7 +4549,7 @@ exports[`typescript should build project with ts 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, _j, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, currentIsTabbar, _prevIndex2, _delta2, _delta3, _prevIndex3, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -4625,72 +4625,166 @@ exports[`typescript should build project with ts 2`] = `
                             shouldLoad = false;
                             stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 41;
+                                _context.next = 45;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
                             delta = stack.getDelta(pathname);
-                            if (currentPage !== stack.getItem(prevIndex)) {
-                                handler.unload(currentPage, delta, prevIndex > -1);
-                                if (prevIndex > -1) {
-                                    handler.show(stack.getItem(prevIndex), pageConfig, prevIndex);
-                                } else {
-                                    shouldLoad = true;
-                                }
-                            }
-                            _context.next = 56;
-                            break;
-
-                          case 41:
-                            if (!(methodName === \\"reLaunch\\")) {
-                                _context.next = 45;
+                            if (!(currentPage !== stack.getItem(prevIndex))) {
+                                _context.next = 43;
                                 break;
                             }
-                            handler.unload(currentPage, stack.length);
-                            _context.next = 55;
+                            handler.unload(currentPage, delta, prevIndex > -1);
+                            if (!(prevIndex > -1)) {
+                                _context.next = 42;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(prevIndex), pageConfig, prevIndex));
+
+                          case 42:
+                            shouldLoad = true;
+
+                          case 43:
+                            _context.next = 93;
                             break;
 
                           case 45:
+                            if (!(action === \\"REPLACE\\")) {
+                                _context.next = 80;
+                                break;
+                            }
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 51;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            shouldLoad = true;
+                            _context.next = 78;
+                            break;
+
+                          case 51:
+                            if (!(methodName === \\"redirectTo\\")) {
+                                _context.next = 56;
+                                break;
+                            }
+                            _prevIndex = stack.getPrevIndex(pathname);
+                            if (handler.isTabBar && _prevIndex > -1) {
+                                _delta = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta + 1);
+                                shouldLoad = true;
+                            } else {
+                                handler.unload(currentPage);
+                                shouldLoad = true;
+                            }
+                            _context.next = 78;
+                            break;
+
+                          case 56:
+                            if (!(methodName === \\"switchTab\\")) {
+                                _context.next = 75;
+                                break;
+                            }
                             if (!handler.isTabBar) {
-                                _context.next = 54;
+                                _context.next = 72;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 48;
+                                _context.next = 60;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 48:
-                            _prevIndex = stack.getPrevIndex(pathname, 0);
-                            handler.hide(currentPage);
-                            if (!(_prevIndex > -1)) {
-                                _context.next = 52;
+                          case 60:
+                            currentIsTabbar = (_h = handler.tabBarList) === null || _h === void 0 ? void 0 : _h.some((function(t) {
+                                var _a;
+                                return stripTrailing(t.pagePath) === stripTrailing((_a = currentPage === null || currentPage === void 0 ? void 0 : currentPage.path) !== null && _a !== void 0 ? _a : \\"\\");
+                            }));
+                            _prevIndex2 = stack.getPrevIndex(pathname, 0);
+                            if (!currentIsTabbar) {
+                                _context.next = 69;
                                 break;
                             }
-                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
+                            handler.hide(currentPage);
+                            if (!(_prevIndex2 > -1)) {
+                                _context.next = 66;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2));
 
-                          case 52:
-                            _context.next = 55;
+                          case 66:
+                            shouldLoad = true;
+                            _context.next = 70;
                             break;
 
-                          case 54:
-                            if (action === \\"REPLACE\\") {
-                                _delta = stack.getDelta(pathname);
-                                handler.unload(currentPage, _delta);
-                            } else if (action === \\"PUSH\\") {
-                                handler.hide(currentPage);
+                          case 69:
+                            if (_prevIndex2 > -1) {
+                                _delta2 = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta2, _prevIndex2 > -1);
+                                handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2);
+                            } else {
+                                handler.unload(currentPage, stack.length);
+                                shouldLoad = true;
                             }
 
-                          case 55:
+                          case 70:
+                            _context.next = 73;
+                            break;
+
+                          case 72:
+                            return _context.abrupt(\\"return\\", console.error(\\"switchTab:fail can not switch to no-tabBar page\\"));
+
+                          case 73:
+                            _context.next = 78;
+                            break;
+
+                          case 75:
+                            _delta3 = stack.getDelta(pathname);
+                            handler.unload(currentPage, _delta3);
                             shouldLoad = true;
 
-                          case 56:
-                            if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 65;
+                          case 78:
+                            _context.next = 93;
+                            break;
+
+                          case 80:
+                            if (!(action === \\"PUSH\\")) {
+                                _context.next = 93;
                                 break;
                             }
-                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
+                            if (!handler.isTabBar) {
+                                _context.next = 91;
+                                break;
+                            }
+                            if (!handler.isSamePage(currentPage)) {
+                                _context.next = 84;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\");
+
+                          case 84:
+                            _prevIndex3 = stack.getPrevIndex(pathname, 0);
+                            handler.hide(currentPage);
+                            if (!(_prevIndex3 > -1)) {
+                                _context.next = 88;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex3), pageConfig, _prevIndex3));
+
+                          case 88:
+                            shouldLoad = true;
+                            _context.next = 93;
+                            break;
+
+                          case 91:
+                            handler.hide(currentPage);
+                            shouldLoad = true;
+
+                          case 93:
+                            if (!(shouldLoad || stack.length < 1)) {
+                                _context.next = 102;
+                                break;
+                            }
+                            el = (_j = element.default) !== null && _j !== void 0 ? _j : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -4699,7 +4793,7 @@ exports[`typescript should build project with ts 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 65:
+                          case 102:
                           case \\"end\\":
                             return _context.stop();
                         }

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue.spec.ts.snap
@@ -3216,6 +3216,7 @@ exports[`vue should build vue app 2`] = `
             _classCallCheck(this, Stacks);
             this.stacks = [];
             this.backDelta = 0;
+            this.methodName = \\"\\";
         }
         _createClass(Stacks, [ {
             \\"key\\": \\"delta\\",
@@ -3230,6 +3231,14 @@ exports[`vue should build vue app 2`] = `
                 } else {
                     this.backDelta = 0;
                 }
+            }
+        }, {
+            \\"key\\": \\"method\\",
+            \\"get\\": function get() {
+                return this.methodName;
+            },
+            \\"set\\": function set(methodName) {
+                this.methodName = methodName;
             }
         }, {
             \\"key\\": \\"length\\",
@@ -3359,6 +3368,7 @@ exports[`vue should build vue app 2`] = `
                                 unListen();
                             }));
                             try {
+                                stack.method = method;
                                 if (\\"url\\" in option) {
                                     var pathPieces = processNavigateUrl(option);
                                     var state = {
@@ -4278,7 +4288,7 @@ exports[`vue should build vue app 2`] = `
                 var _a, _b;
                 if (!page) return;
                 stack.push(page);
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var param = this.getQuery(Date.now(), \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
@@ -4337,17 +4347,22 @@ exports[`vue should build vue app 2`] = `
                 var _this3 = this;
                 var pageConfig = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
                 var stacksIndex = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
-                var _a, _b;
+                var _a, _b, _c, _d;
                 if (!page) return;
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var index = (_b = (_a = page.path) === null || _a === void 0 ? void 0 : _a.indexOf(\\"?\\")) !== null && _b !== void 0 ? _b : -1;
+                var q = index > -1 ? query_string_default.a.parse(page.path.substring(index), {
+                    \\"decode\\": false
+                }) : {};
+                var stamp = q.stamp ? Number(q.stamp) : undefined;
+                var param = this.getQuery(stamp, \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
                     this.addAnimation(pageEl, stacksIndex === 0);
-                    (_a = page.onShow) === null || _a === void 0 ? void 0 : _a.call(page);
+                    (_c = page.onShow) === null || _c === void 0 ? void 0 : _c.call(page);
                     this.bindPageEvents(page, pageEl, pageConfig);
                 } else {
-                    (_b = page.onLoad) === null || _b === void 0 ? void 0 : _b.call(page, param, (function() {
+                    (_d = page.onLoad) === null || _d === void 0 ? void 0 : _d.call(page, param, (function() {
                         var _a;
                         pageEl = _this3.getPageContainer(page);
                         _this3.addAnimation(pageEl, stacksIndex === 0);
@@ -4488,7 +4503,7 @@ exports[`vue should build vue app 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -4560,9 +4575,11 @@ exports[`vue should build vue app 2`] = `
                             }
                             currentPage = undefined.page;
                             pathname = handler.pathname;
+                            methodName = (_g = stack.method) !== null && _g !== void 0 ? _g : \\"\\";
                             shouldLoad = false;
+                            stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 39;
+                                _context.next = 41;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
@@ -4575,34 +4592,43 @@ exports[`vue should build vue app 2`] = `
                                     shouldLoad = true;
                                 }
                             }
-                            _context.next = 50;
+                            _context.next = 56;
                             break;
 
-                          case 39:
+                          case 41:
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 45;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            _context.next = 55;
+                            break;
+
+                          case 45:
                             if (!handler.isTabBar) {
-                                _context.next = 48;
+                                _context.next = 54;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 42;
+                                _context.next = 48;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 42:
+                          case 48:
                             _prevIndex = stack.getPrevIndex(pathname, 0);
                             handler.hide(currentPage);
                             if (!(_prevIndex > -1)) {
-                                _context.next = 46;
+                                _context.next = 52;
                                 break;
                             }
                             return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
 
-                          case 46:
-                            _context.next = 49;
+                          case 52:
+                            _context.next = 55;
                             break;
 
-                          case 48:
+                          case 54:
                             if (action === \\"REPLACE\\") {
                                 _delta = stack.getDelta(pathname);
                                 handler.unload(currentPage, _delta);
@@ -4610,15 +4636,15 @@ exports[`vue should build vue app 2`] = `
                                 handler.hide(currentPage);
                             }
 
-                          case 49:
+                          case 55:
                             shouldLoad = true;
 
-                          case 50:
+                          case 56:
                             if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 59;
+                                _context.next = 65;
                                 break;
                             }
-                            el = (_g = element.default) !== null && _g !== void 0 ? _g : element;
+                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -4627,7 +4653,7 @@ exports[`vue should build vue app 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 59:
+                          case 65:
                           case \\"end\\":
                             return _context.stop();
                         }

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue.spec.ts.snap
@@ -4503,7 +4503,7 @@ exports[`vue should build vue app 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, _j, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, currentIsTabbar, _prevIndex2, _delta2, _delta3, _prevIndex3, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -4579,72 +4579,166 @@ exports[`vue should build vue app 2`] = `
                             shouldLoad = false;
                             stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 41;
+                                _context.next = 45;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
                             delta = stack.getDelta(pathname);
-                            if (currentPage !== stack.getItem(prevIndex)) {
-                                handler.unload(currentPage, delta, prevIndex > -1);
-                                if (prevIndex > -1) {
-                                    handler.show(stack.getItem(prevIndex), pageConfig, prevIndex);
-                                } else {
-                                    shouldLoad = true;
-                                }
-                            }
-                            _context.next = 56;
-                            break;
-
-                          case 41:
-                            if (!(methodName === \\"reLaunch\\")) {
-                                _context.next = 45;
+                            if (!(currentPage !== stack.getItem(prevIndex))) {
+                                _context.next = 43;
                                 break;
                             }
-                            handler.unload(currentPage, stack.length);
-                            _context.next = 55;
+                            handler.unload(currentPage, delta, prevIndex > -1);
+                            if (!(prevIndex > -1)) {
+                                _context.next = 42;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(prevIndex), pageConfig, prevIndex));
+
+                          case 42:
+                            shouldLoad = true;
+
+                          case 43:
+                            _context.next = 93;
                             break;
 
                           case 45:
+                            if (!(action === \\"REPLACE\\")) {
+                                _context.next = 80;
+                                break;
+                            }
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 51;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            shouldLoad = true;
+                            _context.next = 78;
+                            break;
+
+                          case 51:
+                            if (!(methodName === \\"redirectTo\\")) {
+                                _context.next = 56;
+                                break;
+                            }
+                            _prevIndex = stack.getPrevIndex(pathname);
+                            if (handler.isTabBar && _prevIndex > -1) {
+                                _delta = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta + 1);
+                                shouldLoad = true;
+                            } else {
+                                handler.unload(currentPage);
+                                shouldLoad = true;
+                            }
+                            _context.next = 78;
+                            break;
+
+                          case 56:
+                            if (!(methodName === \\"switchTab\\")) {
+                                _context.next = 75;
+                                break;
+                            }
                             if (!handler.isTabBar) {
-                                _context.next = 54;
+                                _context.next = 72;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 48;
+                                _context.next = 60;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 48:
-                            _prevIndex = stack.getPrevIndex(pathname, 0);
-                            handler.hide(currentPage);
-                            if (!(_prevIndex > -1)) {
-                                _context.next = 52;
+                          case 60:
+                            currentIsTabbar = (_h = handler.tabBarList) === null || _h === void 0 ? void 0 : _h.some((function(t) {
+                                var _a;
+                                return stripTrailing(t.pagePath) === stripTrailing((_a = currentPage === null || currentPage === void 0 ? void 0 : currentPage.path) !== null && _a !== void 0 ? _a : \\"\\");
+                            }));
+                            _prevIndex2 = stack.getPrevIndex(pathname, 0);
+                            if (!currentIsTabbar) {
+                                _context.next = 69;
                                 break;
                             }
-                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
+                            handler.hide(currentPage);
+                            if (!(_prevIndex2 > -1)) {
+                                _context.next = 66;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2));
 
-                          case 52:
-                            _context.next = 55;
+                          case 66:
+                            shouldLoad = true;
+                            _context.next = 70;
                             break;
 
-                          case 54:
-                            if (action === \\"REPLACE\\") {
-                                _delta = stack.getDelta(pathname);
-                                handler.unload(currentPage, _delta);
-                            } else if (action === \\"PUSH\\") {
-                                handler.hide(currentPage);
+                          case 69:
+                            if (_prevIndex2 > -1) {
+                                _delta2 = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta2, _prevIndex2 > -1);
+                                handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2);
+                            } else {
+                                handler.unload(currentPage, stack.length);
+                                shouldLoad = true;
                             }
 
-                          case 55:
+                          case 70:
+                            _context.next = 73;
+                            break;
+
+                          case 72:
+                            return _context.abrupt(\\"return\\", console.error(\\"switchTab:fail can not switch to no-tabBar page\\"));
+
+                          case 73:
+                            _context.next = 78;
+                            break;
+
+                          case 75:
+                            _delta3 = stack.getDelta(pathname);
+                            handler.unload(currentPage, _delta3);
                             shouldLoad = true;
 
-                          case 56:
-                            if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 65;
+                          case 78:
+                            _context.next = 93;
+                            break;
+
+                          case 80:
+                            if (!(action === \\"PUSH\\")) {
+                                _context.next = 93;
                                 break;
                             }
-                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
+                            if (!handler.isTabBar) {
+                                _context.next = 91;
+                                break;
+                            }
+                            if (!handler.isSamePage(currentPage)) {
+                                _context.next = 84;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\");
+
+                          case 84:
+                            _prevIndex3 = stack.getPrevIndex(pathname, 0);
+                            handler.hide(currentPage);
+                            if (!(_prevIndex3 > -1)) {
+                                _context.next = 88;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex3), pageConfig, _prevIndex3));
+
+                          case 88:
+                            shouldLoad = true;
+                            _context.next = 93;
+                            break;
+
+                          case 91:
+                            handler.hide(currentPage);
+                            shouldLoad = true;
+
+                          case 93:
+                            if (!(shouldLoad || stack.length < 1)) {
+                                _context.next = 102;
+                                break;
+                            }
+                            el = (_j = element.default) !== null && _j !== void 0 ? _j : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -4653,7 +4747,7 @@ exports[`vue should build vue app 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 65:
+                          case 102:
                           case \\"end\\":
                             return _context.stop();
                         }

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue3.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue3.spec.ts.snap
@@ -4442,7 +4442,7 @@ exports[`vue3 should build vue3 app 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, _j, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, currentIsTabbar, _prevIndex2, _delta2, _delta3, _prevIndex3, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -4518,72 +4518,166 @@ exports[`vue3 should build vue3 app 2`] = `
                             shouldLoad = false;
                             stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 41;
+                                _context.next = 45;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
                             delta = stack.getDelta(pathname);
-                            if (currentPage !== stack.getItem(prevIndex)) {
-                                handler.unload(currentPage, delta, prevIndex > -1);
-                                if (prevIndex > -1) {
-                                    handler.show(stack.getItem(prevIndex), pageConfig, prevIndex);
-                                } else {
-                                    shouldLoad = true;
-                                }
-                            }
-                            _context.next = 56;
-                            break;
-
-                          case 41:
-                            if (!(methodName === \\"reLaunch\\")) {
-                                _context.next = 45;
+                            if (!(currentPage !== stack.getItem(prevIndex))) {
+                                _context.next = 43;
                                 break;
                             }
-                            handler.unload(currentPage, stack.length);
-                            _context.next = 55;
+                            handler.unload(currentPage, delta, prevIndex > -1);
+                            if (!(prevIndex > -1)) {
+                                _context.next = 42;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(prevIndex), pageConfig, prevIndex));
+
+                          case 42:
+                            shouldLoad = true;
+
+                          case 43:
+                            _context.next = 93;
                             break;
 
                           case 45:
+                            if (!(action === \\"REPLACE\\")) {
+                                _context.next = 80;
+                                break;
+                            }
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 51;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            shouldLoad = true;
+                            _context.next = 78;
+                            break;
+
+                          case 51:
+                            if (!(methodName === \\"redirectTo\\")) {
+                                _context.next = 56;
+                                break;
+                            }
+                            _prevIndex = stack.getPrevIndex(pathname);
+                            if (handler.isTabBar && _prevIndex > -1) {
+                                _delta = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta + 1);
+                                shouldLoad = true;
+                            } else {
+                                handler.unload(currentPage);
+                                shouldLoad = true;
+                            }
+                            _context.next = 78;
+                            break;
+
+                          case 56:
+                            if (!(methodName === \\"switchTab\\")) {
+                                _context.next = 75;
+                                break;
+                            }
                             if (!handler.isTabBar) {
-                                _context.next = 54;
+                                _context.next = 72;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 48;
+                                _context.next = 60;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 48:
-                            _prevIndex = stack.getPrevIndex(pathname, 0);
-                            handler.hide(currentPage);
-                            if (!(_prevIndex > -1)) {
-                                _context.next = 52;
+                          case 60:
+                            currentIsTabbar = (_h = handler.tabBarList) === null || _h === void 0 ? void 0 : _h.some((function(t) {
+                                var _a;
+                                return stripTrailing(t.pagePath) === stripTrailing((_a = currentPage === null || currentPage === void 0 ? void 0 : currentPage.path) !== null && _a !== void 0 ? _a : \\"\\");
+                            }));
+                            _prevIndex2 = stack.getPrevIndex(pathname, 0);
+                            if (!currentIsTabbar) {
+                                _context.next = 69;
                                 break;
                             }
-                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
+                            handler.hide(currentPage);
+                            if (!(_prevIndex2 > -1)) {
+                                _context.next = 66;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2));
 
-                          case 52:
-                            _context.next = 55;
+                          case 66:
+                            shouldLoad = true;
+                            _context.next = 70;
                             break;
 
-                          case 54:
-                            if (action === \\"REPLACE\\") {
-                                _delta = stack.getDelta(pathname);
-                                handler.unload(currentPage, _delta);
-                            } else if (action === \\"PUSH\\") {
-                                handler.hide(currentPage);
+                          case 69:
+                            if (_prevIndex2 > -1) {
+                                _delta2 = stack.getDelta(pathname);
+                                handler.unload(currentPage, _delta2, _prevIndex2 > -1);
+                                handler.show(stack.getItem(_prevIndex2), pageConfig, _prevIndex2);
+                            } else {
+                                handler.unload(currentPage, stack.length);
+                                shouldLoad = true;
                             }
 
-                          case 55:
+                          case 70:
+                            _context.next = 73;
+                            break;
+
+                          case 72:
+                            return _context.abrupt(\\"return\\", console.error(\\"switchTab:fail can not switch to no-tabBar page\\"));
+
+                          case 73:
+                            _context.next = 78;
+                            break;
+
+                          case 75:
+                            _delta3 = stack.getDelta(pathname);
+                            handler.unload(currentPage, _delta3);
                             shouldLoad = true;
 
-                          case 56:
-                            if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 65;
+                          case 78:
+                            _context.next = 93;
+                            break;
+
+                          case 80:
+                            if (!(action === \\"PUSH\\")) {
+                                _context.next = 93;
                                 break;
                             }
-                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
+                            if (!handler.isTabBar) {
+                                _context.next = 91;
+                                break;
+                            }
+                            if (!handler.isSamePage(currentPage)) {
+                                _context.next = 84;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\");
+
+                          case 84:
+                            _prevIndex3 = stack.getPrevIndex(pathname, 0);
+                            handler.hide(currentPage);
+                            if (!(_prevIndex3 > -1)) {
+                                _context.next = 88;
+                                break;
+                            }
+                            return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex3), pageConfig, _prevIndex3));
+
+                          case 88:
+                            shouldLoad = true;
+                            _context.next = 93;
+                            break;
+
+                          case 91:
+                            handler.hide(currentPage);
+                            shouldLoad = true;
+
+                          case 93:
+                            if (!(shouldLoad || stack.length < 1)) {
+                                _context.next = 102;
+                                break;
+                            }
+                            el = (_j = element.default) !== null && _j !== void 0 ? _j : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -4592,7 +4686,7 @@ exports[`vue3 should build vue3 app 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 65:
+                          case 102:
                           case \\"end\\":
                             return _context.stop();
                         }

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue3.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue3.spec.ts.snap
@@ -3155,6 +3155,7 @@ exports[`vue3 should build vue3 app 2`] = `
             _classCallCheck(this, Stacks);
             this.stacks = [];
             this.backDelta = 0;
+            this.methodName = \\"\\";
         }
         _createClass(Stacks, [ {
             \\"key\\": \\"delta\\",
@@ -3169,6 +3170,14 @@ exports[`vue3 should build vue3 app 2`] = `
                 } else {
                     this.backDelta = 0;
                 }
+            }
+        }, {
+            \\"key\\": \\"method\\",
+            \\"get\\": function get() {
+                return this.methodName;
+            },
+            \\"set\\": function set(methodName) {
+                this.methodName = methodName;
             }
         }, {
             \\"key\\": \\"length\\",
@@ -3298,6 +3307,7 @@ exports[`vue3 should build vue3 app 2`] = `
                                 unListen();
                             }));
                             try {
+                                stack.method = method;
                                 if (\\"url\\" in option) {
                                     var pathPieces = processNavigateUrl(option);
                                     var state = {
@@ -4217,7 +4227,7 @@ exports[`vue3 should build vue3 app 2`] = `
                 var _a, _b;
                 if (!page) return;
                 stack.push(page);
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var param = this.getQuery(Date.now(), \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
@@ -4276,17 +4286,22 @@ exports[`vue3 should build vue3 app 2`] = `
                 var _this3 = this;
                 var pageConfig = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
                 var stacksIndex = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
-                var _a, _b;
+                var _a, _b, _c, _d;
                 if (!page) return;
-                var param = this.getQuery(stack.length, \\"\\", page.options);
+                var index = (_b = (_a = page.path) === null || _a === void 0 ? void 0 : _a.indexOf(\\"?\\")) !== null && _b !== void 0 ? _b : -1;
+                var q = index > -1 ? query_string_default.a.parse(page.path.substring(index), {
+                    \\"decode\\": false
+                }) : {};
+                var stamp = q.stamp ? Number(q.stamp) : undefined;
+                var param = this.getQuery(stamp, \\"\\", page.options);
                 var pageEl = this.getPageContainer(page);
                 if (pageEl) {
                     setDisplay(pageEl);
                     this.addAnimation(pageEl, stacksIndex === 0);
-                    (_a = page.onShow) === null || _a === void 0 ? void 0 : _a.call(page);
+                    (_c = page.onShow) === null || _c === void 0 ? void 0 : _c.call(page);
                     this.bindPageEvents(page, pageEl, pageConfig);
                 } else {
-                    (_b = page.onLoad) === null || _b === void 0 ? void 0 : _b.call(page, param, (function() {
+                    (_d = page.onLoad) === null || _d === void 0 ? void 0 : _d.call(page, param, (function() {
                         var _a;
                         pageEl = _this3.getPageContainer(page);
                         _this3.addAnimation(pageEl, stacksIndex === 0);
@@ -4427,7 +4442,7 @@ exports[`vue3 should build vue3 app 2`] = `
         var render = function render(_ref) {
             var location = _ref.location, action = _ref.action;
             return spa_awaiter(_this, void 0, void 0, _regeneratorRuntime().mark((function _callee() {
-                var _c, _d, _e, _f, _g, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
+                var _c, _d, _e, _f, _g, _h, element, params, result, _yield$Promise$all, _yield$Promise$all2, pageConfig, enablePullDownRefresh, currentPage, pathname, methodName, shouldLoad, prevIndex, delta, _prevIndex, _delta, el, loadConfig, stacksIndex, page;
                 return _regeneratorRuntime().wrap((function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
@@ -4499,9 +4514,11 @@ exports[`vue3 should build vue3 app 2`] = `
                             }
                             currentPage = undefined.page;
                             pathname = handler.pathname;
+                            methodName = (_g = stack.method) !== null && _g !== void 0 ? _g : \\"\\";
                             shouldLoad = false;
+                            stack.method = \\"\\";
                             if (!(action === \\"POP\\")) {
-                                _context.next = 39;
+                                _context.next = 41;
                                 break;
                             }
                             prevIndex = stack.getPrevIndex(pathname);
@@ -4514,34 +4531,43 @@ exports[`vue3 should build vue3 app 2`] = `
                                     shouldLoad = true;
                                 }
                             }
-                            _context.next = 50;
+                            _context.next = 56;
                             break;
 
-                          case 39:
+                          case 41:
+                            if (!(methodName === \\"reLaunch\\")) {
+                                _context.next = 45;
+                                break;
+                            }
+                            handler.unload(currentPage, stack.length);
+                            _context.next = 55;
+                            break;
+
+                          case 45:
                             if (!handler.isTabBar) {
-                                _context.next = 48;
+                                _context.next = 54;
                                 break;
                             }
                             if (!handler.isSamePage(currentPage)) {
-                                _context.next = 42;
+                                _context.next = 48;
                                 break;
                             }
                             return _context.abrupt(\\"return\\");
 
-                          case 42:
+                          case 48:
                             _prevIndex = stack.getPrevIndex(pathname, 0);
                             handler.hide(currentPage);
                             if (!(_prevIndex > -1)) {
-                                _context.next = 46;
+                                _context.next = 52;
                                 break;
                             }
                             return _context.abrupt(\\"return\\", handler.show(stack.getItem(_prevIndex), pageConfig, _prevIndex));
 
-                          case 46:
-                            _context.next = 49;
+                          case 52:
+                            _context.next = 55;
                             break;
 
-                          case 48:
+                          case 54:
                             if (action === \\"REPLACE\\") {
                                 _delta = stack.getDelta(pathname);
                                 handler.unload(currentPage, _delta);
@@ -4549,15 +4575,15 @@ exports[`vue3 should build vue3 app 2`] = `
                                 handler.hide(currentPage);
                             }
 
-                          case 49:
+                          case 55:
                             shouldLoad = true;
 
-                          case 50:
+                          case 56:
                             if (!(shouldLoad || stack.length < 1)) {
-                                _context.next = 59;
+                                _context.next = 65;
                                 break;
                             }
-                            el = (_g = element.default) !== null && _g !== void 0 ? _g : element;
+                            el = (_h = element.default) !== null && _h !== void 0 ? _h : element;
                             loadConfig = Object.assign({}, pageConfig);
                             stacksIndex = stack.length;
                             delete loadConfig[\\"path\\"];
@@ -4566,7 +4592,7 @@ exports[`vue3 should build vue3 app 2`] = `
                             if (params) page.options = params;
                             return _context.abrupt(\\"return\\", handler.load(page, pageConfig, stacksIndex));
 
-                          case 59:
+                          case 65:
                           case \\"end\\":
                             return _context.stop();
                         }


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
修复h5环境下reLaunch不执行show方法的问题A->B->A


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
