### PR TITLE
fix:修复taro-loader中Map对象可能为空对象而无法调用Map.get方法的bug

### DIFF
--- a/packages/taro-loader/src/h5.ts
+++ b/packages/taro-loader/src/h5.ts
@@ -21,7 +21,15 @@ function genResource (path: string, pages: Map<string, string>, loaderContext: w
 }
 
 export default function (this: webpack.LoaderContext<any>) {
-  const options = getOptions(this)
+  // The objection "options" here might obtained a null Map Object, when I tranform weapp to H5，the console alert "pages.get is not a function"， which is due to the empty Map object without
+  //  the method "{}.get()"
+  let _this = this;
+  // 这里通过webpack5封装的loader-utils中的getOptions函数获取app.config.ts参数配置可能为一个空对象,即使在ts中使用type Map<string, string>规范，在调用"pages.get()"方法时也会报错,导致项目无法构建，此处应该对Map数组options.pages进行非空校验
+  let options = getOptions(_this)
+  while(JSON.stringify(options.pages)==="{}") //when pages is empty Map Obj, it will reobtain once; util the function getOption return; 
+    {
+       options = getOptions(_this)
+    }
   const stringify = (s: string): string => stringifyRequest(this, s)
   const {
     frameworkArgs,


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

相关平台
微信小程序
H5

基于微信小程序的源码移植为H5时出现报错

复现仓库

https://github.com/peitsan/taro-loader-pr

[git@github.com](mailto:git@github.com):peitsan/taro-loader-pr.git
小程序基础库: 1.22.0
使用框架: React

复现步骤
运行  npm run build:h5时，报错“pages.get is not a function”，构建终止。无法打包。
运行  npm run dev:h5时，报错“pages.get is not a function”，构建暂停。 当在app.config.ts文件中按ctrl-s保存时会继续构建

期望结果
正确将app.config.ts中配置的路由参数转为Map对象返回给 options

实际结果
构建时报错“pages.get is not a function”，此时options为空对象，
重新保存app.,config.ts后又继续开时build依赖， 此时options中有

环境信息
👽 Taro v3.5.7

  Taro CLI 3.5.7 environment info:
    System:
      OS: Windows 11
    Binaries:
      Node: 16.14.0 -F:\node\node.EXE
      npm: 8.5.5 - F:\node\npm.CMD

**这个 PR 的类型**

- [x]] 错误修复(Bugfix) issue: fix #

**这个 PR 涉及以下平台:**

- [x]] 微信小程序
- [x]] Web 平台（H5）