### PR TITLE
fix(wx): TypeError: Cannot read property 'route' of null 修复宿主环境同时使用插件页面和插件组件时currentPage.route异常中断插件组件渲染

### DIFF
--- a/packages/taro-plugin-react/src/runtime/connect-native.ts
+++ b/packages/taro-plugin-react/src/runtime/connect-native.ts
@@ -143,7 +143,7 @@ export function createNativeComponentConfig (Component, react: typeof React, rea
         type: null,
         value: null,
         observer (_newVal, oldVal) {
-          oldVal && this.component.forceUpdate()
+          oldVal && this.component?.forceUpdate()
         }
       }
     },
@@ -162,6 +162,7 @@ export function createNativeComponentConfig (Component, react: typeof React, rea
       safeExecute(this.compId, 'onReady')
     },
     detached () {
+      resetCurrent()
       Current.app!.unmount!(this.compId)
     },
     pageLifetimes: {
@@ -181,6 +182,12 @@ export function createNativeComponentConfig (Component, react: typeof React, rea
         safeExecute(this.compId, 'onUnload')
       }
     }
+  }
+  
+  function resetCurrent () {
+    // 小程序插件页面卸载之后返回到宿主页面时，需重置Current页面和路由。否则引发插件组件二次加载异常 fix:#11991
+    Current.page = null
+    Current.router = null
   }
 
   function setCurrent (compId: string) {

--- a/packages/taro-plugin-vue3/src/runtime/connect-native.ts
+++ b/packages/taro-plugin-vue3/src/runtime/connect-native.ts
@@ -152,7 +152,7 @@ export function createNativeComponentConfig (component, h: typeof createElement,
         type: null,
         value: null,
         observer (_newVal, oldVal) {
-          oldVal && this.component.$forceUpdate()
+          oldVal && this.component?.$forceUpdate()
         }
       }
     },
@@ -171,6 +171,7 @@ export function createNativeComponentConfig (component, h: typeof createElement,
       safeExecute(this.compId, 'onReady')
     },
     detached () {
+      resetCurrent()
       Current.app!.unmount!(this.compId)
       this.component = null
     },
@@ -185,6 +186,12 @@ export function createNativeComponentConfig (component, h: typeof createElement,
     methods: {
       eh: eventHandler
     }
+  }
+
+  function resetCurrent () {
+    // 小程序插件页面卸载之后返回到宿主页面时，需重置Current页面和路由。否则引发插件组件二次加载异常 fix:#11991
+    Current.page = null
+    Current.router = null
   }
 
   function setCurrent (compId: string) {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
- 修复微信小程序宿主页面同时使用插件组件和插件页面场景中，插件页面回退到宿主页面之后未正确处理插件中页面实例对象而导致宿主环境中使用的插件组件二次加载异常。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #11991

**这个 PR 涉及以下平台:**

- [x] 微信小程序