### PR TITLE
fix(taro-alipay): 修复支付宝showToast的option.icon的error与fail的映射问题

### DIFF
--- a/packages/taro-alipay/src/apis.ts
+++ b/packages/taro-alipay/src/apis.ts
@@ -35,6 +35,15 @@ const apiDiff: IApiDiff = {
       }, {
         old: 'icon',
         new: 'type'
+      }],
+      set: [{
+        key: 'type',
+        value (options) {
+          if (options.type === 'error') {
+            return 'fail'
+          }
+          return options.type
+        }
       }]
     }
   },

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/alipay.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/alipay.spec.ts.snap
@@ -101,6 +101,15 @@ require(\\"./taro\\");
                         }, {
                             old: \\"icon\\",
                             new: \\"type\\"
+                        } ],
+                        set: [ {
+                            key: \\"type\\",
+                            value: function value(options) {
+                                if (options.type === \\"error\\") {
+                                    return \\"fail\\";
+                                }
+                                return options.type;
+                            }
                         } ]
                     }
                 },

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/bytedance.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/bytedance.spec.ts.snap
@@ -222,6 +222,13 @@ require(\\"./taro\\");
                 bindInit: _empty,
                 bindSuccess: _empty,
                 bindError: _empty
+            },
+            OpenData: {
+                type: _empty,
+                \\"default-text\\": _empty,
+                \\"default-avatar\\": _empty,
+                \\"use-empty-value\\": _false,
+                bindError: _empty
             }
         };
         var hostConfig = {

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/bytedance.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/bytedance.spec.ts.snap
@@ -222,13 +222,6 @@ require(\\"./taro\\");
                 bindInit: _empty,
                 bindSuccess: _empty,
                 bindError: _empty
-            },
-            OpenData: {
-                type: _empty,
-                \\"default-text\\": _empty,
-                \\"default-avatar\\": _empty,
-                \\"use-empty-value\\": _false,
-                bindError: _empty
             }
         };
         var hostConfig = {

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/tabbar.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/tabbar.spec.ts.snap
@@ -101,6 +101,15 @@ require(\\"./taro\\");
                         }, {
                             old: \\"icon\\",
                             new: \\"type\\"
+                        } ],
+                        set: [ {
+                            key: \\"type\\",
+                            value: function value(options) {
+                                if (options.type === \\"error\\") {
+                                    return \\"fail\\";
+                                }
+                                return options.type;
+                            }
                         } ]
                     }
                 },


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复Issue#13073：Taro.showToast的icon的error需要支持支付宝type图标显示，fail可以，error不行

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #13073
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [x] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
