### PR TITLE
fix: 统一stylus的rule名称,方便webpack-chain获取

### DIFF
--- a/packages/taro-webpack-runner/src/util/chain.ts
+++ b/packages/taro-webpack-runner/src/util/chain.ts
@@ -498,7 +498,7 @@ export const parseModule = (appPath: string, {
     test: REG_LESS,
     use: [lessLoader]
   }
-  rule.styl = {
+  rule.stylus = {
     test: REG_STYLUS,
     use: [stylusLoader]
   }

--- a/packages/taro-webpack5-runner/src/webpack/H5WebpackModule.ts
+++ b/packages/taro-webpack5-runner/src/webpack/H5WebpackModule.ts
@@ -82,7 +82,7 @@ export class H5WebpackModule {
         test: REG_LESS,
         use: [lessLoader]
       },
-      styl: {
+      stylus: {
         test: REG_STYLUS,
         use: [stylusLoader]
       },


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

`stylus` 的 webpack module rule 的名称不一致

- `taro-mini-runner` 中是 `stylus`
- `taro-webpack5-runner `中是 `styl`
- `taro-webpack-runner `中是 `styl`
`webpack-chain` 获取的时候需要兼容,感觉没必要,希望统一修改成`stylus`


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
