### PR TITLE
fix(prebundle): 修复支付宝开启小程序基础库2.0构建报错，fix #12879

### DIFF
--- a/packages/taro-webpack5-prebundle/src/prebundle/bundle.ts
+++ b/packages/taro-webpack5-prebundle/src/prebundle/bundle.ts
@@ -231,10 +231,10 @@ export function getSwcPlugin ({
               fs.move(srcPath, destPath)
                 .then(() => fs.writeFile(
                   srcPath,
-                  `var m = require('./${path.basename(destPath)}')
-module.exports = m.default
-exports.default = module.exports
-`
+                  `var m = require('./${path.basename(destPath)}');
+                   module.exports = m.default;
+                   exports.default = module.exports;
+                  `
                 ))
             )
           }

--- a/packages/taro-webpack5-prebundle/src/prebundle/bundle.ts
+++ b/packages/taro-webpack5-prebundle/src/prebundle/bundle.ts
@@ -231,7 +231,7 @@ export function getSwcPlugin ({
               fs.move(srcPath, destPath)
                 .then(() => fs.writeFile(
                   srcPath,
-                  `const m = require('./${path.basename(destPath)}')
+                  `var m = require('./${path.basename(destPath)}')
 module.exports = m.default
 exports.default = module.exports
 `


### PR DESCRIPTION
`const` 导致报错`The keyword 'const' is reserved`

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

Taro 开启 `prebundle` , 支付宝开启 `小程序基础库2.0构建` 后，由于代码中存在`const`导致支付宝小程序加载报错 `The keyword 'const' is reserved`
比如如下代码：
```
const m = __webpack_require__(/*! ./react.core.js */ "./node_modules/.taro/alipay/prebundle/react.core.js")
module.exports = m.default
exports["default"] = module.exports
```

故将 `const` 改为 `var`

fix #12879

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [x] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
