### PR TITLE
feat(plugin-html): 支持a标签转换为自定义小程序标签

### DIFF
--- a/packages/taro-plugin-html/src/constant.ts
+++ b/packages/taro-plugin-html/src/constant.ts
@@ -44,6 +44,7 @@ export const specialElements = new Map<string, string | SpecialMaps>([
   ['canvas', 'canvas'],
   ['a', {
     mapName (props) {
+      if(props.as && isString(props.as)) return props.as.toLowerCase()
       return !props.href || (/^javascript/.test(props.href)) ? 'view' : 'navigator'
     },
     mapNameCondition: ['href'],


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

在某些情况下，html `a` 标签转换为小程序 `navigator` 标签并不符合要求，比如：

```
import {Link} from 'react-router-dom'

<Link to="a/b/c" />   // 期望拦截点击，更改location，而非触发小程序跳转
```

由于支付宝小程序 `navigator` 标签无法触发 `onTap` 事件，从而无法进一步触发 `a` 标签绑定的 `onClick` 事件，路由切换失败。

本PR支持 `<a as="xxx">` 传入 `as` 属性，以支持转换为自定义小程序标签


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #13185
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
