### PR TITLE
修复修改filename对common chunks不生效的问题

### DIFF
--- a/packages/taro-webpack5-runner/src/webpack/H5Combination.ts
+++ b/packages/taro-webpack5-runner/src/webpack/H5Combination.ts
@@ -101,20 +101,17 @@ export class H5Combination extends Combination<H5BuildConfig> {
       defaultVendors: false,
       common: {
         name: isProd ? false : 'common',
-        filename: 'js/[name].js',
         minChunks: 2,
         priority: 1
       },
       vendors: {
         name: isProd ? false : 'vendors',
-        filename: 'js/[name].js',
         minChunks: 2,
         test: (module: any) => /[\\/]node_modules[\\/]/.test(module.resource),
         priority: 10
       },
       taro: {
         name: isProd ? false : 'taro',
-        filename: 'js/[name].js',
         test: (module: any) => /@tarojs[\\/][a-z]+/.test(module.context),
         priority: 100
       }


### PR DESCRIPTION
fix: https://github.com/NervJS/taro/issues/13167

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
删除h5Combination中cacheGroup多余的filename配置


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
