### PR TITLE
fix(taro-helper): 修复readConfig时,createSwcRegister没有对软链接的.config.js进行编译,导致Unexpected token 'export'

### DIFF
--- a/packages/taro-helper/src/utils.ts
+++ b/packages/taro-helper/src/utils.ts
@@ -646,7 +646,7 @@ export function readConfig (configPath: string) {
 
     createSwcRegister({
       only: [
-        configPath,
+        fs.realpathSync(configPath), // configPath might be a symlink. that will cause compilation to fail
         filepath => importPaths.includes(filepath)
       ],
       plugins: [


### PR DESCRIPTION


<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复readConfig函数读取页面index.config.js配置文件(来自软链接)报错, 在createSwcRegister的only选项configPath参数添加realpathSync解析


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
