### PR TITLE
fix(runtime): falsy event detail 的判断导致 vant 原生组件 e.detail 为 0 或空字符串时被强改成object

### DIFF
--- a/packages/taro-runtime/src/dom/event.ts
+++ b/packages/taro-runtime/src/dom/event.ts
@@ -149,10 +149,10 @@ function getEventCBResult (event: MpEvent) {
 // 小程序的事件代理回调函数
 export function eventHandler (event: MpEvent) {
   // Note: ohos 上事件没有设置 type、detail 类型 setter 方法，且部分事件（例如 load 等）缺失 target 导致事件错误
-  !event.type && Object.defineProperty(event, 'type', {
+  event.type === undefined && Object.defineProperty(event, 'type', {
     value: (event as any)._type // ohos only
   })
-  !event.detail && Object.defineProperty(event, 'detail', {
+  event.detail === undefined && Object.defineProperty(event, 'detail', {
     value: (event as any)._detail || { ...event } // ohos only
   })
   event.currentTarget = event.currentTarget || event.target || { ...event }


### PR DESCRIPTION
…符串时被强改成object

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)



**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
