### PR TITLE
fix(h5): 兼容 swiper 衔接模式

### DIFF
--- a/packages/taro-components/src/components/swiper/swiper-item.tsx
+++ b/packages/taro-components/src/components/swiper/swiper-item.tsx
@@ -4,18 +4,25 @@ function isEqualTag (a: Element, b: Element) {
   return typeof a.tagName === 'undefined' ? a.nodeType === b.nodeType : a.tagName === b.tagName
 }
 
-function parseChildNodes (items: NodeListOf<ChildNode>, targets: NodeListOf<ChildNode>) {
+function parseChildNodes (items: NodeListOf<ChildNode>, targets: NodeListOf<ChildNode>, needClean = false) {
   const list = Array.from(targets.values())
-  for (let i = 0, j = 0; i < list.length; i++, j++) {
+  for (let i = 0, j = 0; i < list.length; i++) {
     const target = list[i] as Element
+    if (!target) return
+
     let item = items.item(j) as Element
-    while (item && !isEqualTag(item, target)) {
-      item.remove()
-      j++
-      item = items.item(j) as Element
-    }
-    if (item && !item.isEqualNode(target)) {
-      parseChildNodes(item.childNodes, target.childNodes)
+    while (item) {
+      if (!isEqualTag(item, target) || needClean) {
+        item.remove()
+        j++
+        item = items.item(j) as Element
+        continue
+      }
+      if (target.childNodes.length > 0) {
+        const cleanAll = ['taro-image-core'].includes(target.tagName.toLocaleLowerCase())
+        parseChildNodes(item.childNodes, target.childNodes, cleanAll)
+      }
+      break
     }
     while (i === list.length - 1 && j < items.length) {
       j++
@@ -51,7 +58,7 @@ export class SwiperItem implements ComponentInterface {
 
   render () {
     return (
-      <Host class='swiper-slide' item-id={this.itemId}/>
+      <Host class='swiper-slide' item-id={this.itemId} />
     )
   }
 }

--- a/packages/taro-components/src/components/swiper/swiper.tsx
+++ b/packages/taro-components/src/components/swiper/swiper.tsx
@@ -246,9 +246,15 @@ export class Swiper implements ComponentInterface {
   }
 
   handleSwiperLoop = debounce(() => {
-    if (this.swiper && this.circular) {
-      // @ts-ignore
-      this.swiper.loopFix()
+    if (!this.swiper || !this.circular) return
+    const swiper = this.swiper as any // Note: loop 相关的方法 swiper 未声明
+    const duplicates = this.swiperWrapper?.querySelectorAll('.swiper-slide-duplicate') || []
+    if (duplicates.length < 2) {
+      // Note: 循环模式下，但是前后垫片未注入
+      swiper.loopDestroy()
+      swiper.loopCreate()
+    } else {
+      swiper.loopFix()
     }
   }, 50)
 
@@ -286,8 +292,8 @@ export class Swiper implements ComponentInterface {
         slideTo () {
           that.current = this.realIndex
         },
-         // slideChange 事件在 swiper.slideTo 改写 current 时不触发，因此用 slideChangeTransitionStart 事件代替
-         slideChangeTransitionStart (_swiper: ISwiper) {
+        // slideChange 事件在 swiper.slideTo 改写 current 时不触发，因此用 slideChangeTransitionStart 事件代替
+        slideChangeTransitionStart (_swiper: ISwiper) {
           if (that.circular) {
             if (_swiper.isBeginning || _swiper.isEnd) {
               // _swiper.slideToLoop(this.realIndex, 0, false) // 更新下标


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

在 stencil 版本更新后，在适配 swiper 衔接模式兼容性问题

- 修复 swiperjs 并未成功在组件内填充垫片导致使用差异
- 修复非 slot 传递子节点的 stencil 组件自动填充节点导致的 cloneNodes 重复问题

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #13329

**这个 PR 涉及以下平台:**

- [x] Web 平台（H5）
