### PR TITLE
fix: VirtualList absolute布局下 unlimitedSize setData刷新高度不生效

### DIFF
--- a/packages/taro-components/virtual-list/react/createListComponent.js
+++ b/packages/taro-components/virtual-list/react/createListComponent.js
@@ -505,7 +505,7 @@ export default function createListComponent ({
             style = this._getItemStyle(index)
           }
           items.push(createElement(itemElementType || itemTagName || 'div', {
-            key, style
+            key, style: {...style}
           }, createElement(children, {
             id: `${id}-${index}`,
             data: itemData,


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
VirtualList absolute布局下 unlimitedSize 刷新高度不生效后 触发了新的render 新style已应用
但实际setData到小程序的style并未改变


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
