### PR TITLE
fix(plugin-inject): 修复新增componentsMap时未正确识别 export * 的问题

### DIFF
--- a/packages/taro-plugin-inject/src/index.ts
+++ b/packages/taro-plugin-inject/src/index.ts
@@ -20,6 +20,12 @@ interface IOptions {
 export default (ctx: IPluginContext, options: IOptions) => {
   const fs = ctx.helper.fs
 
+  ctx.modifyWebpackChain(({ chain }) => {
+    if(options.componentsMap){
+      chain.optimization.providedExports(false)
+    }
+  })
+
   ctx.registerMethod({
     name: 'onSetupClose',
     fn (platform: TaroPlatformBase) {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

当通过 `@tarojs/plugin-inject` 插件修改 `componentsMap` 选项时，会将 `@tarojs/components` 依赖重定向到 `@tarojs/plugin-inject/dist/components-react.js` 中，而通过 `export * from ""` 的抛出形式无法被webpack正常解析。从而 moduleUsedExports 异常（只能获取到 `export const xxx = yyy` 的内容）

https://github.com/NervJS/taro/blob/181aa1eccf26b7c7d70a0898ef32d04375b81809/packages/taro-webpack5-runner/src/plugins/TaroLoadChunksPlugin.ts#L168

修改 webpack 的 `optimization.providedExports = false` 即可


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #13299
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
