### PR TITLE
fix: modify buildDependencies default value

### DIFF
--- a/packages/taro-webpack5-runner/src/webpack/BaseConfig.ts
+++ b/packages/taro-webpack5-runner/src/webpack/BaseConfig.ts
@@ -1,4 +1,4 @@
-import { chalk, recursiveMerge } from '@tarojs/helper'
+import { chalk, recursiveMerge, resolveScriptPath } from '@tarojs/helper'
 import { MultiPlatformPlugin } from '@tarojs/runner-utils'
 import path from 'path'
 import { Stats } from 'webpack'
@@ -88,7 +88,8 @@ export class BaseConfig {
         type: 'filesystem',
         // 让缓存失效
         buildDependencies: {
-          config: [path.join(appPath, 'config/index.js')]
+          // 与 Config 中处理的配置文件保持一致
+          config: [resolveScriptPath(path.join(appPath, 'config', 'index'))]
         },
         name: `${process.env.NODE_ENV}-${process.env.TARO_ENV}`
       }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
当配置文件为 ts 时， 由于 cache 的 配置是通过递归merge 得到的， 导致 config/index.js 配置用户无法覆盖
`
<w> [webpack.cache.PackFileCacheStrategy] Caching failed for pack: Error: Can't resolve 'xx/node_modules/@tarojs/webpack5-runner/dist/webpack' in 'xxx'
<w> while resolving 'xxx/node_modules/@tarojs/webpack5-runner/dist/webpack' in xxx as file
<w>  at resolve commonjs xx/node_modules/@tarojs/webpack5-runner/dist/webpack
`
修改  cache.buildDependencies 中 config 的 默认值， 通过 resolveScriptPath 方法， 与 Config 中解析的配置文件保持一致


**需要测试验证**

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
