### PR TITLE
fix(h5): 修补 tabbar 生命周期错误 fix #13581

### DIFF
--- a/packages/taro-components/src/components/tabbar/tabbar.tsx
+++ b/packages/taro-components/src/components/tabbar/tabbar.tsx
@@ -82,9 +82,9 @@ export class Tabbar implements ComponentInterface {
 
   @Element() tabbar: HTMLDivElement
 
-  constructor () {
-    const list = this.conf.list
-    const customRoutes = this.conf.customRoutes
+  componentWillLoad () {
+    const list = this.conf?.list || []
+    const customRoutes = this.conf?.customRoutes || {}
     if (
       Object.prototype.toString.call(list) !== '[object Array]' ||
       list.length < 2 ||

--- a/packages/taro-h5/__tests__/utils.ts
+++ b/packages/taro-h5/__tests__/utils.ts
@@ -1,4 +1,3 @@
-import { defineCustomElement } from '@tarojs/components/dist/components/taro-tabbar'
 import { createReactApp } from '@tarojs/plugin-framework-react/dist/runtime'
 import { createRouter } from '@tarojs/router'
 import React, { Component, PropsWithChildren } from 'react'
@@ -63,8 +62,6 @@ export const delay = (ms = 500) => {
 }
 
 export function buildApp () {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  defineCustomElement = jest.fn()
   const config: any = { ...appConfig }
   class App extends Component<PropsWithChildren> {
     render () {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

- 修补 tabbar 生命周期错误（stencil 升级后 document.createElement 将会直接执行 constructor 导致错误）
- 补充 tabbar 测试用例

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #13581

**这个 PR 涉及以下平台:**

- [x] Web 平台（H5）
