### PR TITLE
fix(components): 修复H5开启下拉刷新后，进行下拉操作一级元素错位问题

### DIFF
--- a/packages/taro-components/src/components/pull-to-refresh-content/index.tsx
+++ b/packages/taro-components/src/components/pull-to-refresh-content/index.tsx
@@ -1,0 +1,27 @@
+import { Component, ComponentInterface, Element, h } from "@stencil/core";
+
+
+// https://developer.mozilla.org/zh-CN/docs/Web/API/Node/nodeType
+const UNUSED_DOCUMENT_NODE_TYPE = 0;
+
+@Component({
+  tag: 'taro-pull-to-refresh-content',
+})
+export class PullToRefreshContent implements ComponentInterface {
+
+  @Element() el: HTMLElement;
+
+  componentDidRender () {
+    // 通过mock数据的方式阻止stencil的diff传播更新，可能会造成之前的document寻址方式出现问题
+    // 想要解决这个问题还是推荐使用原生的web component进行重写
+    // https://github.com/ionic-team/stencil/blob/13621c258e086dfbc949ccc0d64d3c0fee85144b/src/runtime/vdom/vdom-render.ts#L730
+    Object.defineProperty(this.el, 'nodeType', {
+      value: UNUSED_DOCUMENT_NODE_TYPE,
+      writable: false,
+    });
+  }
+
+  render() {
+      return <slot />
+  }
+}

--- a/packages/taro-components/src/components/pull-to-refresh/pull-to-refresh.tsx
+++ b/packages/taro-components/src/components/pull-to-refresh/pull-to-refresh.tsx
@@ -282,7 +282,9 @@ export class PullToRefresh implements ComponentInterface {
                 <div />
               </div>
             )}
-            <slot />
+            <taro-pull-to-refresh-content>
+              <slot />
+            </taro-pull-to-refresh-content>
           </div>
         </div>
       )


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
**bug原因**
直接原因其实是`stencil`的`relocateSlotContent `重新定位slot元素的导致问题。
其内部使用的一种非常不同的，通过创建等量的text元素，从前到后的与真实元素进行比较的重定位形式。
当使用`React`修改`stencil`组件的`slot`内部第一层组件后，下拉刷新时会导致整个下拉组件重新定位，重新定位会不断向下传递，导致实际`stencil` 的重定位时的数组与真实元素数组不同（因为已经被`React`修改过了）。

https://github.com/ionic-team/stencil/blob/13621c258e086dfbc949ccc0d64d3c0fee85144b/src/runtime/vdom/vdom-render.ts#L658

所以会造成下拉刷新时出现一级元素错位的问题
解决方法能想到两种
1. 是使用原生web component 重写一个下拉组件
2. 跳过`stencil`内部的元素重新定位（本PR所选方案）

**修复方式**
通过mock元素类型，跳过`stencil` 内部的`relocateSlot`
https://github.com/ionic-team/stencil/blob/13621c258e086dfbc949ccc0d64d3c0fee85144b/src/runtime/vdom/vdom-render.ts#L730



**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #12838 
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
