### PR TITLE
fix: downloadFile方法的参数中增加timeout字段

### DIFF
--- a/packages/taro-h5/src/api/network/download.ts
+++ b/packages/taro-h5/src/api/network/download.ts
@@ -3,8 +3,8 @@ import Taro from '@tarojs/api'
 import { CallbackManager } from '../../utils/handler'
 import { NETWORK_TIMEOUT, setHeader, XHR_STATS } from './utils'
 
-const createDownloadTask = ({ url, header, withCredentials = true, success, error }): Taro.DownloadTask => {
-  let timeout: ReturnType<typeof setTimeout>
+const createDownloadTask = ({ url, header, withCredentials = true, timeout, success, error }): Taro.DownloadTask => {
+  let timeoutInter: ReturnType<typeof setTimeout>
   const apiName = 'downloadFile'
   const xhr = new XMLHttpRequest()
   const callbackManager = {
@@ -44,7 +44,7 @@ const createDownloadTask = ({ url, header, withCredentials = true, success, erro
   }
 
   xhr.onabort = () => {
-    clearTimeout(timeout)
+    clearTimeout(timeoutInter)
     error({
       errMsg: `${apiName}:fail abort`
     })
@@ -65,7 +65,7 @@ const createDownloadTask = ({ url, header, withCredentials = true, success, erro
 
   const send = () => {
     xhr.send()
-    timeout = setTimeout(() => {
+    timeoutInter = setTimeout(() => {
       xhr.onabort = null
       xhr.onload = null
       xhr.onprogress = null
@@ -75,7 +75,7 @@ const createDownloadTask = ({ url, header, withCredentials = true, success, erro
       error({
         errMsg: `${apiName}:fail timeout`
       })
-    }, NETWORK_TIMEOUT)
+    }, timeout || NETWORK_TIMEOUT)
   }
 
   send()
@@ -115,13 +115,14 @@ const createDownloadTask = ({ url, header, withCredentials = true, success, erro
  * 下载文件资源到本地。客户端直接发起一个 HTTPS GET 请求，返回文件的本地临时路径。使用前请注意阅读相关说明。
  * 注意：请在服务端响应的 header 中指定合理的 Content-Type 字段，以保证客户端正确处理文件类型。
  */
-export const downloadFile: typeof Taro.downloadFile = ({ url, header, withCredentials,success, fail, complete }) => {
+export const downloadFile: typeof Taro.downloadFile = ({ url, header, withCredentials, timeout, success, fail, complete }) => {
   let task!: Taro.DownloadTask
   const result: ReturnType<typeof Taro.downloadFile> = new Promise((resolve, reject) => {
     task = createDownloadTask({
       url,
       header,
       withCredentials,
+      timeout,
       success: res => {
         success && success(res)
         complete && complete(res)

--- a/packages/taro/types/api/network/download.d.ts
+++ b/packages/taro/types/api/network/download.d.ts
@@ -9,6 +9,8 @@ declare module '../../index' {
       filePath?: string
       /** HTTP 请求的 Header，Header 中不能设置 Referer */
       header?: TaroGeneral.IAnyObject
+      /** 超时时间，单位为毫秒 */
+      timeout?: number
       /** 是否应使用传出凭据 (cookie) 发送此请求
        * @default true
        * @supported h5


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

为 downloadFile 方法新增 `timeout` 字段，解决下载任务时长超过默认时间(60s)直接失败的问题。



**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #12648 
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] Web 平台（H5）
