### PR TITLE
fix(h5): request 更严谨的判断 options.data 为 Object #9786

### DIFF
--- a/packages/taro-h5/src/api/network/request/index.ts
+++ b/packages/taro-h5/src/api/network/request/index.ts
@@ -56,7 +56,7 @@ function _request (options) {
   params.cache = options.cache || 'default'
   if (methodUpper === 'GET' || methodUpper === 'HEAD') {
     url = generateRequestUrlWithParams(url, options.data)
-  } else if (typeof options.data === 'object') {
+  } else if (Object.prototype.toString.call(options.data) === '[object Object]') {
     options.header = options.header || {}
 
     const keyOfContentType = Object.keys(options.header).find(item => item.toLowerCase() === 'content-type')


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
fix(h5): request 更严谨的判断 options.data 为 Object ，可以避免部分问题。
比如，当 options.data 为 FormData 时，原本的写法 `typeof options.data === 'object'` 会返回 true 。

相关 issues: 
- https://github.com/NervJS/taro/issues/9786
- https://github.com/NervJS/taro/issues/5514


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
