### PR TITLE
fix(taro-cli): 序列化后的自定义变量未使用

### DIFF
--- a/packages/taro-cli/src/util/index.ts
+++ b/packages/taro-cli/src/util/index.ts
@@ -156,6 +156,6 @@ export const patchEnv = (config: IProjectConfig, expandEnv: Record<string, strin
   }
   return {
     ...config.env,
-    ...expandEnv
+    ...expandEnvStringify
   }
 }


### PR DESCRIPTION

**这个 PR 做了什么?** (简要描述所做更改)
读取的env自定义变量未序列化成字符串。

本来这个bug应该放到`3.5.8`版本修复的，我之前错误的合并到了`feta3.6.0` 分支。



**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
