### PR TITLE
feat: custom connect devtools hostname

### DIFF
--- a/packages/taro-plugin-react-devtools/src/index.ts
+++ b/packages/taro-plugin-react-devtools/src/index.ts
@@ -8,12 +8,14 @@ const detectPort = require('detect-port')
 
 interface IOptions {
   enabled?: boolean
+  hostname?: string
   port?: string
 }
 
 export default function (ctx: IPluginContext, options: IOptions) {
   if (process.env.NODE_ENV === 'production' || options.enabled === false) return
 
+  const hostname = JSON.stringify(options.hostname || 'localhost')
   const port = Number(options.port || '8097')
 
   detectPort(port, (err, availablePort) => {
@@ -41,6 +43,7 @@ export default function (ctx: IPluginContext, options: IOptions) {
       .plugin('definePlugin')
       .tap(args => {
         const config = args[0]
+        config.__REACT_DEVTOOLS_HOSTNAME__ = hostname
         config.__REACT_DEVTOOLS_PORT__ = port
         return args
       })

--- a/packages/taro-plugin-react-devtools/src/runtime.ts
+++ b/packages/taro-plugin-react-devtools/src/runtime.ts
@@ -2,12 +2,13 @@ import WebSocket from './websocket'
 
 const { connectToDevTools } = require('./backend')
 
+declare const __REACT_DEVTOOLS_HOSTNAME__: string
 declare const __REACT_DEVTOOLS_PORT__: number
 
-const ws = new WebSocket(`ws://localhost:${__REACT_DEVTOOLS_PORT__}`)
+const ws = new WebSocket(`ws://${__REACT_DEVTOOLS_HOSTNAME__}:${__REACT_DEVTOOLS_PORT__}`)
 
 connectToDevTools({
-  // host: string (defaults to "localhost") - Websocket will connect to this host.
+  host: __REACT_DEVTOOLS_HOSTNAME__, // string (defaults to "localhost") - Websocket will connect to this host.
   port: __REACT_DEVTOOLS_PORT__, // number (defaults to 8097) - Websocket will connect to this port.
   // useHttps: boolean (defaults to false) - Websocket should use a secure protocol (wss).
   websocket: ws // Custom websocket to use. Overrides host and port settings if provided.

--- a/packages/taro-plugin-vue-devtools/src/index.ts
+++ b/packages/taro-plugin-vue-devtools/src/index.ts
@@ -8,12 +8,14 @@ const detectPort = require('detect-port')
 
 interface IOptions {
   enabled?: boolean
+  hostname?: string
   port?: string
 }
 
 export default function (ctx: IPluginContext, options: IOptions) {
   if (process.env.NODE_ENV === 'production' || options.enabled === false) return
 
+  const hostname = JSON.stringify(options.hostname || 'localhost')
   const port = Number(options.port || '8098')
 
   detectPort(port, (err, availablePort) => {
@@ -41,6 +43,7 @@ export default function (ctx: IPluginContext, options: IOptions) {
       .plugin('definePlugin')
       .tap(args => {
         const config = args[0]
+        config.__VUE_DEVTOOLS_HOSTNAME__ = hostname
         config.__VUE_DEVTOOLS_PORT__ = port
         config.ENABLE_SIZE_APIS = true
         config.ENABLE_CONTAINS = true

--- a/packages/taro-plugin-vue-devtools/src/runtime.ts
+++ b/packages/taro-plugin-vue-devtools/src/runtime.ts
@@ -2,8 +2,9 @@ import createSocket from './socket-io'
 
 const { connect } = require('./backend')
 
+declare const __VUE_DEVTOOLS_HOSTNAME__: string
 declare const __VUE_DEVTOOLS_PORT__: number
 
-connect('localhost', __VUE_DEVTOOLS_PORT__, {
+connect(__VUE_DEVTOOLS_HOSTNAME__, __VUE_DEVTOOLS_PORT__, {
   io: createSocket
 })


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

因为公司的小程序开发者工具需要走公司的网络代理，默认的 localhost 不能访问，所以才有这个 pr，可以指定局域网的 ip。
如果公司网络复杂的情况下，可以自定义 taro 连接 vue 和 react 的 devtools 主机名，默认为 localhost。
custom connect devtools hostname，default is localhost.

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
