### PR TITLE
chore(SelectorQuery): add callback function return value type

### DIFF
--- a/packages/taro/types/api/wxml/index.d.ts
+++ b/packages/taro/types/api/wxml/index.d.ts
@@ -304,7 +304,7 @@ declare module '../../index' {
   namespace NodesRef {
     /** 回调函数，在执行 `SelectorQuery.exec` 方法后，节点信息会在 `callback` 中返回。 */
     type BoundingClientRectCallback = (
-      result: BoundingClientRectCallbackResult,
+      result: BoundingClientRectCallbackResult | BoundingClientRectCallbackResult[],
     ) => void
     interface BoundingClientRectCallbackResult {
       /** 节点的下边界坐标 */


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
增加了 SelectorQuery 下 selectAll 方法的回调函数返回值的 ts 类型。在 SelectorQuery 下有两个方法，分别是 select 以及 selectAll，select 返回首个选中元素，而 selectAll 使用数组返回所有选中元素，目前类型定义仅定义了 select 的返回值，因此补充 selectAll 的返回值类型。

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [x] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
