### PR TITLE
fix: 修复Taro.createInnerAudioContext执行destroy异常的问题

### DIFF
--- a/packages/taro-h5/src/api/audio/index.js
+++ b/packages/taro-h5/src/api/audio/index.js
@@ -71,7 +71,6 @@ export const createInnerAudioContext = () => {
    */
   iac.destroy = () => {
     iac.stop()
-    document.body.removeChild(audioEl)
     audioEl = null
   }
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复H5在执行destroy报错的问题，查看了commit记录，以前是appendChild在body上的，现在是直接new了一个Audio对象，在destroy的时候不需要再执行removeChild

<img width="411" alt="image" src="https://user-images.githubusercontent.com/64971822/224317493-39d78b14-1901-409c-9d0c-71a3f5cf9ee7.png">
<img width="893" alt="image" src="https://user-images.githubusercontent.com/64971822/224317536-011070b7-3549-42ab-94a2-06be9d89919b.png">


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
