### PR TITLE
perf(plugin-mini-ci): 控制台预览二维码尺寸过大，不方便扫码

### DIFF
--- a/packages/taro-plugin-mini-ci/src/utils/qrcode.ts
+++ b/packages/taro-plugin-mini-ci/src/utils/qrcode.ts
@@ -30,7 +30,7 @@ export async function readQrcodeImageContent (imagePath: string): Promise<string
  * @param content
  */
 export async function printQrcode2Terminal (content: string) {
-  const terminalStr = await QRCode.toString(content, { type: 'terminal' })
+  const terminalStr = await QRCode.toString(content, { type: 'terminal', small: true })
   // eslint-disable-next-line no-console
   console.log(terminalStr)
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

小程序自动上传时，控制台生成的预览二维码尺寸过大，不方便扫码

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
