### PR TITLE
refactor(react): 因升级react-reconciler而做的必要代码调整

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@types/node": "^14.14.31",
     "@types/postcss-import": "^12.0.0",
     "@types/react": "^18.0.0",
-    "@types/react-reconciler": "0.26.1",
+    "@types/react-reconciler": "0.28.1",
     "@types/request": "^2.48.1",
     "@types/resolve": "1.19.0",
     "@types/sass": "^1.16.1",

--- a/packages/taro-plugin-react/src/webpack.mini.ts
+++ b/packages/taro-plugin-react/src/webpack.mini.ts
@@ -23,7 +23,6 @@ function setAlias (ctx: IPluginContext, framework: Frameworks, chain) {
       // 不是生产环境，且没有设置 debugReact，则使用压缩版本的 react 依赖，减少体积
       alias.set('react-reconciler$', 'react-reconciler/cjs/react-reconciler.production.min.js')
       alias.set('react$', 'react/cjs/react.production.min.js')
-      alias.set('scheduler$', 'scheduler/cjs/scheduler.production.min.js')
       alias.set('react/jsx-runtime$', 'react/cjs/react-jsx-runtime.production.min.js')
 
       // 在React18中，使用了exports字段约定了模块暴露路径，其中并未暴露 ./cjs/ 。这将使上面的alias在编译时报错。相当的tricky。

--- a/packages/taro-react/README.md
+++ b/packages/taro-react/README.md
@@ -1,3 +1,284 @@
 # @tarojs/react
 
 基于 `react-reconciler` 的小程序专用 React 渲染器，连接 `@tarojs/runtime 的 DOM 实例，相当于小程序版的 `react-dom`，暴露的 API 也和 `react-dom` 保持一致。
+
+## HostConfig for Taro
+
+Taro 对 HostConfig 进行了针对性的改造，以适应小程序环境。现对各字段进行阐述，具体实现以文件 `./src/reconciler.ts` 为准。
+
+字段的含义描述来源于 [react-reconciler](https://www.npmjs.com/package/react-reconciler/v/0.27.0)
+
+### getPublicInstance(instance)
+
+> Determines what object gets exposed as a ref. If you don't want to do anything here, return instance.
+
+Taro: 默认返回 instance 即可
+
+### getRootHostContext(rootContainer)
+
+> This method lets you return the initial host context from the root of the tree. If you don't intend to use host context, you can return null.
+
+Taro: 默认返回 {}
+
+### getChildHostContext(parentHostContext, type, rootContainer)
+
+> Host context lets you track some information about where you are in the tree so that it's available inside createInstance as the hostContext parameter.
+
+Taro: 默认返回 {}
+
+### resetAfterCommit(containerInfo)
+
+> This method is called right after React has performed the tree mutations. You can leave it empty.
+
+Taro: 该方法置空
+
+### prepareForCommit(containerInfo)
+
+> This method lets you store some information before React starts making changes to the tree on the screen. 
+
+Taro: 返回 null 即可.
+
+### createInstance(type, props, rootContainer, hostContext, internalHandle)
+
+> This method should return a newly created node. For example, the DOM renderer would call document.createElement(type) here and then set the properties from props.
+
+Taro: 在 ReactDOM 中会调用 document.createElement 来生成 dom，而在小程序环境中 Taro 中模拟了 document，直接返回 `document.createElement(type)` 即可
+
+> 也因为 Taro 没有使用其他入参，因此方法 getRootHostContext / getChildHostContext 默认返回 {} 即可
+
+### appendInitialChild(parentInstance, child)
+
+> This method should mutate the parentInstance and add the child to its list of children. For example, in the DOM this would translate to a parentInstance.appendChild(child) call.
+
+Taro: 直接 parentInstance.appendChild(child) 即可
+
+### finalizeInitialChildren(instance, type, props, rootContainer, hostContext)
+
+> In this method, you can perform some final mutations on the instance. There is a second purpose to this method. It lets you specify whether there is some work that needs to happen when the node is connected to the tree on the screen. If you return true, the instance will receive a commitMount call later. See its documentation below.
+
+finalizeInitialChildren 在组件挂载到页面中前调用，更新时不会调用.
+
+Taro: 遍历 props，更新到 instance 中即可，同时返回false，即不需要调用 `commitMount` 方法
+
+#### prepareUpdate(instance, type, oldProps, newProps, rootContainer, hostContext)
+
+> React calls this method so that you can compare the previous and the next props, and decide whether you need to update the underlying instance or not. If you need to update it, you can return an arbitrary object representing the changes that need to happen. Then in commitUpdate you would need to apply those changes to the instance.
+
+prepareUpdate 的返回结果是 `commitUpdate` 的第二个入参。prepareUpdate 主要作用是render阶段计算出dom的哪些属性需要更新，这样在 commitUpdate 方法在commit阶段中可以快速更新dom，提高性能.
+
+Taro: 对比 oldProps、newProps 计算出差异点，返回 `[prop1, value1, prop2, value2, ...]` .
+
+### shouldSetTextContent(type, props)
+
+> Some target platforms support setting an instance's text content without manually creating a text node. 
+
+Taro: taro 模拟的 text 支持直接赋值 textContent (`packages/taro-runtime/src/dom/text.ts`)，该方法返回 false 即可.
+
+> 因返回false，因此 resetTextContent 不会被调用
+
+### createTextInstance(text, rootContainer, hostContext, internalHandle)
+
+> Same as createInstance, but for text nodes. If your renderer doesn't support text nodes, you can throw here.
+
+Taro: 模拟的 document 支持创建 text 节点， 返回 `document.createTextNode(text)` 即可.
+
+### scheduleTimeout(fn, delay)
+
+> You can proxy this to setTimeout or its equivalent in your environment.
+
+Taro: setTimeout
+
+### cancelTimeout(id)
+
+> You can proxy this to clearTimeout or its equivalent in your environment.
+
+Taro: clearTimeout
+
+### noTimeout
+
+> This is a property (not a function) that should be set to something that can never be a valid timeout ID. For example, you can set it to -1.
+
+Taro: -1
+
+### isPrimaryRenderer
+
+> This is a property (not a function) that should be set to true if your renderer is the main one on the page.
+
+Taro: true
+
+### warnsIfNotActing
+
+> Only used in development mode.
+
+Taro: true
+
+### supportsMutation
+
+> If your target platform is similar to the DOM and has methods similar to appendChild, removeChild, and so on, you'll want to use the mutation mode.
+
+Taro: true
+
+### supportsPersistence
+
+> If your target platform has immutable trees, you'll want the persistent mode instead. 
+
+Taro: false
+
+### supportsHydration
+
+> is support hydration
+
+Taro: false
+
+### getInstanceFromNode(hostRoot)
+
+> 自定义获取 instance 的逻辑
+
+Taro: 返回 null，React 内部会继续调用 `findFiberRoot` 方法获取.
+
+### beforeActiveInstanceBlur
+
+> flag enableCreateEventHandleAPI is false, never call it
+
+Taro: 置空
+
+### afterActiveInstanceBlur
+
+> flag enableCreateEventHandleAPI is false, never call it
+
+Taro: 置空
+
+### preparePortalMount(containerInfo)
+
+> This method is called for a container that's used as a portal target. Usually you can leave it empty.
+
+Taro: 暂不支持 portal，置空即可
+
+### prepareScopeUpdate
+
+> flag enableScopeAPI is false, never call it
+
+Taro: 置空
+
+### getInstanceFromScope
+
+> flag enableScopeAPI is false, never call it
+
+Taro: 返回 null 即可
+
+### getCurrentEventPriority
+
+> The constant you return depends on which event, if any, is being handled right now.
+
+Taro: 默认为点击事件，返回 `DefaultEventPriority` 即可
+
+### detachDeletedInstance
+
+> 当 fiber 被标记为 Deletion 时，dom被卸载后，从dom节点上删除 react 初始化的内容，如 __reactProps$xxxx 等. 详见[React源码](https://github.com/facebook/react/blob/973b90bdf6f4a1d9b3864d93985d4a204f233855/packages/react-dom-bindings/src/client/ReactDOMComponentTree.js#L54)
+
+Taro: 因taro无法获取到 $xxxx 随机数，因此暂无法实现善后工作，该方法置空. 但可以根据字段是否 `__react` 开头来实现。
+
+### supportsMicrotasks
+
+> 是否支持微任务
+
+Taro: true
+
+### scheduleMicrotask
+
+> 微任务方法 polyfill
+
+Taro: 使用 promise.then 模拟实现，或直接使用 setTimeout
+
+**以下字段因 `supportsMutation=true` 而需要被实现**
+### appendChild(parentInstance, child)
+
+> This method should mutate the parentInstance and add the child to its list of children. 
+
+Taro: 调用 `parentInstance.appendChild(child)` 即可
+
+### appendChildToContainer(container, child)
+
+> Same as appendChild, but for when a node is attached to the root container.
+
+Taro: 调用 `parentInstance.appendChild(child)` 即可
+
+### commitTextUpdate(textInstance, prevText, nextText)
+
+> This method should mutate the textInstance and update its text content to nextText.
+
+Taro: 赋值 `textInstance.nodeValue` 即可
+
+### commitMount(instance, type, props, internalHandle)
+
+> This method is only called if you returned true from finalizeInitialChildren for this instance.
+
+Taro: 因 `finalizeInitialChildren` 返回 false，该方法置空
+
+### commitUpdate(instance, updatePayload, type, prevProps, nextProps, internalHandle)
+
+> This method should mutate the instance according to the set of changes in updatePayload.
+
+Taro: 根据 updatePayload，将属性更新到 instance 中，此时 updatePayload 是一个类似 `[prop1, value1, prop2, value2, ...]` 的数组
+
+> 如果 updatePayload 为 null，该方法在 React 内部不会被调用
+
+### insertBefore(parentInstance, child, beforeChild)
+
+> This method should mutate the parentInstance and place the child before beforeChild in the list of its children.
+
+Taro: 调用 `parentInstance.insertBefore(child)` 即可
+
+### insertInContainerBefore(container, child, beforeChild)
+
+> Same as insertBefore, but for when a node is attached to the root container.
+
+Taro: 调用 `container.insertBefore(child)` 即可
+
+### removeChild(parentInstance, child)
+
+> This method should mutate the parentInstance to remove the child from the list of its children.
+
+Taro: 调用 `parentInstance.removeChild(child)` 即可
+
+### removeChildFromContainer(container, child)
+
+> Same as removeChild, but for when a node is detached from the root container.
+
+Taro: 调用 `container.removeChild(child)` 即可
+
+### resetTextContent(instance)
+
+> If you never return true from shouldSetTextContent, you can leave it empty.
+
+Taro: 该方法置空
+
+### hideInstance(instance)
+
+> This method should make the instance invisible without removing it from the tree.
+
+Taro: `display` 样式置为 `none` 即可
+
+### hideTextInstance(textInstance)
+
+> Same as hideInstance, but for nodes created by createTextInstance.
+
+Taro: `textInstance.nodeValue = ''` 即可
+
+### unhideInstance(instance, props)
+
+> This method should make the instance visible, undoing what hideInstance did.
+
+Taro: `display` 样式重置即可
+
+### unhideTextInstance(textInstance, text)
+
+> Same as unhideInstance, but for nodes created by createTextInstance.
+
+Taro: `textInstance.nodeValue = text` 即可
+
+### clearContainer(container)
+
+> This method should mutate the container root node and remove all children from it.
+
+Taro: 将 `container` 所有孩子节点 `nodeValue` 置空即可

--- a/packages/taro-react/package.json
+++ b/packages/taro-react/package.json
@@ -26,8 +26,7 @@
   "dependencies": {
     "@tarojs/runtime": "workspace:*",
     "@tarojs/shared": "workspace:*",
-    "react-reconciler": "0.27.0",
-    "scheduler": "^0.20.1"
+    "react-reconciler": "0.27.0"
   },
   "devDependencies": {
     "react": "^18.2.0"

--- a/packages/taro-react/rollup.config.js
+++ b/packages/taro-react/rollup.config.js
@@ -14,7 +14,7 @@ const baseConfig = {
       exports: 'named'
     }
   ],
-  external: ['@tarojs/runtime', 'scheduler', 'react-reconciler', '@tarojs/shared'],
+  external: ['@tarojs/runtime', 'react-reconciler', '@tarojs/shared'],
   plugins: [
     ts(),
     buble()

--- a/packages/taro-react/src/props.ts
+++ b/packages/taro-react/src/props.ts
@@ -10,19 +10,36 @@ function isEventName (s: string) {
 const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i
 
 export function updateProps (dom: TaroElement, oldProps: Props, newProps: Props) {
+  const updatePayload = getUpdatePayload(dom, oldProps, newProps)
+  if(updatePayload){
+    updatePropsByPayload(dom, oldProps, updatePayload)
+  }
+}
+
+export function updatePropsByPayload (dom: TaroElement, oldProps: Props, updatePayload: any[]){
+  for(let i = 0; i < updatePayload.length; i += 2){ // key, value 成对出现
+    const key = updatePayload[i]; const newProp = updatePayload[i+1]; const oldProp = oldProps[key]
+    setProperty(dom, key, newProp, oldProp)
+  }
+}
+
+export function getUpdatePayload (dom: TaroElement, oldProps: Props, newProps: Props){
   let i: string
+  let updatePayload: any[] | null = null
 
   for (i in oldProps) {
     if (!(i in newProps)) {
-      setProperty(dom, i, null, oldProps[i])
+      (updatePayload = updatePayload || []).push(i, null)
     }
   }
   const isFormElement = dom instanceof FormElement
   for (i in newProps) {
     if (oldProps[i] !== newProps[i] || (isFormElement && i === 'value')) {
-      setProperty(dom, i, newProps[i], oldProps[i])
+      (updatePayload = updatePayload || []).push(i, newProps[i])
     }
   }
+
+  return updatePayload
 }
 
 // function eventProxy (e: CommonEvent) {

--- a/packages/taro-react/src/reconciler.ts
+++ b/packages/taro-react/src/reconciler.ts
@@ -1,18 +1,10 @@
 /* eslint-disable @typescript-eslint/indent */
 import { document, TaroElement, TaroText } from '@tarojs/runtime'
-import { EMPTY_ARR, isBoolean, isUndefined, noop } from '@tarojs/shared'
+import { isBoolean, isUndefined, noop } from '@tarojs/shared'
 import Reconciler, { HostConfig } from 'react-reconciler'
-import * as scheduler from 'scheduler'
+import { DefaultEventPriority } from 'react-reconciler/constants'
 
-import { Props, updateProps } from './props'
-
-const {
-  unstable_now: now
-} = scheduler
-
-function returnFalse () {
-  return false
-}
+import { getUpdatePayload, Props, updateProps, updatePropsByPayload } from './props'
 
 const hostConfig: HostConfig<
   string, // Type
@@ -28,129 +20,131 @@ const hostConfig: HostConfig<
   unknown, // ChildSet
   unknown, // TimeoutHandle
   unknown // NoTimeout
-> & {
-  hideInstance (instance: TaroElement): void
-  unhideInstance (instance: TaroElement, props): void
-  getCurrentEventPriority(): number
-  detachDeletedInstance(): void
-} = {
-  createInstance (type) {
-    return document.createElement(type)
-  },
+> = {
+  // below keys order by {React ReactFiberHostConfig.custom.js}, convenient for comparing each other.
 
-  createTextInstance (text) {
-    return document.createTextNode(text)
-  },
-
+  // -------------------
+  // required by @types/react-reconciler
+  // -------------------
   getPublicInstance (inst: TaroElement) {
     return inst
   },
-
   getRootHostContext () {
     return {}
   },
-
-  getChildHostContext () {
-    return {}
+  getChildHostContext (parentHostContext) {
+    return parentHostContext
   },
-
-  getCurrentEventPriority () {
-    // 因 @types/react-reconciler 未更新，ts会报错，这里直接返回16
-    return 16 // import { DefaultEventPriority } from 'react-reconciler/constants'
+  prepareForCommit (..._: any[]) {
+    return null
   },
-
-  detachDeletedInstance () {
-    // noop
+  resetAfterCommit: noop,
+  createInstance (type) {
+    return document.createElement(type)
   },
-
-  appendChild (parent, child) {
-    parent.appendChild(child)
-  },
-
   appendInitialChild (parent, child) {
     parent.appendChild(child)
   },
+  finalizeInitialChildren (dom, _, props: any) {
+    updateProps(dom, {}, props)  // 提前执行更新属性操作，Taro 在 Page 初始化后会立即从 dom 读取必要信息
+    return false
+  },
+  prepareUpdate (instance, _, oldProps, newProps) {
+    return getUpdatePayload(instance, oldProps, newProps)
+  },
+  shouldSetTextContent () {
+    return false
+  },
+  createTextInstance (text) {
+    return document.createTextNode(text)
+  },
+  scheduleTimeout: setTimeout,
+  cancelTimeout: clearTimeout,
+  noTimeout: -1,
+  isPrimaryRenderer: true,
+  warnsIfNotActing: true,
+  supportsMutation: true,
+  supportsPersistence: false,
+  supportsHydration: false,
+  getInstanceFromNode: () => null,
+  beforeActiveInstanceBlur: noop,
+  afterActiveInstanceBlur: noop,
+  preparePortalMount: noop,
+  prepareScopeUpdate: noop,
+  getInstanceFromScope: () => null,
+  getCurrentEventPriority () {
+    return DefaultEventPriority
+  },
+  detachDeletedInstance: noop,
 
+  // -------------------
+  //      Microtasks
+  //     (optional)
+  // -------------------
+  supportsMicrotasks: true,
+  scheduleMicrotask: isUndefined(Promise)
+    ? setTimeout
+    : (callback) =>
+        Promise.resolve(null)
+          .then(callback)
+          .catch(function (error) {
+            setTimeout(() => {
+              throw error
+            })
+          }),
+
+  // -------------------
+  //      Mutation
+  //     (required if supportsMutation is true)
+  // -------------------
+  appendChild (parent, child) {
+    parent.appendChild(child)
+  },
   appendChildToContainer (parent, child) {
     parent.appendChild(child)
   },
-
-  removeChild (parent, child) {
-    parent.removeChild(child)
-  },
-
-  removeChildFromContainer (parent, child) {
-    parent.removeChild(child)
-  },
-
-  insertBefore (parent, child, refChild) {
-    parent.insertBefore(child, refChild)
-  },
-
-  insertInContainerBefore (parent, child, refChild) {
-    parent.insertBefore(child, refChild)
-  },
-
   commitTextUpdate (textInst, _, newText) {
     textInst.nodeValue = newText
   },
-
-  finalizeInitialChildren (dom, _, props) {
-    updateProps(dom, {}, props)
-    return false
+  commitMount: noop,
+  commitUpdate (dom, updatePayload, _, oldProps) {
+    updatePropsByPayload(dom, oldProps, updatePayload)
   },
-
-  prepareUpdate () {
-    return EMPTY_ARR
+  insertBefore (parent, child, refChild) {
+    parent.insertBefore(child, refChild)
   },
-
-  commitUpdate (dom, _payload, _type, oldProps, newProps) {
-    updateProps(dom, oldProps, newProps)
+  insertInContainerBefore (parent, child, refChild) {
+    parent.insertBefore(child, refChild)
   },
-
+  removeChild (parent, child) {
+    parent.removeChild(child)
+  },
+  removeChildFromContainer (parent, child) {
+    parent.removeChild(child)
+  },
+  resetTextContent: noop,
   hideInstance (instance) {
     const style = instance.style
     style.setProperty('display', 'none')
   },
-
+  hideTextInstance (textInstance) {
+    textInstance.nodeValue = ''
+  },
   unhideInstance (instance, props) {
-    const styleProp = props.style
+    const styleProp = props.style as {display?: any}
     let display = styleProp?.hasOwnProperty('display') ? styleProp.display : null
     display = display == null || isBoolean(display) || display === '' ? '' : ('' + display).trim()
     // eslint-disable-next-line dot-notation
     instance.style['display'] = display
   },
-
+  unhideTextInstance (textInstance, text) {
+    textInstance.nodeValue = text
+  },
   clearContainer (element) {
     if (element.childNodes.length > 0) {
       element.textContent = ''
     }
   },
-
-  queueMicrotask: !isUndefined(Promise)
-  ? callback =>
-      Promise.resolve(null)
-        .then(callback)
-        .catch(function (error) {
-          setTimeout(() => {
-            throw error
-          })
-        })
-  : setTimeout,
-
-  shouldSetTextContent: returnFalse,
-  prepareForCommit (..._: any[]) { return null },
-  resetAfterCommit: noop,
-  commitMount: noop,
-  now,
-  cancelTimeout: clearTimeout,
-  scheduleTimeout: setTimeout,
-  preparePortalMount: noop,
-  noTimeout: -1,
-  supportsMutation: true,
-  supportsPersistence: false,
-  isPrimaryRenderer: true,
-  supportsHydration: false
 }
 
 const TaroReconciler = Reconciler(hostConfig)
@@ -159,14 +153,17 @@ if (process.env.NODE_ENV !== 'production') {
   const foundDevTools = TaroReconciler.injectIntoDevTools({
     bundleType: 1,
     version: '18.0.0',
-    rendererPackageName: 'taro-react'
+    rendererPackageName: 'taro-react',
   })
   if (!foundDevTools) {
     // eslint-disable-next-line no-console
-    console.info('%cDownload the React DevTools ' + 'for a better development experience: ' + 'https://reactjs.org/link/react-devtools', 'font-weight:bold')
+    console.info(
+      '%cDownload the React DevTools ' +
+        'for a better development experience: ' +
+        'https://reactjs.org/link/react-devtools',
+      'font-weight:bold'
+    )
   }
 }
 
-export {
-  TaroReconciler
-}
+export { TaroReconciler }

--- a/packages/taro-react/src/reconciler.ts
+++ b/packages/taro-react/src/reconciler.ts
@@ -20,7 +20,9 @@ const hostConfig: HostConfig<
   unknown, // ChildSet
   unknown, // TimeoutHandle
   unknown // NoTimeout
-> = {
+> & {
+  supportsMicrotasks: boolean  // 待官方类型文件修复后删除
+} = {
   // below keys order by {React ReactFiberHostConfig.custom.js}, convenient for comparing each other.
 
   // -------------------

--- a/packages/taro-react/src/render.ts
+++ b/packages/taro-react/src/render.ts
@@ -8,16 +8,72 @@ export const ContainerMap: WeakMap<TaroElement, Root> = new WeakMap()
 
 type Renderer = typeof TaroReconciler
 
+type CreateRootOptions = {
+  unstable_strictMode?: boolean
+  unstable_concurrentUpdatesByDefault?: boolean
+  unstable_transitionCallbacks?: any
+  identifierPrefix?: string
+  onRecoverableError?: (error: any) => void
+}
+
 export type Callback = () => void | null | undefined
 
 class Root {
   private renderer: Renderer
   private internalRoot: OpaqueRoot
 
-  public constructor (renderer: Renderer, domContainer: TaroElement, isConcurrentRoot = false) {
+  public constructor (renderer: Renderer, domContainer: TaroElement, options?: CreateRootOptions) {
     this.renderer = renderer
-    /** ConcurrentRoot & LegacyRoot: react-reconciler/src/ReactRootTags.js */
-    this.internalRoot = renderer.createContainer(domContainer, isConcurrentRoot ? 1 : 0, false, null)
+    this.initInternalRoot(renderer, domContainer, options)
+  }
+
+  private initInternalRoot (renderer: Renderer, domContainer: TaroElement, options?: CreateRootOptions) {
+    // Since react-reconciler v0.27, createContainer need more parameters
+    // @see:https://github.com/facebook/react/blob/0b974418c9a56f6c560298560265dcf4b65784bc/packages/react-reconciler/src/ReactFiberReconciler.js#L248
+    const containerInfo = domContainer
+    if (options) {
+      const tag = 1 // ConcurrentRoot
+      const concurrentUpdatesByDefaultOverride = false
+      let isStrictMode = false
+      let identifierPrefix = ''
+      let onRecoverableError = (error: any) => console.error(error)
+      let transitionCallbacks = null
+      if (options.unstable_strictMode === true) {
+        isStrictMode = true
+      }
+      if (options.identifierPrefix !== undefined) {
+        identifierPrefix = options.identifierPrefix
+      }
+      if (options.onRecoverableError !== undefined) {
+        onRecoverableError = options.onRecoverableError
+      }
+      if (options.unstable_transitionCallbacks !== undefined) {
+        transitionCallbacks = options.unstable_transitionCallbacks
+      }
+
+      this.internalRoot = renderer.createContainer(
+        containerInfo,
+        tag,
+        null, // hydrationCallbacks
+        isStrictMode,
+        concurrentUpdatesByDefaultOverride,
+        identifierPrefix,
+        onRecoverableError,
+        transitionCallbacks
+      )
+    } else {
+      const tag = 0 // LegacyRoot
+      this.internalRoot = renderer.createContainer(
+        containerInfo,
+        tag,
+        null, // hydrationCallbacks
+        false, // isStrictMode
+        false, // concurrentUpdatesByDefaultOverride,
+        '', // identifierPrefix
+        () => {}, // onRecoverableError, this isn't reachable because onRecoverableError isn't called in the legacy API.
+        null // transitionCallbacks
+      )
+    }
   }
 
   public render (children: ReactNode, cb: Callback) {
@@ -42,12 +98,13 @@ export function render (element: ReactNode, domContainer: TaroElement, cb: Callb
   return root.render(element, cb)
 }
 
-export function createRoot (domContainer: TaroElement) {
+export function createRoot (domContainer: TaroElement, options: CreateRootOptions = {}) {
   const oldRoot = ContainerMap.get(domContainer)
   if (oldRoot != null) {
     return oldRoot
   }
-  const root = new Root(TaroReconciler, domContainer, true)
+  // options should be an object
+  const root = new Root(TaroReconciler, domContainer, options)
   ContainerMap.set(domContainer, root)
   return root
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,7 +72,7 @@ importers:
       '@types/node': ^14.14.31
       '@types/postcss-import': ^12.0.0
       '@types/react': ^18.0.0
-      '@types/react-reconciler': 0.26.1
+      '@types/react-reconciler': 0.28.1
       '@types/request': ^2.48.1
       '@types/resolve': 1.19.0
       '@types/sass': ^1.16.1
@@ -227,7 +227,7 @@ importers:
       '@types/node': registry.npmjs.org/@types/node/14.18.21
       '@types/postcss-import': registry.npmjs.org/@types/postcss-import/12.0.1
       '@types/react': registry.npmjs.org/@types/react/18.0.14
-      '@types/react-reconciler': registry.npmjs.org/@types/react-reconciler/0.26.1
+      '@types/react-reconciler': registry.npmjs.org/@types/react-reconciler/0.28.1
       '@types/request': registry.npmjs.org/@types/request/2.48.8
       '@types/resolve': registry.npmjs.org/@types/resolve/1.19.0
       '@types/sass': registry.npmjs.org/@types/sass/1.43.1
@@ -683,6 +683,9 @@ importers:
       react-native-svg: registry.npmjs.org/react-native-svg/12.4.3_ws5w265lwlgfx6ddpl3mdiooma
       react-test-renderer: registry.npmjs.org/react-test-renderer/18.0.0_react@18.0.0
 
+  packages/taro-components/loader:
+    specifiers: {}
+
   packages/taro-extend:
     specifiers: {}
 
@@ -1048,12 +1051,10 @@ importers:
       '@tarojs/shared': workspace:*
       react: ^18.2.0
       react-reconciler: 0.27.0
-      scheduler: ^0.20.1
     dependencies:
       '@tarojs/runtime': link:../taro-runtime
       '@tarojs/shared': link:../shared
       react-reconciler: registry.npmjs.org/react-reconciler/0.27.0_react@18.2.0
-      scheduler: registry.npmjs.org/scheduler/0.20.2
     devDependencies:
       react: registry.npmjs.org/react/18.2.0
 
@@ -8460,10 +8461,10 @@ packages:
       '@types/react': registry.npmjs.org/@types/react/18.0.14
     dev: true
 
-  registry.npmjs.org/@types/react-reconciler/0.26.1:
-    resolution: {integrity: sha512-jeizEH5o/k6tv42RYNbaulR9KvoSM4RAUq1Q2SXd2HZ7dqgTxN9OIf+GU/sErT7CohB/mUxy9hSjaRLiCPGF5w==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.26.1.tgz}
+  registry.npmjs.org/@types/react-reconciler/0.28.1:
+    resolution: {integrity: sha512-ExBHUBykCcDh0HqqlJb6BA1yNpvW2iluIThK9tr1CX2tRMe3HeLt5/ow/bTpKGWoRBE5v/ISXFyjbnHRSKT6ng==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.1.tgz}
     name: '@types/react-reconciler'
-    version: 0.26.1
+    version: 0.28.1
     dependencies:
       '@types/react': registry.npmjs.org/@types/react/18.0.14
     dev: true
@@ -12744,7 +12745,7 @@ packages:
       mississippi: registry.npmjs.org/mississippi/3.0.0
       mkdirp: registry.npmjs.org/mkdirp/0.5.6
       move-concurrently: registry.npmjs.org/move-concurrently/1.0.1
-      promise-inflight: registry.npmjs.org/promise-inflight/1.0.1_bluebird@3.7.2
+      promise-inflight: registry.npmjs.org/promise-inflight/1.0.1
       rimraf: registry.npmjs.org/rimraf/2.7.1
       ssri: registry.npmjs.org/ssri/6.0.2
       unique-filename: registry.npmjs.org/unique-filename/1.1.1
@@ -28960,19 +28961,6 @@ packages:
       bluebird:
         optional: true
 
-  registry.npmjs.org/promise-inflight/1.0.1_bluebird@3.7.2:
-    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz}
-    id: registry.npmjs.org/promise-inflight/1.0.1
-    name: promise-inflight
-    version: 1.0.1
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
-    dependencies:
-      bluebird: registry.npmjs.org/bluebird/3.7.2
-
   registry.npmjs.org/promise-polyfill/7.1.2:
     resolution: {integrity: sha512-FuEc12/eKqqoRYIGBrUptCBRhobL19PS2U31vMNTfyck1FxPyMfgsXyW4Mav85y/ZN1hop3hOwRlUDok23oYfQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-7.1.2.tgz}
     name: promise-polyfill
@@ -31287,15 +31275,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       xmlchars: registry.npmjs.org/xmlchars/2.2.0
-
-  registry.npmjs.org/scheduler/0.20.2:
-    resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz}
-    name: scheduler
-    version: 0.20.2
-    dependencies:
-      loose-envify: registry.npmjs.org/loose-envify/1.4.0
-      object-assign: registry.npmjs.org/object-assign/4.1.1
-    dev: false
 
   registry.npmjs.org/scheduler/0.21.0:
     resolution: {integrity: sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz}


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

本 PR 主要内容

1. 修复 `createContainer` 入参问题
    1. 在 Taro v3.5 版本中将 `react-reconciler` 升级到 v0.27 版本，在0.27版本中 `createContianer` 方法调整了若干个入参，新增入参如下：
    
    ```jsx
    function createContainer(
      containerInfo: Container,
      tag: RootTag,
      hydrationCallbacks: null | SuspenseHydrationCallbacks,
      isStrictMode: boolean,
      concurrentUpdatesByDefaultOverride: null | boolean,
      identifierPrefix: string,
      onRecoverableError: (error: mixed) => void,
      transitionCallbacks: null | TransitionTracingCallbacks,
    ): OpaqueRoot {
      // ...
    }
    ```
    
    而 Taro 内调用的该方法没有做相关兼容，从而引起异常。本PR修复了该问题。
    
    2. 修改 render 与 createRoot 方法的入参，以适应 createContianer 的调用
    
2. 更新包 `@types/react-reconciler` 版本
    
    react-reconciler 升级后，也顺便升级了包 `@types/react-reconciler` 版本， v0.26.1 —> v0.28.1
    
3. 调整 HostConfig 字段顺序
    
    为了方便开发迭代与维护，调整了 HostConfig 字段顺序，该顺序遵循 React 源码文件 [[ReactFiberHostConfig.custom.js](https://github.com/facebook/react/blob/main/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js)](https://github.com/facebook/react/blob/main/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js) 中定义的字段顺序，这样方便按字段顺序对照实现，从而清晰知道哪些字段是必需的，哪些字段是可选的。
    
4. HostConfig 调整部分字段
    
    因升级了包 `@types/react-reconciler` 版本，按照TS类型提示，需要调整部分字段：
    
    1. 新增字段：
    
    | 字段 | 说明 |
    | --- | --- |
    | getInstanceFromNode | 详见文档内说明 |
    | beforeActiveInstanceBlur |  |
    | afterActiveInstanceBlur |  |
    | prepareScopeUpdate |  |
    | supportsMicrotasks |  |
    | scheduleMicrotask |  |
    
    2. 删除字段：
    
    | 字段 | 说明 |
    | --- | --- |
    | now | v0.27 中已不再需要 now 方法 |
    | queueMicrotask | 由 scheduleMicrotask 方法取代 |
    
    因删除了 now 方法，从而不再需要 `scheduler` 依赖项，已删除。
    
    3. `prepareUpdate` & `commitUpdate` 方法调整
    
    按照最新 `react-reconciler` 中的描述，需要在 `prepareUpdate` 中提前完成 `updatePayload` 更新内容的生成，从而在 `commitUpdate` 方法中直接使用，以提升性能。特更改了两个方法的实现.
    
5. 完善文档说明
    
    增加了 `HostConfig for Taro` 的文档说明，分析了各个字段的用途，以及相应在 Taro 环境中应具备的能力.


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [x] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
