### PR TITLE
fix(plugin-html): prevent errors arising from undeclared dependencies

### DIFF
--- a/packages/taro-plugin-html/package.json
+++ b/packages/taro-plugin-html/package.json
@@ -27,15 +27,15 @@
   },
   "homepage": "https://github.com/NervJS/taro#readme",
   "dependencies": {
+    "@babel/generator": "^7.20.0",
     "@babel/parser": "^7.20.0",
+    "@babel/traverse": "^7.20.0",
+    "@babel/types": "^7.20.0",
     "@tarojs/runtime": "workspace:*",
     "@tarojs/service": "workspace:*",
     "@tarojs/shared": "workspace:*"
   },
   "devDependencies": {
-    "@babel/generator": "^7.20.0",
-    "@babel/traverse": "^7.20.0",
-    "@babel/types": "^7.20.0",
     "@tarojs/taro": "workspace:*",
     "rollup": "^3.8.1",
     "rollup-plugin-node-externals": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1285,8 +1285,6 @@ importers:
         specifier: 18.1.0
         version: registry.npmjs.org/react-test-renderer@18.1.0(react@18.1.0)
 
-  packages/taro-components/loader: {}
-
   packages/taro-extend:
     devDependencies:
       jest:
@@ -1789,9 +1787,18 @@ importers:
 
   packages/taro-plugin-html:
     dependencies:
+      '@babel/generator':
+        specifier: ^7.20.0
+        version: registry.npmjs.org/@babel/generator@7.20.14
       '@babel/parser':
         specifier: ^7.20.0
         version: registry.npmjs.org/@babel/parser@7.20.13
+      '@babel/traverse':
+        specifier: ^7.20.0
+        version: registry.npmjs.org/@babel/traverse@7.20.13
+      '@babel/types':
+        specifier: ^7.20.0
+        version: registry.npmjs.org/@babel/types@7.20.7
       '@tarojs/runtime':
         specifier: workspace:*
         version: link:../taro-runtime
@@ -1802,15 +1809,6 @@ importers:
         specifier: workspace:*
         version: link:../shared
     devDependencies:
-      '@babel/generator':
-        specifier: ^7.20.0
-        version: registry.npmjs.org/@babel/generator@7.20.14
-      '@babel/traverse':
-        specifier: ^7.20.0
-        version: registry.npmjs.org/@babel/traverse@7.20.13
-      '@babel/types':
-        specifier: ^7.20.0
-        version: registry.npmjs.org/@babel/types@7.20.7
       '@tarojs/taro':
         specifier: workspace:*
         version: link:../taro
@@ -32286,7 +32284,7 @@ packages:
     name: read-package-json
     version: 2.1.2
     dependencies:
-      glob: registry.npmjs.org/glob@7.1.2
+      glob: registry.npmjs.org/glob@7.2.3
       json-parse-even-better-errors: registry.npmjs.org/json-parse-even-better-errors@2.3.1
       normalize-package-data: registry.npmjs.org/normalize-package-data@2.5.0
       npm-normalize-package-bin: registry.npmjs.org/npm-normalize-package-bin@1.0.1


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

With the latest stable release of Taro (v3.6.2), I ran into the following error when building with Yarn (v3.4.1):
```console
$ yarn dev:weapp

> front_app@1.0.0 build:weapp
> taro build --type weapp --watch

👽 Taro v3.6.2

Error: @tarojs/plugin-html tried to access @babel/generator, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: @babel/generator
Required by: @tarojs/plugin-html@npm:3.6.2 (via /home/nobody/somewhere/front_app/.yarn/cache/@tarojs-plugin-html-npm-3.6.2-79a6025293-babd09181c.zip/node_modules/@tarojs/plugin-html/dist/)

Require stack:
- /home/nobody/somewhere/front_app/.yarn/cache/@tarojs-plugin-html-npm-3.6.2-79a6025293-babd09181c.zip/node_modules/@tarojs/plugin-html/dist/index.js
- /home/nobody/somewhere/front_app/.yarn/cache/@tarojs-plugin-html-npm-3.6.2-79a6025293-babd09181c.zip/node_modules/@tarojs/plugin-html/index.js
- /home/nobody/somewhere/front_app/.yarn/cache/@tarojs-service-npm-3.6.2-1974c43cf3-f438f0b30d.zip/node_modules/@tarojs/service/dist/utils/index.js
- /home/nobody/somewhere/front_app/.yarn/cache/@tarojs-service-npm-3.6.2-1974c43cf3-f438f0b30d.zip/node_modules/@tarojs/service/dist/Kernel.js
- /home/nobody/somewhere/front_app/.yarn/cache/@tarojs-service-npm-3.6.2-1974c43cf3-f438f0b30d.zip/node_modules/@tarojs/service/dist/index.js
- /home/nobody/somewhere/front_app/.yarn/cache/@tarojs-service-npm-3.6.2-1974c43cf3-f438f0b30d.zip/node_modules/@tarojs/service/index.js
- /home/nobody/somewhere/front_app/.yarn/__virtual__/@tarojs-cli-virtual-b9b2585247/0/cache/@tarojs-cli-npm-3.6.2-94eed4029d-035dd606eb.zip/node_modules/@tarojs/cli/dist/cli.js
- /home/nobody/somewhere/front_app/.yarn/__virtual__/@tarojs-cli-virtual-b9b2585247/0/cache/@tarojs-cli-npm-3.6.2-94eed4029d-035dd606eb.zip/node_modules/@tarojs/cli/bin/taro
    at Function.require$$0.Module._resolveFilename (/home/nobody/somewhere/front_app/.pnp.cjs:31204:13)
    at Function.require$$0.Module._load (/home/nobody/somewhere/front_app/.pnp.cjs:31054:42)
    at Module.require (node:internal/modules/cjs/loader:1141:19)
    at require (node:internal/modules/cjs/helpers:110:18)
    at Object.<anonymous> (/home/nobody/somewhere/front_app/.yarn/cache/@tarojs-plugin-html-npm-3.6.2-79a6025293-babd09181c.zip/node_modules/@tarojs/plugin-html/dist/index.js:5:17)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at require$$0.Module._extensions..js (/home/nobody/somewhere/front_app/.pnp.cjs:31248:33)
    at Object.newLoader [as .js] (/home/nobody/somewhere/front_app/.yarn/cache/pirates-npm-4.0.5-22f8e827ce-c9994e61b8.zip/node_modules/pirates/lib/index.js:141:7)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
/home/nobody/somewhere/front_app/.yarn/cache/@tarojs-service-npm-3.6.2-1974c43cf3-f438f0b30d.zip/node_modules/@tarojs/service/dist/utils/index.js:75
                    throw new Error(`插件依赖 "${item}" 加载失败，请检查插件配置`);
                          ^

Error: 插件依赖 "@tarojs/plugin-html" 加载失败，请检查插件配置
    at apply (/home/nobody/somewhere/front_app/.yarn/cache/@tarojs-service-npm-3.6.2-1974c43cf3-f438f0b30d.zip/node_modules/@tarojs/service/src/utils/index.ts:72:17)
    at Kernel.initPlugin (/home/nobody/somewhere/front_app/.yarn/cache/@tarojs-service-npm-3.6.2-1974c43cf3-f438f0b30d.zip/node_modules/@tarojs/service/src/Kernel.ts:157:5)
    at Kernel.resolvePlugins (/home/nobody/somewhere/front_app/.yarn/cache/@tarojs-service-npm-3.6.2-1974c43cf3-f438f0b30d.zip/node_modules/@tarojs/service/src/Kernel.ts:130:12)
    at Kernel.initPresetsAndPlugins (/home/nobody/somewhere/front_app/.yarn/cache/@tarojs-service-npm-3.6.2-1974c43cf3-f438f0b30d.zip/node_modules/@tarojs/service/src/Kernel.ts:115:10)
    at Kernel.<anonymous> (/home/nobody/somewhere/front_app/.yarn/cache/@tarojs-service-npm-3.6.2-1974c43cf3-f438f0b30d.zip/node_modules/@tarojs/service/src/Kernel.ts:312:10)
    at Generator.next (<anonymous>)
    at /home/nobody/somewhere/front_app/.yarn/cache/@tarojs-service-npm-3.6.2-1974c43cf3-f438f0b30d.zip/node_modules/@tarojs/service/dist/Kernel.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/home/nobody/somewhere/front_app/.yarn/cache/@tarojs-service-npm-3.6.2-1974c43cf3-f438f0b30d.zip/node_modules/@tarojs/service/dist/Kernel.js:4:12)
    at Kernel.run (/home/nobody/somewhere/front_app/.yarn/cache/@tarojs-service-npm-3.6.2-1974c43cf3-f438f0b30d.zip/node_modules/@tarojs/service/dist/Kernel.js:247:16)

Node.js v18.15.0
```

This is caused by the `@tarojs/plugin-html` not declaring all required dependencies in its `package.json`. Since the `@babel/*` packages are required not only for developing/building the plugin, but also **at run time** (i.e. when the plugin is used), they should be specified as `dependencies` rather than `devDependencies`.

https://github.com/NervJS/taro/blob/4b17fae036ab4250b63e7671fc8e834b2c39c8f1/packages/taro-plugin-html/src/index.ts#L1-L6

In the past, you could get away with it because installed packages are hoisted to the root of `node_modules` ([a behaviour introduced by npm v3](https://npm.github.io/how-npm-works-docs/npm3/how-npm3-works.html)). However, phantom dependencies are known to be unsafe and has long been frowned upon. Moreover, these days, we can no longer rely on hoisting being in place, especially when newer package managers offer ways to explicitly guard against these violations (e.g. npm's [`install-strategy`](https://docs.npmjs.com/cli/v9/using-npm/config#install-strategy), Yarn's [Plug'n'Play](https://yarnpkg.com/features/pnp) and pnpm's [`hoist=false`](https://pnpm.io/blog/2020/10/17/node-modules-configuration-options-with-pnpm#a-strict-traditional-modules-directory)).

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix)
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
