### PR TITLE
fix(pxtransform): 修复 designWidth 函数类型导致的 API 错误 fix #12078

### DIFF
--- a/packages/taro-api/src/tools.js
+++ b/packages/taro-api/src/tools.js
@@ -1,4 +1,4 @@
-import { isObject } from './utils'
+import { isFunction, isObject } from './utils'
 
 export function Behavior (options) {
   return options
@@ -38,10 +38,11 @@ export function getInitPxTransform (taro) {
 
 export function getPxTransform (taro) {
   return function (size) {
-    const {
-      designWidth = defaultDesignWidth,
-      deviceRatio = defaultDesignRatio
-    } = taro.config || {}
+    const config = taro.config || {}
+    const deviceRatio = config.deviceRatio || defaultDesignRatio
+    const designWidth = (((input = 0) => isFunction(config.designWidth)
+      ? config.designWidth(input)
+      : config.designWidth || defaultDesignWidth))(size)
     if (!(designWidth in deviceRatio)) {
       throw new Error(`deviceRatio 配置中不存在 ${designWidth} 的设置！`)
     }

--- a/packages/taro-h5/src/api/taro.ts
+++ b/packages/taro-h5/src/api/taro.ts
@@ -2,7 +2,7 @@ import Taro from '@tarojs/api'
 import { history } from '@tarojs/router'
 
 import { getApp, getCurrentInstance, getCurrentPages, navigateBack, navigateTo, nextTick, redirectTo, reLaunch, switchTab } from '../api'
-import { permanentlyNotSupport } from '../utils'
+import { isFunction, permanentlyNotSupport } from '../utils'
 
 const {
   Behavior,
@@ -46,13 +46,13 @@ const initPxTransform = getInitPxTransform(taro)
 const requirePlugin = permanentlyNotSupport('requirePlugin')
 
 const pxTransform = function (size) {
-  const options = (taro as any).config
-  const baseFontSize = options.baseFontSize || 20
-  const designWidth = ((input = 0) => typeof options.designWidth === 'function'
-    ? options.designWidth(input)
-    : options.designWidth)
-  const rootValue = (input = 0) => baseFontSize / options.deviceRatio[designWidth(input)] * 2
-  return Math.ceil((parseInt(size, 10) / rootValue(size)) * 10000) / 10000 + 'rem'
+  const config = (taro as any).config
+  const baseFontSize = config.baseFontSize || 20
+  const designWidth = (((input = 0) => isFunction(config.designWidth)
+    ? config.designWidth(input)
+    : config.designWidth))(size)
+  const rootValue = baseFontSize / config.deviceRatio[designWidth] * 2
+  return Math.ceil((parseInt(size, 10) / rootValue) * 10000) / 10000 + 'rem'
 }
 
 const canIUseWebp = function () {

--- a/packages/taro-h5/src/utils/valid.ts
+++ b/packages/taro-h5/src/utils/valid.ts
@@ -1,5 +1,5 @@
-export function isFunction (obj) {
-  return typeof obj === 'function'
+export function isFunction (o: unknown): o is (...args: any[]) => any {
+  return typeof o === 'function'
 }
 
 const VALID_COLOR_REG = /^#[0-9a-fA-F]{6}$/

--- a/packages/taro-rn-style-transformer/src/types/index.ts
+++ b/packages/taro-rn-style-transformer/src/types/index.ts
@@ -198,8 +198,8 @@ interface RNConfig {
 }
 
 export interface Config {
-  designWidth?: number
-  deviceRatio?: { [key: number]: number }
+  designWidth?: number | ((size: number) => number)
+  deviceRatio?: Record<string, number>
   sass?: SassGlobalConfig
   alias?: Record<string, string>
   rn: RNConfig

--- a/packages/taro-rn-supporter/src/types/index.ts
+++ b/packages/taro-rn-supporter/src/types/index.ts
@@ -23,8 +23,8 @@ interface Sass {
 export interface Config {
   projectName?: string
   date?: string
-  designWidth?: number
-  deviceRatio?: Record<string, any>
+  designWidth?: number | ((size: number) => number)
+  deviceRatio?: Record<string, number>
   sourceRoot?: string
   outputRoot?: string
   defineConstants?: Record<string, any>

--- a/packages/taro-rn-transformer/src/types/index.ts
+++ b/packages/taro-rn-transformer/src/types/index.ts
@@ -9,8 +9,8 @@ export interface TransformType {
     projectRoot: string
     appName?: string
     isEntryFile: (filename: string) => boolean
-    designWidth?: number
-    deviceRatio?: Record<number, number>
+    designWidth?: number | ((size: number) => number)
+    deviceRatio?: Record<string, number>
     rn?: Record<string, any>
   }
 }
@@ -27,8 +27,8 @@ export interface TransformEntry {
   appName: string
   projectRoot: string
   filename: string
-  designWidth: number
-  deviceRatio: Record<number, number>
+  designWidth: number | ((size: number) => number)
+  deviceRatio: Record<string, number>
   entryName: string
 }
 
@@ -36,8 +36,8 @@ export interface AppConfig {
   pages: string[]
   subPackages?: SubPackage[]
   subpackages?: SubPackage[]
-  designWidth: number
-  deviceRatio?: Record<number, unknown>
+  designWidth: number | ((size: number) => number)
+  deviceRatio?: Record<string, number>
   tabBar:Record<string, any>
 }
 

--- a/packages/taro-router-rn/src/utils/index.ts
+++ b/packages/taro-router-rn/src/utils/index.ts
@@ -32,8 +32,8 @@ export function isUrl (str: string): boolean {
   return false
 }
 
-export function isFunction (obj: unknown): boolean {
-  return typeof obj === 'function'
+export function isFunction (o: unknown): o is (...args: any[]) => any {
+  return typeof o === 'function'
 }
 
 export function isEmptyObject (obj: any): boolean {

--- a/packages/taro-runtime-rn/src/compute.ts
+++ b/packages/taro-runtime-rn/src/compute.ts
@@ -1,6 +1,8 @@
 import { Dimensions } from 'react-native'
 
-import { AppConfig } from './types/index'
+import { isFunction } from './utils'
+
+import type { AppConfig } from './types/index'
 
 const globalAny: any = global
 const defaultWidth = 750
@@ -14,7 +16,10 @@ export function pxTransform (size: number): number {
   const deviceWidthDp = Dimensions.get('window').width
   const uiWidthPx = 375
   const config: AppConfig = globalAny.__taroAppConfig?.appConfig || {}
-  const { designWidth = defaultWidth, deviceRatio = defaultRadio } = config
+  const deviceRatio = config.deviceRatio || defaultRadio
+  const designWidth = (((input = 0) => isFunction(config.designWidth)
+    ? config.designWidth(input)
+    : config.designWidth || defaultWidth))(size)
   if (!(designWidth in deviceRatio)) {
     throw new Error(`deviceRatio 配置中不存在 ${designWidth} 的设置！`)
   }

--- a/packages/taro-runtime-rn/src/types/index.d.ts
+++ b/packages/taro-runtime-rn/src/types/index.d.ts
@@ -154,16 +154,16 @@ export interface WindowConfig extends CommonConfig {
   allowsBounceVertical?: 'YES' | 'NO'
 }
 export interface AppConfig {
-  pages: string[],
-  window?: WindowConfig,
-  tabBar?: TabBar,
+  pages: string[]
+  window?: WindowConfig
+  tabBar?: TabBar
   subPackages?: SubPackage[]
-  subpackages?: SubPackage[],
-  designWidth: number,
-  deviceRatio: Record<number, number>,
-  linkPrefix: string[],
-  rn?: any,
-  entryPagePath?: string,
+  subpackages?: SubPackage[]
+  designWidth: number | ((size: number) => number)
+  deviceRatio: Record<string, number>
+  linkPrefix: string[]
+  rn?: any
+  entryPagePath?: string
 }
 
 export interface RNAppConfig {

--- a/packages/taro-runtime-rn/src/utils.ts
+++ b/packages/taro-runtime-rn/src/utils.ts
@@ -35,7 +35,7 @@ export const incrementId = () => {
 }
 
 
-export function isFunction (o: unknown): boolean {
+export function isFunction (o: unknown): o is (...args: any[]) => any {
   return typeof o === 'function'
 }
 

--- a/packages/taro/types/compile/config/project.d.ts
+++ b/packages/taro/types/compile/config/project.d.ts
@@ -24,9 +24,9 @@ export interface IProjectBaseConfig {
   port?: number
   projectName?: string
   date?: string
-  designWidth?: number
-  watcher?: any[]
+  designWidth?: number | ((size: number) => number)
   deviceRatio?: TaroGeneral.TDeviceRatio
+  watcher?: any[]
   sourceRoot?: string
   outputRoot?: string
   env?: IOption


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

- 修复 designWidth 函数类型导致的 API 错误 （修复小程序、RN，并对齐 web 端逻辑）
- 对齐 designWidth 类型，并优化 isFunction 函数写法

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #12078
- [x] TypeScript 类型定义修改(Typings)
- [x] 代码风格更新(Code style update)

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [x] Web 平台（H5）
- [x] 移动端（React-Native）
