### PR TITLE
fix(webpack-runner): 修复端口对比逻辑不正确的问题

### DIFF
--- a/packages/taro-webpack-runner/src/index.ts
+++ b/packages/taro-webpack-runner/src/index.ts
@@ -166,7 +166,7 @@ const buildDev = async (appPath: string, config: BuildConfig, appConfig: AppConf
     devServerOptions.useLocalIp = false
   }
 
-  const originalPort = devServerOptions.port
+  const originalPort = Number(devServerOptions.port)
   const availablePort = await detectPort(originalPort)
 
   if (availablePort !== originalPort) {

--- a/packages/taro-webpack5-runner/src/index.h5.ts
+++ b/packages/taro-webpack5-runner/src/index.h5.ts
@@ -251,8 +251,8 @@ async function getDevServerOptions (appPath: string, config: H5BuildConfig): Pro
     customDevServerOption
   )
 
-  const originalPort = devServerOptions.port
-  const availablePort = await detectPort(Number(originalPort))
+  const originalPort = Number(devServerOptions.port)
+  const availablePort = await detectPort(originalPort)
 
   if (availablePort !== originalPort) {
     console.log(`ℹ 预览端口 ${originalPort} 被占用, 自动切换到空闲端口 ${availablePort}`)


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复 `h5.devServer.port` 为字符串时， h5 端启动时的端口对比逻辑不正确导致展示不必要提示的问题（[issue #12946](https://github.com/NervJS/taro/issues/12946#issue-1482322960)）。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix [#12946](https://github.com/NervJS/taro/issues/12946#issue-1482322960)
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
