### PR TITLE
feat(runtime): 增加运行时 URL 类的实现

### DIFF
--- a/packages/taro-mini-runner/src/webpack/build.conf.ts
+++ b/packages/taro-mini-runner/src/webpack/build.conf.ts
@@ -190,6 +190,7 @@ export default (appPath: string, mode, config: Partial<IBuildConfig>): any => {
     history: ['@tarojs/runtime', 'history'],
     location: ['@tarojs/runtime', 'location'],
     URLSearchParams: ['@tarojs/runtime', 'URLSearchParams'],
+    URL: ['@tarojs/runtime', 'URL'],
   })
 
   const isCssoEnabled = !((csso && csso.enable === false))

--- a/packages/taro-plugin-html/src/constant.ts
+++ b/packages/taro-plugin-html/src/constant.ts
@@ -44,6 +44,7 @@ export const specialElements = new Map<string, string | SpecialMaps>([
   ['canvas', 'canvas'],
   ['a', {
     mapName (props) {
+      if(props.as && isString(props.as)) return props.as.toLowerCase()
       return !props.href || (/^javascript/.test(props.href)) ? 'view' : 'navigator'
     },
     mapNameCondition: ['href'],

--- a/packages/taro-runtime/src/__tests__/location.spec.js
+++ b/packages/taro-runtime/src/__tests__/location.spec.js
@@ -49,4 +49,58 @@ describe('location', () => {
       expect(search).toBe('?a=1')
     }
   })
+
+  it('URLSearchParams', () => {
+    const URLSearchParams = runtime.URLSearchParams
+
+    // query is empty
+    {
+      const searchParams = new URLSearchParams('')
+      expect(searchParams.keys()).toEqual([])
+    }
+    // constructor
+    {
+      const searchParams = new URLSearchParams('?a=1&b=2')
+      expect(searchParams.keys()).toEqual(['a', 'b'])
+      expect(searchParams.get('a')).toBe('1')
+      expect(searchParams.get('b')).toBe('2')
+    }
+    {
+      const searchParams = new URLSearchParams('a=1&b=2')
+      expect(searchParams.keys()).toEqual(['a', 'b'])
+      expect(searchParams.get('a')).toBe('1')
+      expect(searchParams.get('b')).toBe('2')
+    }
+    {
+      const searchParams = new URLSearchParams([['a', '1'], ['b', '2']])
+      expect(searchParams.keys()).toEqual(['a', 'b'])
+      expect(searchParams.get('a')).toBe('1')
+      expect(searchParams.get('b')).toBe('2')
+    }
+    {
+      const searchParams = new URLSearchParams({'a': '1', 'b': '2'})
+      expect(searchParams.keys()).toEqual(['a', 'b'])
+      expect(searchParams.get('a')).toBe('1')
+      expect(searchParams.get('b')).toBe('2')
+    }
+
+    // methods
+    {
+      const searchParams = new URLSearchParams({'a': '1'})
+      expect(searchParams.get('a')).toBe('1')
+      searchParams.set('b', '2')
+      expect(searchParams.get('b')).toBe('2')
+      expect(searchParams.has('b')).toBe(true)
+      searchParams.delete('b')
+      expect(searchParams.has('b')).toBe(false)
+      searchParams.set('c', '3')
+      expect(searchParams.toString()).toBe('a=1&c=3')
+      searchParams.append('c', '4')
+      expect(searchParams.toString()).toBe('a=1&c=3&c=4')
+    }
+    {
+      const searchParams = new URLSearchParams('a=1&a=2')
+      expect(searchParams.getAll('a')).toEqual(['1', '2'])
+    }
+  })
 })

--- a/packages/taro-runtime/src/__tests__/location.spec.js
+++ b/packages/taro-runtime/src/__tests__/location.spec.js
@@ -72,13 +72,16 @@ describe('location', () => {
       expect(searchParams.get('b')).toBe('2')
     }
     {
-      const searchParams = new URLSearchParams([['a', '1'], ['b', '2']])
+      const searchParams = new URLSearchParams([
+        ['a', '1'],
+        ['b', '2'],
+      ])
       expect(searchParams.keys()).toEqual(['a', 'b'])
       expect(searchParams.get('a')).toBe('1')
       expect(searchParams.get('b')).toBe('2')
     }
     {
-      const searchParams = new URLSearchParams({'a': '1', 'b': '2'})
+      const searchParams = new URLSearchParams({ a: '1', b: '2' })
       expect(searchParams.keys()).toEqual(['a', 'b'])
       expect(searchParams.get('a')).toBe('1')
       expect(searchParams.get('b')).toBe('2')
@@ -86,7 +89,7 @@ describe('location', () => {
 
     // methods
     {
-      const searchParams = new URLSearchParams({'a': '1'})
+      const searchParams = new URLSearchParams({ a: '1' })
       expect(searchParams.get('a')).toBe('1')
       searchParams.set('b', '2')
       expect(searchParams.get('b')).toBe('2')
@@ -102,5 +105,67 @@ describe('location', () => {
       const searchParams = new URLSearchParams('a=1&a=2')
       expect(searchParams.getAll('a')).toEqual(['1', '2'])
     }
+  })
+
+  it('URL', () => {
+    const URL = runtime.URL
+
+    // constructor
+
+    try {
+      // eslint-disable-next-line
+        new URL()
+    } catch (error) {
+      expect(error instanceof TypeError).toBe(true)
+      // expect(error.message).toBe('')
+    }
+
+
+
+    try {
+      // eslint-disable-next-line
+        new URL('/a/b', '/c/d')
+    } catch (error) {
+      expect(error instanceof TypeError).toBe(true)
+      // expect(error.message).toBe('')
+    }
+
+
+    {
+      const url = new URL('http://taro.com')
+      expect(url.toString()).toBe('http://taro.com/')
+    }
+
+    // cases from https://developer.mozilla.org/en-US/docs/Web/API/URL/URL
+    {
+      const baseUrl = 'https://developer.mozilla.org'
+      const A = new URL('/', baseUrl)
+      expect(A.toString()).toBe('https://developer.mozilla.org/')
+      const B = new URL(baseUrl)
+      expect(B.toString()).toBe('https://developer.mozilla.org/')
+      const C = new URL('en-US/docs', B)
+      expect(C.toString()).toBe('https://developer.mozilla.org/en-US/docs')
+      const D = new URL('/en-US/docs', B)
+      expect(D.toString()).toBe('https://developer.mozilla.org/en-US/docs')
+      const E = new URL('/en-US/docs', D)
+      expect(E.toString()).toBe('https://developer.mozilla.org/en-US/docs')
+      const F = new URL('/en-US/docs', A)
+      expect(F.toString()).toBe('https://developer.mozilla.org/en-US/docs')
+      const G = new URL('/en-US/docs', 'https://developer.mozilla.org/fr-FR/toto')
+      expect(G.toString()).toBe('https://developer.mozilla.org/en-US/docs')
+
+      const H = new URL('', 'https://example.com/?query=1')
+      expect(H.toString()).toBe('https://example.com/?query=1')
+      const J = new URL('//foo.com', 'https://example.com')
+      expect(J.toString()).toBe('https://foo.com/')
+    }
+
+    {
+      const searchParams = new URL('http://taro.com?a=1&b=2').searchParams
+      expect(searchParams.keys()).toEqual(['a', 'b'])
+      expect(searchParams.get('a')).toBe('1')
+      expect(searchParams.get('b')).toBe('2')
+    }
+
   })
 })

--- a/packages/taro-runtime/src/__tests__/location.spec.js
+++ b/packages/taro-runtime/src/__tests__/location.spec.js
@@ -111,29 +111,52 @@ describe('location', () => {
     const URL = runtime.URL
 
     // constructor
+    try {
+      // eslint-disable-next-line
+      new URL()
+    } catch (error) {
+      expect(error instanceof TypeError).toBe(true)
+      expect(error.message).toMatch('Invalid URL')
+    }
 
     try {
       // eslint-disable-next-line
-        new URL()
+      new URL('//taro.com')
     } catch (error) {
       expect(error instanceof TypeError).toBe(true)
-      // expect(error.message).toBe('')
+      expect(error.message).toMatch('Invalid URL')
     }
-
-
 
     try {
       // eslint-disable-next-line
-        new URL('/a/b', '/c/d')
+      new URL('/a/b', '/c/d')
     } catch (error) {
       expect(error instanceof TypeError).toBe(true)
-      // expect(error.message).toBe('')
+      expect(error.message).toMatch('Invalid base URL')
     }
 
+    try {
+      // eslint-disable-next-line
+      new URL('http://taro.com', '')
+    } catch (error) {
+      expect(error instanceof TypeError).toBe(true)
+      expect(error.message).toMatch('Invalid base URL')
+    }
 
     {
       const url = new URL('http://taro.com')
       expect(url.toString()).toBe('http://taro.com/')
+    }
+
+    {
+      const url = new URL('http://taro.com/')
+      expect(url.toString()).toBe('http://taro.com/')
+      expect(url.pathname).toBe('/')
+    }
+
+    {
+      const url = new URL('?a=1#b=2', 'https://taro.com')
+      expect(url.toString()).toBe('https://taro.com/?a=1#b=2')
     }
 
     // cases from https://developer.mozilla.org/en-US/docs/Web/API/URL/URL
@@ -156,16 +179,44 @@ describe('location', () => {
 
       const H = new URL('', 'https://example.com/?query=1')
       expect(H.toString()).toBe('https://example.com/?query=1')
-      const J = new URL('//foo.com', 'https://example.com')
-      expect(J.toString()).toBe('https://foo.com/')
+      const I = new URL('//foo.com', 'https://example.com')
+      expect(I.toString()).toBe('https://foo.com/')
     }
 
+    // searchParams
     {
-      const searchParams = new URL('http://taro.com?a=1&b=2').searchParams
+      const searchParams = new URL('http://taro.com/?a=1&b=2').searchParams
       expect(searchParams.keys()).toEqual(['a', 'b'])
       expect(searchParams.get('a')).toBe('1')
       expect(searchParams.get('b')).toBe('2')
     }
 
+    // setters
+    {
+      const url = new URL('http://taro.com')
+      expect(url.toString()).toBe('http://taro.com/')
+      url.protocol = 'https:'
+      expect(url.toString()).toBe('https://taro.com/')
+      url.port = '8080'
+      expect(url.toString()).toBe('https://taro.com:8080/')
+      url.pathname = '/hello/world'
+      expect(url.toString()).toBe('https://taro.com:8080/hello/world')
+      url.hostname = 'example.com'
+      expect(url.toString()).toBe('https://example.com:8080/hello/world')
+      url.hostname = 'taro.com'
+      expect(url.toString()).toBe('https://taro.com:8080/hello/world')
+      url.search = '?a=1'
+      expect(url.toString()).toBe('https://taro.com:8080/hello/world?a=1')
+      url.hash = '#b=2'
+      expect(url.toString()).toBe('https://taro.com:8080/hello/world?a=1#b=2')
+
+      url.host = 'example.com:8081'
+      expect(url.toString()).toBe('https://example.com:8081/hello/world?a=1#b=2')
+      url.origin = 'http://taro.com:8080'
+      expect(url.toString()).toBe('http://taro.com:8080/hello/world?a=1#b=2')
+      url.href = 'https://taro.com/user?name=hongxin#age=18'
+      expect(url.toString()).toBe('https://taro.com/user?name=hongxin#age=18')
+      expect(url.search).toBe('?name=hongxin')
+    }
   })
 })

--- a/packages/taro-runtime/src/__tests__/location.spec.js
+++ b/packages/taro-runtime/src/__tests__/location.spec.js
@@ -1,0 +1,52 @@
+describe('location', () => {
+  const runtime = require('../../dist/runtime.esm')
+
+  it('parseUrl', () => {
+    const parseUrl = runtime.parseUrl
+
+    // full url
+    {
+      const { href, origin, protocol, hostname, host, port, pathname, search, hash } = parseUrl(
+        'https://taro.com:8080/hello/world?name=hongxin&age=18#a=1&b=2'
+      )
+      expect(href).toBe('https://taro.com:8080/hello/world?name=hongxin&age=18#a=1&b=2')
+      expect(origin).toBe('https://taro.com')
+      expect(protocol).toBe('https:')
+      expect(hostname).toBe('taro.com')
+      expect(host).toBe('taro.com:8080')
+      expect(port).toBe('8080')
+      expect(pathname).toBe('/hello/world')
+      expect(search).toBe('?name=hongxin&age=18')
+      expect(hash).toBe('#a=1&b=2')
+    }
+
+    {
+      const { href, origin, protocol, hostname, host, port, pathname, search, hash } = parseUrl(
+        'http://taro.com/hello/world#a=1&b=2?name=hongxin&age=18'
+      )
+      expect(href).toBe('http://taro.com/hello/world#a=1&b=2?name=hongxin&age=18')
+      expect(origin).toBe('http://taro.com')
+      expect(protocol).toBe('http:')
+      expect(hostname).toBe('taro.com')
+      expect(host).toBe('taro.com')
+      expect(port).toBe('')
+      expect(pathname).toBe('/hello/world')
+      expect(search).toBe('')
+      expect(hash).toBe('#a=1&b=2?name=hongxin&age=18')
+    }
+
+    // the url should be correct
+    {
+      const { href } = parseUrl('/a/b')
+      expect(href).toBe('')
+    }
+
+    // pathname should be "/" if not exist in url
+    {
+      const { protocol, pathname, search } = parseUrl('//taro.com?a=1')
+      expect(protocol).toBe('https:')
+      expect(pathname).toBe('/')
+      expect(search).toBe('?a=1')
+    }
+  })
+})

--- a/packages/taro-runtime/src/bom/URL.ts
+++ b/packages/taro-runtime/src/bom/URL.ts
@@ -4,6 +4,14 @@ import { parseUrl } from './location'
 import { URLSearchParams } from './URLSearchParams'
 
 export class URL {
+  static createObjectURL () {
+    throw new Error('Oops, not support URL.createObjectURL() in miniprogram.')
+  }
+
+  static revokeObjectURL () {
+    throw new Error('Oops, not support URL.revokeObjectURL() in miniprogram.')
+  }
+
   /* private property */
   #hash = ''
   #hostname = ''
@@ -33,11 +41,20 @@ export class URL {
   }
 
   set protocol (val: string) {
-    isString(val) && (this.#protocol = val)
+    isString(val) && (this.#protocol = val.trim())
   }
 
   get host () {
-    return (this.hostname || '') + (this.port ? ':' + this.port : '')
+    return this.hostname + (this.port ? ':' + this.port : '')
+  }
+
+  set host (val: string) {
+    if (val && isString(val)) {
+      val = val.trim()
+      const { hostname, port } = parseUrl(`//${val}`)
+      this.hostname = hostname
+      this.port = port
+    }
   }
 
   get hostname () {
@@ -45,7 +62,7 @@ export class URL {
   }
 
   set hostname (val: string) {
-    val && isString(val) && (this.#hostname = val)
+    val && isString(val) && (this.#hostname = val.trim())
   }
 
   get port () {
@@ -53,7 +70,7 @@ export class URL {
   }
 
   set port (val: string) {
-    isString(val) && (this.#port = val)
+    isString(val) && (this.#port = val.trim())
   }
 
   get pathname () {
@@ -62,7 +79,7 @@ export class URL {
 
   set pathname (val: string) {
     if (isString(val)) {
-      if (val) this.#pathname = val
+      if (val) this.#pathname = val.trim()
       else this.#pathname = '/'
     }
   }
@@ -71,9 +88,10 @@ export class URL {
     return this.#search
   }
 
-  set search (val: string){
-    if(isString(val)){
-      if(val) this.#search = val.startsWith('?') ? val : `?${val}`
+  set search (val: string) {
+    if (isString(val)) {
+      val = val.trim()
+      if (val) this.#search = val.startsWith('?') ? val : `?${val}`
       else this.#search = ''
     }
   }
@@ -82,9 +100,10 @@ export class URL {
     return this.#hash
   }
 
-  set hash (val: string){
-    if(isString(val)){
-      if(val) this.#hash = val.startsWith('#') ? val : `#${val}`
+  set hash (val: string) {
+    if (isString(val)) {
+      val = val.trim()
+      if (val) this.#hash = val.startsWith('#') ? val : `#${val}`
       else this.#hash = ''
     }
   }
@@ -93,8 +112,31 @@ export class URL {
     return `${this.protocol}//${this.host}${this.pathname}${this.search}${this.hash}`
   }
 
+  set href (val: string) {
+    if (val && isString(val)) {
+      val = val.trim()
+      const { protocol, hostname, port, hash, search, pathname } = parseUrl(val)
+      this.protocol = protocol
+      this.hostname = hostname
+      this.pathname = pathname
+      this.port = port
+      this.hash = hash
+      this.search = search
+    }
+  }
+
   get origin () {
     return `${this.protocol}//${this.host}`
+  }
+
+  set origin (val: string){
+    if (val && isString(val)) {
+      val = val.trim()
+      const { protocol, hostname, port } = parseUrl(val)
+      this.protocol = protocol
+      this.hostname = hostname
+      this.port = port
+    }
   }
 
   get searchParams () {

--- a/packages/taro-runtime/src/bom/URL.ts
+++ b/packages/taro-runtime/src/bom/URL.ts
@@ -1,0 +1,131 @@
+import { isString } from '@tarojs/shared'
+
+import { parseUrl } from './location'
+import { URLSearchParams } from './URLSearchParams'
+
+export class URL {
+  /* private property */
+  #hash = ''
+  #hostname = ''
+  #pathname = ''
+  #port = ''
+  #protocol = ''
+  #search = ''
+
+  constructor (url: string, base = '') {
+    if (!isString(url)) url = String(url)
+    if (base && !isString(base)) base = String(base)
+
+    const parseResult = parseFullPath(url, base)
+    const { hash, hostname, pathname, port, protocol, search } = parseResult
+
+    this.#hash = hash
+    this.#hostname = hostname
+    this.#pathname = pathname || '/'
+    this.#port = port
+    this.#protocol = protocol
+    this.#search = search
+  }
+
+  /* public property */
+  get protocol () {
+    return this.#protocol
+  }
+
+  set protocol (val: string) {
+    isString(val) && (this.#protocol = val)
+  }
+
+  get host () {
+    return (this.hostname || '') + (this.port ? ':' + this.port : '')
+  }
+
+  get hostname () {
+    return this.#hostname
+  }
+
+  set hostname (val: string) {
+    val && isString(val) && (this.#hostname = val)
+  }
+
+  get port () {
+    return this.#port
+  }
+
+  set port (val: string) {
+    isString(val) && (this.#port = val)
+  }
+
+  get pathname () {
+    return this.#pathname
+  }
+
+  set pathname (val: string) {
+    if (isString(val)) {
+      if (val) this.#pathname = val
+      else this.#pathname = '/'
+    }
+  }
+
+  get search () {
+    return this.#search
+  }
+
+  set search (val: string){
+    if(isString(val)){
+      if(val) this.#search = val.startsWith('?') ? val : `?${val}`
+      else this.#search = ''
+    }
+  }
+
+  get hash () {
+    return this.#hash
+  }
+
+  set hash (val: string){
+    if(isString(val)){
+      if(val) this.#hash = val.startsWith('#') ? val : `#${val}`
+      else this.#hash = ''
+    }
+  }
+
+  get href () {
+    return `${this.protocol}//${this.host}${this.pathname}${this.search}${this.hash}`
+  }
+
+  get origin () {
+    return `${this.protocol}//${this.host}`
+  }
+
+  get searchParams () {
+    return new URLSearchParams(this.search)
+  }
+
+  // public method
+  toString () {
+    return this.href
+  }
+
+  toJSON () {
+    return this.toString()
+  }
+}
+
+function parseFullPath (url: string, base: string) {
+  const VALID_URL = /^(https?:)?\/\//i
+  let fullUrl = ''
+  if (VALID_URL.test(url)) {
+    fullUrl = url
+  } else if (VALID_URL.test(base)) {
+    const baseUrlObj = parseUrl(base)
+    if (url) {
+      fullUrl = baseUrlObj.origin + (url.startsWith('/') ? url : `/${url}`)
+    } else {
+      fullUrl = base
+    }
+  } else {
+    throw new TypeError(`${url} is not a valid URL`)
+  }
+
+  return parseUrl(fullUrl)
+}

--- a/packages/taro-runtime/src/bom/location.ts
+++ b/packages/taro-runtime/src/bom/location.ts
@@ -358,7 +358,7 @@ export class Location extends Events {
   }
 }
 
-function resolveRelativePath (path, relative): string {
+export function resolveRelativePath (path: string, relative: string): string {
   const relativeArr = relative.split('/')
   const parent = relativeArr.slice(0, relativeArr.length - 1)
   let depth = 0

--- a/packages/taro-runtime/src/bom/location.ts
+++ b/packages/taro-runtime/src/bom/location.ts
@@ -409,6 +409,7 @@ export function parseUrl (url = '') {
 
   if (!matches) return result
 
+  // TODO: username & password ?
   result.protocol = matches[1] || 'https:'
   result.hostname = matches[6] || DEFAULT_HOSTNAME
   result.port = matches[8] || ''

--- a/packages/taro-runtime/src/index.ts
+++ b/packages/taro-runtime/src/index.ts
@@ -8,6 +8,7 @@ export { document } from './bom/document'
 export { getComputedStyle } from './bom/getComputedStyle'
 export { nav as navigator } from './bom/navigator'
 export { caf as cancelAnimationFrame, now, raf as requestAnimationFrame } from './bom/raf'
+export { URL } from './bom/URL'
 export { URLSearchParams } from './bom/URLSearchParams'
 export { history, location, window } from './bom/window'
 // dom

--- a/packages/taro-webpack5-prebundle/src/mini.ts
+++ b/packages/taro-webpack5-prebundle/src/mini.ts
@@ -115,6 +115,7 @@ export class MiniPrebundle extends BasePrebundle<IMiniPrebundleConfig> {
       history: [taroRuntimeBundlePath, 'history'],
       location: [taroRuntimeBundlePath, 'location'],
       URLSearchParams: [taroRuntimeBundlePath, 'URLSearchParams'],
+      URL: [taroRuntimeBundlePath, 'URL'],
     }
     const customWebpackConfig = this.option.webpack
     if (customWebpackConfig?.provide?.length) {

--- a/packages/taro-webpack5-runner/src/webpack/MiniWebpackPlugin.ts
+++ b/packages/taro-webpack5-runner/src/webpack/MiniWebpackPlugin.ts
@@ -50,6 +50,7 @@ export class MiniWebpackPlugin {
       history: ['@tarojs/runtime', 'history'],
       location: ['@tarojs/runtime', 'location'],
       URLSearchParams: ['@tarojs/runtime', 'URLSearchParams'],
+      URL: ['@tarojs/runtime', 'URL'],
     })
   }
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

背景：`react-router` 从 v6.4 版本开始使用了 `URL` 类来处理 url 字符串，但在小程序运行时中却没有 `URL` 类，从而无法使用新版本 `react-router`

本 PR 完成以下工作：
- `@tarojs/runtime` 新增 `URL` 类的实现；
- 增加了对 `location` 暴露的 `parseUrl` `URL` `URLSearchParams` API 的测试用例，以保证运行时正确性；

待办事项：
- 随着 `URL` 类的实现，重构 `Location` 类的实现，以减少运行时代码量；
- 增加更多测试用例；


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
