### PR TITLE
feat(postcss-pxtransform): h5 支持 px单位; weapp 支持 rem 和 px 单位

### DIFF
--- a/packages/postcss-pxtransform/__tests__/index.test.js
+++ b/packages/postcss-pxtransform/__tests__/index.test.js
@@ -566,7 +566,7 @@ describe('platform 为 weapp, targetUnit 为 px', () => {
 
   it('{platform: \'weapp\', designWidth: 640, targetUnit: \'px\'} ', () => {
     const rules = 'h1 {margin: 0 0 20px;font-size: 40px;line-height: 1.2;}'
-    const expected = 'h1 {margin: 0 0 8.54701px;font-size: 17.09402px;line-height: 1.2;}'
+    const expected = 'h1 {margin: 0 0 11.7px;font-size: 23.4px;line-height: 1.2;}'
     const options = {
       platform: 'weapp',
       designWidth: 640,
@@ -616,7 +616,7 @@ describe('platform 为 h5, targetUnit 为 px', () => {
 
   it('{platform: \'h5\', designWidth: 640, targetUnit: \'px\'} ', () => {
     const rules = 'h1 {margin: 0 0 20px;font-size: 40Px;line-height: 1.2;}'
-    const expected = 'h1 {margin: 0 0 8.54701px;font-size: 40Px;line-height: 1.2;}'
+    const expected = 'h1 {margin: 0 0 11.7px;font-size: 40Px;line-height: 1.2;}'
     const options = {
       platform: 'h5',
       designWidth: 640,
@@ -738,6 +738,17 @@ describe('vw 单位转换', () => {
     const options = {
       platform: 'h5',
       designWidth: 750,
+      targetUnit: 'vw'
+    }
+    const processed = postcss(px2rem(options)).process(rules).css
+    expect(processed).toBe('h1 {margin: 0 0 50vw;font-size: 40Px;line-height: 1.2;} .test{}')
+  })
+
+  it('{platform: \'h5\', designWidth: 640} ', () => {
+    const rules = 'h1 {margin: 0 0 320px;font-size: 40Px;line-height: 1.2;} .test{}'
+    const options = {
+      platform: 'h5',
+      designWidth: 640,
       targetUnit: 'vw'
     }
     const processed = postcss(px2rem(options)).process(rules).css

--- a/packages/postcss-pxtransform/__tests__/index.test.js
+++ b/packages/postcss-pxtransform/__tests__/index.test.js
@@ -525,6 +525,58 @@ describe('platform 为 weapp', () => {
   })
 })
 
+describe('platform 为 weapp, targetUnit 为 rem', () => {
+  it('{platform: \'weapp\', designWidth: 750, targetUnit: \'rem\'} ', () => {
+    const rules = 'h1 {margin: 0 0 20px;font-size: 40Px;line-height: 1.2;}'
+    const expected = 'h1 {margin: 0 0 0.5rem;font-size: 40Px;line-height: 1.2;}'
+    const options = {
+      platform: 'weapp',
+      designWidth: 750,
+      targetUnit: 'rem'
+    }
+    const processed = postcss(px2rem(options)).process(rules).css
+    expect(processed).toBe(expected)
+  })
+
+  it('{platform: \'weapp\', designWidth: 640, targetUnit: \'rem\'} ', () => {
+    const rules = 'h1 {margin: 0 0 20px;font-size: 40px;line-height: 1.2;}'
+    const expected = 'h1 {margin: 0 0 0.585rem;font-size: 1.17rem;line-height: 1.2;}'
+    const options = {
+      platform: 'weapp',
+      designWidth: 640,
+      targetUnit: 'rem'
+    }
+    const processed = postcss(px2rem(options)).process(rules).css
+    expect(processed).toBe(expected)
+  })
+})
+
+describe('platform 为 weapp, targetUnit 为 px', () => {
+  it('{platform: \'weapp\', designWidth: 750, targetUnit: \'px\'} ', () => {
+    const rules = 'h1 {margin: 0 0 20px;font-size: 40Px;line-height: 1.2;}'
+    const expected = 'h1 {margin: 0 0 10px;font-size: 40Px;line-height: 1.2;}'
+    const options = {
+      platform: 'weapp',
+      designWidth: 750,
+      targetUnit: 'px'
+    }
+    const processed = postcss(px2rem(options)).process(rules).css
+    expect(processed).toBe(expected)
+  })
+
+  it('{platform: \'weapp\', designWidth: 640, targetUnit: \'px\'} ', () => {
+    const rules = 'h1 {margin: 0 0 20px;font-size: 40px;line-height: 1.2;}'
+    const expected = 'h1 {margin: 0 0 8.54701px;font-size: 17.09402px;line-height: 1.2;}'
+    const options = {
+      platform: 'weapp',
+      designWidth: 640,
+      targetUnit: 'px'
+    }
+    const processed = postcss(px2rem(options)).process(rules).css
+    expect(processed).toBe(expected)
+  })
+})
+
 describe('platform 为 h5', () => {
   it('{platform: \'h5\', designWidth: 750} ', () => {
     const rules = 'h1 {margin: 0 0 20px;font-size: 40px;line-height: 1.2;}'
@@ -543,6 +595,32 @@ describe('platform 为 h5', () => {
     const options = {
       platform: 'h5',
       designWidth: 640
+    }
+    const processed = postcss(px2rem(options)).process(rules).css
+    expect(processed).toBe(expected)
+  })
+})
+
+describe('platform 为 h5, targetUnit 为 px', () => {
+  it('{platform: \'h5\', designWidth: 750, targetUnit: \'px\'} ', () => {
+    const rules = 'h1 {margin: 0 0 20px;font-size: 40px;line-height: 1.2;}'
+    const expected = 'h1 {margin: 0 0 10px;font-size: 20px;line-height: 1.2;}'
+    const options = {
+      platform: 'h5',
+      designWidth: 750,
+      targetUnit: 'px'
+    }
+    const processed = postcss(px2rem(options)).process(rules).css
+    expect(processed).toBe(expected)
+  })
+
+  it('{platform: \'h5\', designWidth: 640, targetUnit: \'px\'} ', () => {
+    const rules = 'h1 {margin: 0 0 20px;font-size: 40Px;line-height: 1.2;}'
+    const expected = 'h1 {margin: 0 0 8.54701px;font-size: 40Px;line-height: 1.2;}'
+    const options = {
+      platform: 'h5',
+      designWidth: 640,
+      targetUnit: 'px'
     }
     const processed = postcss(px2rem(options)).process(rules).css
     expect(processed).toBe(expected)

--- a/packages/postcss-pxtransform/index.js
+++ b/packages/postcss-pxtransform/index.js
@@ -42,19 +42,28 @@ module.exports = (options = {}) => {
   options = Object.assign({}, DEFAULT_WEAPP_OPTIONS, options)
 
   const transUnits = ['px']
-  let baseFontSize = options.baseFontSize || (options.minRootSize >= 1 ? options.minRootSize : 20)
+  const baseFontSize = options.baseFontSize || (options.minRootSize >= 1 ? options.minRootSize : 20)
   const designWidth = (input) =>
     typeof options.designWidth === 'function' ? options.designWidth(input) : options.designWidth
 
   switch (options.platform) {
     case 'h5': {
       targetUnit = options.targetUnit ?? 'rem'
-      options.rootValue = (input) => {
-        if (targetUnit === 'vw') {
-          baseFontSize = 0.5 * designWidth(input) / 100
+
+      if (targetUnit === 'vw') {
+        options.rootValue = (input) => {
+          const designWidthValue = designWidth(input)
+          return designWidthValue / 100 / options.deviceRatio[designWidthValue]
         }
-        return (baseFontSize / options.deviceRatio[designWidth(input)]) * 2 
+      } else if (targetUnit === 'px') {
+        options.rootValue = (input) => options.deviceRatio[designWidth(input)] * 2
+      } else {
+        // rem
+        options.rootValue = (input) => {
+          return (baseFontSize / options.deviceRatio[designWidth(input)]) * 2
+        }
       }
+
       transUnits.push('rpx')
       break
     }
@@ -75,8 +84,16 @@ module.exports = (options = {}) => {
     }
     default: {
       // mini-program
-      options.rootValue = (input) => 1 / options.deviceRatio[designWidth(input)]
-      targetUnit = 'rpx'
+      targetUnit = options.targetUnit ?? 'rpx'
+
+      if (targetUnit === 'rem') {
+        options.rootValue = (input) => (baseFontSize / options.deviceRatio[designWidth(input)]) * 2
+      } else if (targetUnit === 'px') {
+        options.rootValue = (input) => options.deviceRatio[designWidth(input)] * 2
+      } else {
+        // rpx
+        options.rootValue = (input) => 1 / options.deviceRatio[designWidth(input)]
+      }
     }
   }
 

--- a/packages/postcss-pxtransform/index.js
+++ b/packages/postcss-pxtransform/index.js
@@ -52,11 +52,10 @@ module.exports = (options = {}) => {
 
       if (targetUnit === 'vw') {
         options.rootValue = (input) => {
-          const designWidthValue = designWidth(input)
-          return designWidthValue / 100 / options.deviceRatio[designWidthValue]
+          return designWidth(input) / 100
         }
       } else if (targetUnit === 'px') {
-        options.rootValue = (input) => options.deviceRatio[designWidth(input)] * 2
+        options.rootValue = (input) => (1 / options.deviceRatio[designWidth(input)]) * 2
       } else {
         // rem
         options.rootValue = (input) => {
@@ -89,7 +88,7 @@ module.exports = (options = {}) => {
       if (targetUnit === 'rem') {
         options.rootValue = (input) => (baseFontSize / options.deviceRatio[designWidth(input)]) * 2
       } else if (targetUnit === 'px') {
-        options.rootValue = (input) => options.deviceRatio[designWidth(input)] * 2
+        options.rootValue = (input) => (1 / options.deviceRatio[designWidth(input)]) * 2
       } else {
         // rpx
         options.rootValue = (input) => 1 / options.deviceRatio[designWidth(input)]

--- a/packages/taro-api/__tests__/pxTransform.test.ts
+++ b/packages/taro-api/__tests__/pxTransform.test.ts
@@ -1,0 +1,80 @@
+import Taro from '@tarojs/taro'
+
+describe('pxtransform', () => {
+  test('pxTransform', () => {
+    Taro.initPxTransform({
+      designWidth: 750,
+      deviceRatio: {
+        640: 2.34 / 2,
+        750: 1,
+        828: 1.81 / 2,
+      },
+    })
+    expect(Taro.pxTransform(20)).toBe('20rpx')
+  })
+
+  test('pxTransform, designWidth=640', () => {
+    Taro.initPxTransform({
+      designWidth: 640,
+      deviceRatio: {
+        640: 2.34 / 2,
+        750: 1,
+        828: 1.81 / 2,
+      },
+    })
+    expect(Taro.pxTransform(20)).toBe('23.4rpx')
+  })
+
+  test('pxTransform, targetUnit=px', () => {
+    Taro.initPxTransform({
+      designWidth: 750,
+      deviceRatio: {
+        640: 2.34 / 2,
+        750: 1,
+        828: 1.81 / 2,
+      },
+      targetUnit: 'px'
+    })
+    expect(Taro.pxTransform(20)).toBe('10px')
+  })
+
+  test('pxTransform, targetUnit=px, designWidth=640', () => {
+    Taro.initPxTransform({
+      designWidth: 640,
+      deviceRatio: {
+        640: 2.34 / 2,
+        750: 1,
+        828: 1.81 / 2,
+      },
+      targetUnit: 'px'
+    })
+    expect(Taro.pxTransform(20)).toBe('11.7px')
+  })
+
+  test('pxTransform, targetUnit=rem', () => {
+    Taro.initPxTransform({
+      designWidth: 750,
+      deviceRatio: {
+        640: 2.34 / 2,
+        750: 1,
+        828: 1.81 / 2,
+      },
+      targetUnit: 'rem'
+    })
+    expect(Taro.pxTransform(20)).toBe('0.5rem')
+  })
+
+  test('pxTransform, targetUnit=rew, designWidth=640', () => {
+    Taro.initPxTransform({
+      designWidth: 640,
+      deviceRatio: {
+        640: 2.34 / 2,
+        750: 1,
+        828: 1.81 / 2,
+      },
+      targetUnit: 'rem'
+    })
+    expect(Taro.pxTransform(20)).toBe('0.585rem')
+  })
+
+})

--- a/packages/taro-api/__tests__/pxTransform.test.ts
+++ b/packages/taro-api/__tests__/pxTransform.test.ts
@@ -64,7 +64,7 @@ describe('pxtransform', () => {
     expect(Taro.pxTransform(20)).toBe('0.5rem')
   })
 
-  test('pxTransform, targetUnit=rew, designWidth=640', () => {
+  test('pxTransform, targetUnit=rem, designWidth=640', () => {
     Taro.initPxTransform({
       designWidth: 640,
       deviceRatio: {

--- a/packages/taro-api/jest.config.js
+++ b/packages/taro-api/jest.config.js
@@ -1,0 +1,34 @@
+const path = require('path')
+
+module.exports = {
+  globals: {
+    ENABLE_INNER_HTML: true,
+    ENABLE_ADJACENT_HTML: true,
+    ENABLE_SIZE_APIS: true,
+    ENABLE_TEMPLATE_CONTENT: true,
+    ENABLE_MUTATION_OBSERVER: true,
+    ENABLE_CLONE_NODE: true,
+    ENABLE_CONTAINS: true,
+  },
+  moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx', 'json', 'node'],
+  moduleNameMapper: {
+    '@tarojs/api': '<rootDir>/src/index.js',
+    '@tarojs/shared': path.resolve(__dirname, '..', '..', 'packages/shared/src/index.ts'),
+    '@tarojs/runtime': path.resolve(__dirname, '..', '..', 'packages/taro-runtime/dist/runtime.esm.js')
+  },
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testEnvironmentOptions: {
+    url: 'http://localhost/'
+  },
+  testMatch: ['**/__tests__/**/?(*.)+(spec|test).[jt]s?(x)'],
+  testPathIgnorePatterns: [
+    'node_modules',
+  ],
+  transform: {
+    '^.+\\.m?[tj]sx?$': ['ts-jest', {
+      diagnostics: false,
+      tsconfig: 'tsconfig.test.json'
+    }],
+  }
+}

--- a/packages/taro-api/package.json
+++ b/packages/taro-api/package.json
@@ -22,7 +22,7 @@
     "url": "git+https://github.com/NervJS/taro.git"
   },
   "scripts": {
-    "test": "echo \"Error: run tests from root\" && exit 1",
+    "test": "jest",
     "build": "rollup -c rollup.config.js"
   },
   "bugs": {
@@ -38,6 +38,11 @@
     "@rollup/plugin-babel": "^5.2.1",
     "@rollup/plugin-commonjs": "^20.0.0",
     "@rollup/plugin-node-resolve": "^8.0.0",
-    "rollup": "^2.79.0"
+    "jest": "^29.3.1",
+    "jest-cli": "^29.3.1",
+    "jest-environment-node": "^29.5.0",
+    "rollup": "^2.79.0",
+    "ts-jest": "^29.0.5",
+    "typescript": "^4.7.4"
   }
 }

--- a/packages/taro-api/src/tools.js
+++ b/packages/taro-api/src/tools.js
@@ -21,18 +21,24 @@ const defaultDesignRatio = {
   828: 1.81 / 2
 }
 const defaultBaseFontSize = 20
+const defaultUnitPrecision = 5
+const defaultTargetUnit = 'rpx'
 
 export function getInitPxTransform (taro) {
   return function (config) {
     const {
       designWidth = defaultDesignWidth,
       deviceRatio = defaultDesignRatio,
-      baseFontSize = defaultBaseFontSize
+      baseFontSize = defaultBaseFontSize,
+      targetUnit = defaultTargetUnit,
+      unitPrecision = defaultUnitPrecision,
     } = config
     taro.config = taro.config || {}
     taro.config.designWidth = designWidth
     taro.config.deviceRatio = deviceRatio
     taro.config.baseFontSize = baseFontSize
+    taro.config.targetUnit = targetUnit
+    taro.config.unitPrecision = unitPrecision
   }
 }
 
@@ -40,12 +46,27 @@ export function getPxTransform (taro) {
   return function (size) {
     const config = taro.config || {}
     const deviceRatio = config.deviceRatio || defaultDesignRatio
+    const baseFontSize = config.baseFontSize
     const designWidth = (((input = 0) => isFunction(config.designWidth)
       ? config.designWidth(input)
       : config.designWidth || defaultDesignWidth))(size)
     if (!(designWidth in deviceRatio)) {
       throw new Error(`deviceRatio 配置中不存在 ${designWidth} 的设置！`)
     }
-    return (parseInt(size, 10) * deviceRatio[designWidth]) + 'rpx'
+    const formatSize = ~~size
+    let rootValue = 1 / config.deviceRatio[designWidth]
+    switch (config.targetUnit) {
+      case 'rem':
+        rootValue *= baseFontSize * 2
+        break
+      case 'px':
+        rootValue *= 2
+        break
+    }
+    let val = formatSize / rootValue
+    if (config.unitPrecision >= 0 && config.unitPrecision <= 100) {
+      val = Number(val.toFixed(config.unitPrecision))
+    }
+    return val + config.targetUnit
   }
 }

--- a/packages/taro-api/tsconfig.test.json
+++ b/packages/taro-api/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.root.json",
+  "compilerOptions": {
+    "jsx": "react",
+    "allowJs": true
+  }
+}

--- a/packages/taro-h5/__tests__/base/pxTransform.test.ts
+++ b/packages/taro-h5/__tests__/base/pxTransform.test.ts
@@ -1,0 +1,80 @@
+import * as Taro from '@tarojs/taro-h5'
+
+describe('pxtransform', () => {
+  test('pxTransform', () => {
+    Taro.initPxTransform({
+      designWidth: 750,
+      deviceRatio: {
+        640: 2.34 / 2,
+        750: 1,
+        828: 1.81 / 2,
+      },
+    })
+    expect(Taro.pxTransform(20)).toBe('0.5rem')
+  })
+
+  test('pxTransform, designWidth=640', () => {
+    Taro.initPxTransform({
+      designWidth: 640,
+      deviceRatio: {
+        640: 2.34 / 2,
+        750: 1,
+        828: 1.81 / 2,
+      },
+    })
+    expect(Taro.pxTransform(20)).toBe('0.585rem')
+  })
+
+  test('pxTransform, targetUnit=px', () => {
+    Taro.initPxTransform({
+      designWidth: 750,
+      deviceRatio: {
+        640: 2.34 / 2,
+        750: 1,
+        828: 1.81 / 2,
+      },
+      targetUnit: 'px'
+    })
+    expect(Taro.pxTransform(20)).toBe('10px')
+  })
+
+  test('pxTransform, targetUnit=px, designWidth=640', () => {
+    Taro.initPxTransform({
+      designWidth: 640,
+      deviceRatio: {
+        640: 2.34 / 2,
+        750: 1,
+        828: 1.81 / 2,
+      },
+      targetUnit: 'px'
+    })
+    expect(Taro.pxTransform(20)).toBe('11.7px')
+  })
+
+  test('pxTransform, targetUnit=vw', () => {
+    Taro.initPxTransform({
+      designWidth: 750,
+      deviceRatio: {
+        640: 2.34 / 2,
+        750: 1,
+        828: 1.81 / 2,
+      },
+      targetUnit: 'vw'
+    })
+    expect(Taro.pxTransform(375)).toBe('50vw')
+  })
+
+  test('pxTransform, targetUnit=vw, designWidth=640', () => {
+    Taro.initPxTransform({
+      designWidth: 640,
+      deviceRatio: {
+        640: 2.34 / 2,
+        750: 1,
+        828: 1.81 / 2,
+      },
+      targetUnit: 'vw'
+    })
+    expect(Taro.pxTransform(320)).toBe('50vw')
+  })
+
+})

--- a/packages/taro-h5/src/api/taro.ts
+++ b/packages/taro-h5/src/api/taro.ts
@@ -77,17 +77,22 @@ const pxTransform = function (size = 0) {
     throw new Error(`deviceRatio 配置中不存在 ${designWidth} 的设置！`)
   }
   const formatSize = ~~size
-  let rootValue = 1 / config.deviceRatio[designWidth] * 2
+  let rootValue = 1 / config.deviceRatio[designWidth]
   switch (config?.targetUnit) {
     case 'vw':
-      rootValue *= 0.5 * designWidth / 100
+      rootValue = designWidth / 100
       break
-    default:
-      rootValue *= baseFontSize
+    case 'rem':
+      rootValue *= baseFontSize * 2
+      break
+    case 'px':
+      rootValue *= 2
+      break
   }
   let val: number | string = formatSize / rootValue
   if (config.unitPrecision >= 0 && config.unitPrecision <= 100) {
-    val = val.toFixed(config.unitPrecision)
+    // Number(val): 0.50000 => 0.5
+    val = Number(val.toFixed(config.unitPrecision))
   }
   return val + config?.targetUnit
 }

--- a/packages/taro-h5/src/api/taro.ts
+++ b/packages/taro-h5/src/api/taro.ts
@@ -82,12 +82,12 @@ const pxTransform = function (size = 0) {
     case 'vw':
       rootValue = designWidth / 100
       break
-    case 'rem':
-      rootValue *= baseFontSize * 2
-      break
     case 'px':
       rootValue *= 2
       break
+    default:
+      // rem
+      rootValue *= baseFontSize * 2
   }
   let val: number | string = formatSize / rootValue
   if (config.unitPrecision >= 0 && config.unitPrecision <= 100) {

--- a/packages/taro-loader/src/app.ts
+++ b/packages/taro-loader/src/app.ts
@@ -61,6 +61,9 @@ ${options.prerender ? prerender : ''}
 initPxTransform({
   designWidth: ${pxTransformConfig.designWidth},
   deviceRatio: ${JSON.stringify(pxTransformConfig.deviceRatio)}
+  baseFontSize: ${pxTransformConfig.baseFontSize || (pxTransformConfig.minRootSize >= 1 ? pxTransformConfig.minRootSize : 20)},
+  unitPrecision: ${pxTransformConfig.unitPrecision},
+  targetUnit: ${JSON.stringify(pxTransformConfig.targetUnit)}
 })
 `
 }

--- a/packages/taro-loader/src/app.ts
+++ b/packages/taro-loader/src/app.ts
@@ -60,7 +60,7 @@ ${instantiateApp}
 ${options.prerender ? prerender : ''}
 initPxTransform({
   designWidth: ${pxTransformConfig.designWidth},
-  deviceRatio: ${JSON.stringify(pxTransformConfig.deviceRatio)}
+  deviceRatio: ${JSON.stringify(pxTransformConfig.deviceRatio)},
   baseFontSize: ${pxTransformConfig.baseFontSize || (pxTransformConfig.minRootSize >= 1 ? pxTransformConfig.minRootSize : 20)},
   unitPrecision: ${pxTransformConfig.unitPrecision},
   targetUnit: ${JSON.stringify(pxTransformConfig.targetUnit)}

--- a/packages/taro-loader/src/app.ts
+++ b/packages/taro-loader/src/app.ts
@@ -61,7 +61,7 @@ ${options.prerender ? prerender : ''}
 initPxTransform({
   designWidth: ${pxTransformConfig.designWidth},
   deviceRatio: ${JSON.stringify(pxTransformConfig.deviceRatio)},
-  baseFontSize: ${pxTransformConfig.baseFontSize || (pxTransformConfig.minRootSize >= 1 ? pxTransformConfig.minRootSize : 20)},
+  baseFontSize: ${pxTransformConfig.baseFontSize || 20},
   unitPrecision: ${pxTransformConfig.unitPrecision},
   targetUnit: ${JSON.stringify(pxTransformConfig.targetUnit)}
 })

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/alipay.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/alipay.spec.ts.snap
@@ -828,7 +828,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 17, 0, 1, 3, 2 ] ] ]);

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/babel.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/babel.spec.ts.snap
@@ -518,7 +518,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 15, 0, 1, 3, 2 ] ] ]);

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/bytedance.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/bytedance.spec.ts.snap
@@ -299,7 +299,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 14, 0, 1, 3, 2 ] ] ]);

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/common-style.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/common-style.spec.ts.snap
@@ -518,7 +518,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 17, 0, 1, 3, 2 ] ] ]);

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/compiler-macros.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/compiler-macros.spec.ts.snap
@@ -518,7 +518,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 14, 0, 1, 3, 2 ] ] ]);

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/config.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/config.spec.ts.snap
@@ -518,7 +518,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 15, 0, 1, 3, 2 ] ] ]);
@@ -2294,7 +2297,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 15, 0, 1, 3, 2 ] ] ]);
@@ -4008,7 +4014,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 15, 0, 1, 3, 2 ] ] ]);

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/css-modules.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/css-modules.spec.ts.snap
@@ -520,7 +520,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 17, 0, 1, 3, 2 ] ] ]);
@@ -2138,7 +2141,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 17, 0, 1, 3, 2 ] ] ]);

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/custom-tabbar.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/custom-tabbar.spec.ts.snap
@@ -499,7 +499,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 18, 0, 1, 3, 2 ] ] ]);

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/jd.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/jd.spec.ts.snap
@@ -131,7 +131,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 15, 0, 1, 3, 2 ] ] ]);

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/parse-html.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/parse-html.spec.ts.snap
@@ -518,7 +518,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 15, 0, 1, 3, 2 ] ] ]);

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/prerender.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/prerender.spec.ts.snap
@@ -521,7 +521,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 18, 0, 1, 3, 2 ] ] ]);
@@ -3513,7 +3516,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 18, 0, 1, 3, 2 ] ] ]);
@@ -6505,7 +6511,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 18, 0, 1, 3, 2 ] ] ]);

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/qq.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/qq.spec.ts.snap
@@ -582,7 +582,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 15, 0, 1, 3, 2 ] ] ]);
@@ -2845,7 +2848,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 15, 0, 1, 3, 2 ] ] ]);

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/react.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/react.spec.ts.snap
@@ -518,7 +518,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 15, 0, 1, 3, 2 ] ] ]);

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/sass.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/sass.spec.ts.snap
@@ -518,7 +518,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 15, 0, 1, 3, 2 ] ] ]);
@@ -2119,7 +2122,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 15, 0, 1, 3, 2 ] ] ]);
@@ -3720,7 +3726,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 15, 0, 1, 3, 2 ] ] ]);
@@ -5321,7 +5330,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 15, 0, 1, 3, 2 ] ] ]);

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/subpackages.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/subpackages.spec.ts.snap
@@ -485,7 +485,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 19, 0, 1, 3, 2 ] ] ]);

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/swan.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/swan.spec.ts.snap
@@ -387,7 +387,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 14, 0, 1, 3, 2 ] ] ]);

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/tabbar.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/tabbar.spec.ts.snap
@@ -843,7 +843,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 16, 0, 1, 3, 2 ] ] ]);
@@ -1798,7 +1801,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 15, 0, 1, 3, 2 ] ] ]);

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/ts.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/ts.spec.ts.snap
@@ -518,7 +518,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 15, 0, 1, 3, 2 ] ] ]);

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/vue.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/vue.spec.ts.snap
@@ -491,7 +491,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 7, 0, 1 ] ] ]);

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/vue3.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/vue3.spec.ts.snap
@@ -490,7 +490,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 8, 0, 1, 2 ] ] ]);

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/wx-hybrid.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/wx-hybrid.spec.ts.snap
@@ -482,7 +482,10 @@ require("./taro");
                 640: 1.17,
                 750: 1,
                 828: .905
-            }
+            },
+            baseFontSize: 20,
+            unitPrecision: undefined,
+            targetUnit: undefined
         });
     }
 }, [ [ 24, 0, 1, 3, 2 ] ] ]);

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/babel.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/babel.spec.ts.snap
@@ -1230,19 +1230,24 @@ exports[`babel should convert do expressions 2`] = `
         "828": 1.81 / 2
     };
     var defaultBaseFontSize = 20;
+    var defaultUnitPrecision = 5;
+    var defaultTargetUnit = "rpx";
     function getInitPxTransform(taro) {
         return function(config) {
-            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize;
+            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize, _config$targetUnit = config.targetUnit, targetUnit = _config$targetUnit === void 0 ? defaultTargetUnit : _config$targetUnit, _config$unitPrecision = config.unitPrecision, unitPrecision = _config$unitPrecision === void 0 ? defaultUnitPrecision : _config$unitPrecision;
             taro.config = taro.config || {};
             taro.config.designWidth = designWidth;
             taro.config.deviceRatio = deviceRatio;
             taro.config.baseFontSize = baseFontSize;
+            taro.config.targetUnit = targetUnit;
+            taro.config.unitPrecision = unitPrecision;
         };
     }
     function getPxTransform(taro) {
         return function(size) {
             var config = taro.config || {};
             var deviceRatio = config.deviceRatio || defaultDesignRatio;
+            var baseFontSize = config.baseFontSize;
             var designWidth = function() {
                 var input = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
                 return isFunction$1(config.designWidth) ? config.designWidth(input) : config.designWidth || defaultDesignWidth;
@@ -1250,7 +1255,22 @@ exports[`babel should convert do expressions 2`] = `
             if (!(designWidth in deviceRatio)) {
                 throw new Error("deviceRatio 配置中不存在 ".concat(designWidth, " 的设置！"));
             }
-            return parseInt(size, 10) * deviceRatio[designWidth] + "rpx";
+            var formatSize = ~~size;
+            var rootValue = 1 / config.deviceRatio[designWidth];
+            switch (config.targetUnit) {
+              case "rem":
+                rootValue *= baseFontSize * 2;
+                break;
+
+              case "px":
+                rootValue *= 2;
+                break;
+            }
+            var val = formatSize / rootValue;
+            if (config.unitPrecision >= 0 && config.unitPrecision <= 100) {
+                val = Number(val.toFixed(config.unitPrecision));
+            }
+            return val + config.targetUnit;
         };
     }
     var Taro = {

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/compiler-macros.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/compiler-macros.spec.ts.snap
@@ -1225,19 +1225,24 @@ exports[`compiler-macros - defineAppConfig and definePageConfig should read app 
         "828": 1.81 / 2
     };
     var defaultBaseFontSize = 20;
+    var defaultUnitPrecision = 5;
+    var defaultTargetUnit = "rpx";
     function getInitPxTransform(taro) {
         return function(config) {
-            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize;
+            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize, _config$targetUnit = config.targetUnit, targetUnit = _config$targetUnit === void 0 ? defaultTargetUnit : _config$targetUnit, _config$unitPrecision = config.unitPrecision, unitPrecision = _config$unitPrecision === void 0 ? defaultUnitPrecision : _config$unitPrecision;
             taro.config = taro.config || {};
             taro.config.designWidth = designWidth;
             taro.config.deviceRatio = deviceRatio;
             taro.config.baseFontSize = baseFontSize;
+            taro.config.targetUnit = targetUnit;
+            taro.config.unitPrecision = unitPrecision;
         };
     }
     function getPxTransform(taro) {
         return function(size) {
             var config = taro.config || {};
             var deviceRatio = config.deviceRatio || defaultDesignRatio;
+            var baseFontSize = config.baseFontSize;
             var designWidth = function() {
                 var input = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
                 return isFunction$1(config.designWidth) ? config.designWidth(input) : config.designWidth || defaultDesignWidth;
@@ -1245,7 +1250,22 @@ exports[`compiler-macros - defineAppConfig and definePageConfig should read app 
             if (!(designWidth in deviceRatio)) {
                 throw new Error("deviceRatio 配置中不存在 ".concat(designWidth, " 的设置！"));
             }
-            return parseInt(size, 10) * deviceRatio[designWidth] + "rpx";
+            var formatSize = ~~size;
+            var rootValue = 1 / config.deviceRatio[designWidth];
+            switch (config.targetUnit) {
+              case "rem":
+                rootValue *= baseFontSize * 2;
+                break;
+
+              case "px":
+                rootValue *= 2;
+                break;
+            }
+            var val = formatSize / rootValue;
+            if (config.unitPrecision >= 0 && config.unitPrecision <= 100) {
+                val = Number(val.toFixed(config.unitPrecision));
+            }
+            return val + config.targetUnit;
         };
     }
     var Taro = {

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/config.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/config.spec.ts.snap
@@ -1237,19 +1237,24 @@ exports[`config should build from origin and pipe to output 2`] = `
         "828": 1.81 / 2
     };
     var defaultBaseFontSize = 20;
+    var defaultUnitPrecision = 5;
+    var defaultTargetUnit = "rpx";
     function getInitPxTransform(taro) {
         return function(config) {
-            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize;
+            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize, _config$targetUnit = config.targetUnit, targetUnit = _config$targetUnit === void 0 ? defaultTargetUnit : _config$targetUnit, _config$unitPrecision = config.unitPrecision, unitPrecision = _config$unitPrecision === void 0 ? defaultUnitPrecision : _config$unitPrecision;
             taro.config = taro.config || {};
             taro.config.designWidth = designWidth;
             taro.config.deviceRatio = deviceRatio;
             taro.config.baseFontSize = baseFontSize;
+            taro.config.targetUnit = targetUnit;
+            taro.config.unitPrecision = unitPrecision;
         };
     }
     function getPxTransform(taro) {
         return function(size) {
             var config = taro.config || {};
             var deviceRatio = config.deviceRatio || defaultDesignRatio;
+            var baseFontSize = config.baseFontSize;
             var designWidth = function() {
                 var input = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
                 return isFunction$1(config.designWidth) ? config.designWidth(input) : config.designWidth || defaultDesignWidth;
@@ -1257,7 +1262,22 @@ exports[`config should build from origin and pipe to output 2`] = `
             if (!(designWidth in deviceRatio)) {
                 throw new Error("deviceRatio 配置中不存在 ".concat(designWidth, " 的设置！"));
             }
-            return parseInt(size, 10) * deviceRatio[designWidth] + "rpx";
+            var formatSize = ~~size;
+            var rootValue = 1 / config.deviceRatio[designWidth];
+            switch (config.targetUnit) {
+              case "rem":
+                rootValue *= baseFontSize * 2;
+                break;
+
+              case "px":
+                rootValue *= 2;
+                break;
+            }
+            var val = formatSize / rootValue;
+            if (config.unitPrecision >= 0 && config.unitPrecision <= 100) {
+                val = Number(val.toFixed(config.unitPrecision));
+            }
+            return val + config.targetUnit;
         };
     }
     var Taro = {
@@ -2717,19 +2737,24 @@ I m irrelevant.
         "828": 1.81 / 2
     };
     var defaultBaseFontSize = 20;
+    var defaultUnitPrecision = 5;
+    var defaultTargetUnit = "rpx";
     function getInitPxTransform(taro) {
         return function(config) {
-            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize;
+            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize, _config$targetUnit = config.targetUnit, targetUnit = _config$targetUnit === void 0 ? defaultTargetUnit : _config$targetUnit, _config$unitPrecision = config.unitPrecision, unitPrecision = _config$unitPrecision === void 0 ? defaultUnitPrecision : _config$unitPrecision;
             taro.config = taro.config || {};
             taro.config.designWidth = designWidth;
             taro.config.deviceRatio = deviceRatio;
             taro.config.baseFontSize = baseFontSize;
+            taro.config.targetUnit = targetUnit;
+            taro.config.unitPrecision = unitPrecision;
         };
     }
     function getPxTransform(taro) {
         return function(size) {
             var config = taro.config || {};
             var deviceRatio = config.deviceRatio || defaultDesignRatio;
+            var baseFontSize = config.baseFontSize;
             var designWidth = function() {
                 var input = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
                 return isFunction$1(config.designWidth) ? config.designWidth(input) : config.designWidth || defaultDesignWidth;
@@ -2737,7 +2762,22 @@ I m irrelevant.
             if (!(designWidth in deviceRatio)) {
                 throw new Error("deviceRatio 配置中不存在 ".concat(designWidth, " 的设置！"));
             }
-            return parseInt(size, 10) * deviceRatio[designWidth] + "rpx";
+            var formatSize = ~~size;
+            var rootValue = 1 / config.deviceRatio[designWidth];
+            switch (config.targetUnit) {
+              case "rem":
+                rootValue *= baseFontSize * 2;
+                break;
+
+              case "px":
+                rootValue *= 2;
+                break;
+            }
+            var val = formatSize / rootValue;
+            if (config.unitPrecision >= 0 && config.unitPrecision <= 100) {
+                val = Number(val.toFixed(config.unitPrecision));
+            }
+            return val + config.targetUnit;
         };
     }
     var Taro = {
@@ -4197,19 +4237,24 @@ exports[`config should resolved alias 2`] = `
         "828": 1.81 / 2
     };
     var defaultBaseFontSize = 20;
+    var defaultUnitPrecision = 5;
+    var defaultTargetUnit = "rpx";
     function getInitPxTransform(taro) {
         return function(config) {
-            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize;
+            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize, _config$targetUnit = config.targetUnit, targetUnit = _config$targetUnit === void 0 ? defaultTargetUnit : _config$targetUnit, _config$unitPrecision = config.unitPrecision, unitPrecision = _config$unitPrecision === void 0 ? defaultUnitPrecision : _config$unitPrecision;
             taro.config = taro.config || {};
             taro.config.designWidth = designWidth;
             taro.config.deviceRatio = deviceRatio;
             taro.config.baseFontSize = baseFontSize;
+            taro.config.targetUnit = targetUnit;
+            taro.config.unitPrecision = unitPrecision;
         };
     }
     function getPxTransform(taro) {
         return function(size) {
             var config = taro.config || {};
             var deviceRatio = config.deviceRatio || defaultDesignRatio;
+            var baseFontSize = config.baseFontSize;
             var designWidth = function() {
                 var input = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
                 return isFunction$1(config.designWidth) ? config.designWidth(input) : config.designWidth || defaultDesignWidth;
@@ -4217,7 +4262,22 @@ exports[`config should resolved alias 2`] = `
             if (!(designWidth in deviceRatio)) {
                 throw new Error("deviceRatio 配置中不存在 ".concat(designWidth, " 的设置！"));
             }
-            return parseInt(size, 10) * deviceRatio[designWidth] + "rpx";
+            var formatSize = ~~size;
+            var rootValue = 1 / config.deviceRatio[designWidth];
+            switch (config.targetUnit) {
+              case "rem":
+                rootValue *= baseFontSize * 2;
+                break;
+
+              case "px":
+                rootValue *= 2;
+                break;
+            }
+            var val = formatSize / rootValue;
+            if (config.unitPrecision >= 0 && config.unitPrecision <= 100) {
+                val = Number(val.toFixed(config.unitPrecision));
+            }
+            return val + config.targetUnit;
         };
     }
     var Taro = {

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/css-modules.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/css-modules.spec.ts.snap
@@ -1254,19 +1254,24 @@ exports[`css modules should use css modules with global mode 2`] = `
         "828": 1.81 / 2
     };
     var defaultBaseFontSize = 20;
+    var defaultUnitPrecision = 5;
+    var defaultTargetUnit = "rpx";
     function getInitPxTransform(taro) {
         return function(config) {
-            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize;
+            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize, _config$targetUnit = config.targetUnit, targetUnit = _config$targetUnit === void 0 ? defaultTargetUnit : _config$targetUnit, _config$unitPrecision = config.unitPrecision, unitPrecision = _config$unitPrecision === void 0 ? defaultUnitPrecision : _config$unitPrecision;
             taro.config = taro.config || {};
             taro.config.designWidth = designWidth;
             taro.config.deviceRatio = deviceRatio;
             taro.config.baseFontSize = baseFontSize;
+            taro.config.targetUnit = targetUnit;
+            taro.config.unitPrecision = unitPrecision;
         };
     }
     function getPxTransform(taro) {
         return function(size) {
             var config = taro.config || {};
             var deviceRatio = config.deviceRatio || defaultDesignRatio;
+            var baseFontSize = config.baseFontSize;
             var designWidth = function() {
                 var input = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
                 return isFunction$1(config.designWidth) ? config.designWidth(input) : config.designWidth || defaultDesignWidth;
@@ -1274,7 +1279,22 @@ exports[`css modules should use css modules with global mode 2`] = `
             if (!(designWidth in deviceRatio)) {
                 throw new Error("deviceRatio 配置中不存在 ".concat(designWidth, " 的设置！"));
             }
-            return parseInt(size, 10) * deviceRatio[designWidth] + "rpx";
+            var formatSize = ~~size;
+            var rootValue = 1 / config.deviceRatio[designWidth];
+            switch (config.targetUnit) {
+              case "rem":
+                rootValue *= baseFontSize * 2;
+                break;
+
+              case "px":
+                rootValue *= 2;
+                break;
+            }
+            var val = formatSize / rootValue;
+            if (config.unitPrecision >= 0 && config.unitPrecision <= 100) {
+                val = Number(val.toFixed(config.unitPrecision));
+            }
+            return val + config.targetUnit;
         };
     }
     var Taro = {
@@ -2745,19 +2765,24 @@ exports[`css modules should use css modules with module mode 2`] = `
         "828": 1.81 / 2
     };
     var defaultBaseFontSize = 20;
+    var defaultUnitPrecision = 5;
+    var defaultTargetUnit = "rpx";
     function getInitPxTransform(taro) {
         return function(config) {
-            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize;
+            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize, _config$targetUnit = config.targetUnit, targetUnit = _config$targetUnit === void 0 ? defaultTargetUnit : _config$targetUnit, _config$unitPrecision = config.unitPrecision, unitPrecision = _config$unitPrecision === void 0 ? defaultUnitPrecision : _config$unitPrecision;
             taro.config = taro.config || {};
             taro.config.designWidth = designWidth;
             taro.config.deviceRatio = deviceRatio;
             taro.config.baseFontSize = baseFontSize;
+            taro.config.targetUnit = targetUnit;
+            taro.config.unitPrecision = unitPrecision;
         };
     }
     function getPxTransform(taro) {
         return function(size) {
             var config = taro.config || {};
             var deviceRatio = config.deviceRatio || defaultDesignRatio;
+            var baseFontSize = config.baseFontSize;
             var designWidth = function() {
                 var input = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
                 return isFunction$1(config.designWidth) ? config.designWidth(input) : config.designWidth || defaultDesignWidth;
@@ -2765,7 +2790,22 @@ exports[`css modules should use css modules with module mode 2`] = `
             if (!(designWidth in deviceRatio)) {
                 throw new Error("deviceRatio 配置中不存在 ".concat(designWidth, " 的设置！"));
             }
-            return parseInt(size, 10) * deviceRatio[designWidth] + "rpx";
+            var formatSize = ~~size;
+            var rootValue = 1 / config.deviceRatio[designWidth];
+            switch (config.targetUnit) {
+              case "rem":
+                rootValue *= baseFontSize * 2;
+                break;
+
+              case "px":
+                rootValue *= 2;
+                break;
+            }
+            var val = formatSize / rootValue;
+            if (config.unitPrecision >= 0 && config.unitPrecision <= 100) {
+                val = Number(val.toFixed(config.unitPrecision));
+            }
+            return val + config.targetUnit;
         };
     }
     var Taro = {

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/nerv.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/nerv.spec.ts.snap
@@ -1236,19 +1236,24 @@ exports[`nerv should build nerv app 2`] = `
         "828": 1.81 / 2
     };
     var defaultBaseFontSize = 20;
+    var defaultUnitPrecision = 5;
+    var defaultTargetUnit = "rpx";
     function getInitPxTransform(taro) {
         return function(config) {
-            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize;
+            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize, _config$targetUnit = config.targetUnit, targetUnit = _config$targetUnit === void 0 ? defaultTargetUnit : _config$targetUnit, _config$unitPrecision = config.unitPrecision, unitPrecision = _config$unitPrecision === void 0 ? defaultUnitPrecision : _config$unitPrecision;
             taro.config = taro.config || {};
             taro.config.designWidth = designWidth;
             taro.config.deviceRatio = deviceRatio;
             taro.config.baseFontSize = baseFontSize;
+            taro.config.targetUnit = targetUnit;
+            taro.config.unitPrecision = unitPrecision;
         };
     }
     function getPxTransform(taro) {
         return function(size) {
             var config = taro.config || {};
             var deviceRatio = config.deviceRatio || defaultDesignRatio;
+            var baseFontSize = config.baseFontSize;
             var designWidth = function() {
                 var input = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
                 return isFunction$1(config.designWidth) ? config.designWidth(input) : config.designWidth || defaultDesignWidth;
@@ -1256,7 +1261,22 @@ exports[`nerv should build nerv app 2`] = `
             if (!(designWidth in deviceRatio)) {
                 throw new Error("deviceRatio 配置中不存在 ".concat(designWidth, " 的设置！"));
             }
-            return parseInt(size, 10) * deviceRatio[designWidth] + "rpx";
+            var formatSize = ~~size;
+            var rootValue = 1 / config.deviceRatio[designWidth];
+            switch (config.targetUnit) {
+              case "rem":
+                rootValue *= baseFontSize * 2;
+                break;
+
+              case "px":
+                rootValue *= 2;
+                break;
+            }
+            var val = formatSize / rootValue;
+            if (config.unitPrecision >= 0 && config.unitPrecision <= 100) {
+                val = Number(val.toFixed(config.unitPrecision));
+            }
+            return val + config.targetUnit;
         };
     }
     var Taro = {

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/react.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/react.spec.ts.snap
@@ -1237,19 +1237,24 @@ exports[`react should build react app 2`] = `
         "828": 1.81 / 2
     };
     var defaultBaseFontSize = 20;
+    var defaultUnitPrecision = 5;
+    var defaultTargetUnit = "rpx";
     function getInitPxTransform(taro) {
         return function(config) {
-            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize;
+            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize, _config$targetUnit = config.targetUnit, targetUnit = _config$targetUnit === void 0 ? defaultTargetUnit : _config$targetUnit, _config$unitPrecision = config.unitPrecision, unitPrecision = _config$unitPrecision === void 0 ? defaultUnitPrecision : _config$unitPrecision;
             taro.config = taro.config || {};
             taro.config.designWidth = designWidth;
             taro.config.deviceRatio = deviceRatio;
             taro.config.baseFontSize = baseFontSize;
+            taro.config.targetUnit = targetUnit;
+            taro.config.unitPrecision = unitPrecision;
         };
     }
     function getPxTransform(taro) {
         return function(size) {
             var config = taro.config || {};
             var deviceRatio = config.deviceRatio || defaultDesignRatio;
+            var baseFontSize = config.baseFontSize;
             var designWidth = function() {
                 var input = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
                 return isFunction$1(config.designWidth) ? config.designWidth(input) : config.designWidth || defaultDesignWidth;
@@ -1257,7 +1262,22 @@ exports[`react should build react app 2`] = `
             if (!(designWidth in deviceRatio)) {
                 throw new Error("deviceRatio 配置中不存在 ".concat(designWidth, " 的设置！"));
             }
-            return parseInt(size, 10) * deviceRatio[designWidth] + "rpx";
+            var formatSize = ~~size;
+            var rootValue = 1 / config.deviceRatio[designWidth];
+            switch (config.targetUnit) {
+              case "rem":
+                rootValue *= baseFontSize * 2;
+                break;
+
+              case "px":
+                rootValue *= 2;
+                break;
+            }
+            var val = formatSize / rootValue;
+            if (config.unitPrecision >= 0 && config.unitPrecision <= 100) {
+                val = Number(val.toFixed(config.unitPrecision));
+            }
+            return val + config.targetUnit;
         };
     }
     var Taro = {

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/sass.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/sass.spec.ts.snap
@@ -1222,19 +1222,24 @@ exports[`sass should build app with sass 2`] = `
         "828": 1.81 / 2
     };
     var defaultBaseFontSize = 20;
+    var defaultUnitPrecision = 5;
+    var defaultTargetUnit = "rpx";
     function getInitPxTransform(taro) {
         return function(config) {
-            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize;
+            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize, _config$targetUnit = config.targetUnit, targetUnit = _config$targetUnit === void 0 ? defaultTargetUnit : _config$targetUnit, _config$unitPrecision = config.unitPrecision, unitPrecision = _config$unitPrecision === void 0 ? defaultUnitPrecision : _config$unitPrecision;
             taro.config = taro.config || {};
             taro.config.designWidth = designWidth;
             taro.config.deviceRatio = deviceRatio;
             taro.config.baseFontSize = baseFontSize;
+            taro.config.targetUnit = targetUnit;
+            taro.config.unitPrecision = unitPrecision;
         };
     }
     function getPxTransform(taro) {
         return function(size) {
             var config = taro.config || {};
             var deviceRatio = config.deviceRatio || defaultDesignRatio;
+            var baseFontSize = config.baseFontSize;
             var designWidth = function() {
                 var input = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
                 return isFunction$1(config.designWidth) ? config.designWidth(input) : config.designWidth || defaultDesignWidth;
@@ -1242,7 +1247,22 @@ exports[`sass should build app with sass 2`] = `
             if (!(designWidth in deviceRatio)) {
                 throw new Error("deviceRatio 配置中不存在 ".concat(designWidth, " 的设置！"));
             }
-            return parseInt(size, 10) * deviceRatio[designWidth] + "rpx";
+            var formatSize = ~~size;
+            var rootValue = 1 / config.deviceRatio[designWidth];
+            switch (config.targetUnit) {
+              case "rem":
+                rootValue *= baseFontSize * 2;
+                break;
+
+              case "px":
+                rootValue *= 2;
+                break;
+            }
+            var val = formatSize / rootValue;
+            if (config.unitPrecision >= 0 && config.unitPrecision <= 100) {
+                val = Number(val.toFixed(config.unitPrecision));
+            }
+            return val + config.targetUnit;
         };
     }
     var Taro = {
@@ -2688,19 +2708,24 @@ exports[`sass should build app with scss 2`] = `
         "828": 1.81 / 2
     };
     var defaultBaseFontSize = 20;
+    var defaultUnitPrecision = 5;
+    var defaultTargetUnit = "rpx";
     function getInitPxTransform(taro) {
         return function(config) {
-            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize;
+            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize, _config$targetUnit = config.targetUnit, targetUnit = _config$targetUnit === void 0 ? defaultTargetUnit : _config$targetUnit, _config$unitPrecision = config.unitPrecision, unitPrecision = _config$unitPrecision === void 0 ? defaultUnitPrecision : _config$unitPrecision;
             taro.config = taro.config || {};
             taro.config.designWidth = designWidth;
             taro.config.deviceRatio = deviceRatio;
             taro.config.baseFontSize = baseFontSize;
+            taro.config.targetUnit = targetUnit;
+            taro.config.unitPrecision = unitPrecision;
         };
     }
     function getPxTransform(taro) {
         return function(size) {
             var config = taro.config || {};
             var deviceRatio = config.deviceRatio || defaultDesignRatio;
+            var baseFontSize = config.baseFontSize;
             var designWidth = function() {
                 var input = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
                 return isFunction$1(config.designWidth) ? config.designWidth(input) : config.designWidth || defaultDesignWidth;
@@ -2708,7 +2733,22 @@ exports[`sass should build app with scss 2`] = `
             if (!(designWidth in deviceRatio)) {
                 throw new Error("deviceRatio 配置中不存在 ".concat(designWidth, " 的设置！"));
             }
-            return parseInt(size, 10) * deviceRatio[designWidth] + "rpx";
+            var formatSize = ~~size;
+            var rootValue = 1 / config.deviceRatio[designWidth];
+            switch (config.targetUnit) {
+              case "rem":
+                rootValue *= baseFontSize * 2;
+                break;
+
+              case "px":
+                rootValue *= 2;
+                break;
+            }
+            var val = formatSize / rootValue;
+            if (config.unitPrecision >= 0 && config.unitPrecision <= 100) {
+                val = Number(val.toFixed(config.unitPrecision));
+            }
+            return val + config.targetUnit;
         };
     }
     var Taro = {
@@ -4164,19 +4204,24 @@ exports[`sass should set global sass content with data 2`] = `
         "828": 1.81 / 2
     };
     var defaultBaseFontSize = 20;
+    var defaultUnitPrecision = 5;
+    var defaultTargetUnit = "rpx";
     function getInitPxTransform(taro) {
         return function(config) {
-            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize;
+            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize, _config$targetUnit = config.targetUnit, targetUnit = _config$targetUnit === void 0 ? defaultTargetUnit : _config$targetUnit, _config$unitPrecision = config.unitPrecision, unitPrecision = _config$unitPrecision === void 0 ? defaultUnitPrecision : _config$unitPrecision;
             taro.config = taro.config || {};
             taro.config.designWidth = designWidth;
             taro.config.deviceRatio = deviceRatio;
             taro.config.baseFontSize = baseFontSize;
+            taro.config.targetUnit = targetUnit;
+            taro.config.unitPrecision = unitPrecision;
         };
     }
     function getPxTransform(taro) {
         return function(size) {
             var config = taro.config || {};
             var deviceRatio = config.deviceRatio || defaultDesignRatio;
+            var baseFontSize = config.baseFontSize;
             var designWidth = function() {
                 var input = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
                 return isFunction$1(config.designWidth) ? config.designWidth(input) : config.designWidth || defaultDesignWidth;
@@ -4184,7 +4229,22 @@ exports[`sass should set global sass content with data 2`] = `
             if (!(designWidth in deviceRatio)) {
                 throw new Error("deviceRatio 配置中不存在 ".concat(designWidth, " 的设置！"));
             }
-            return parseInt(size, 10) * deviceRatio[designWidth] + "rpx";
+            var formatSize = ~~size;
+            var rootValue = 1 / config.deviceRatio[designWidth];
+            switch (config.targetUnit) {
+              case "rem":
+                rootValue *= baseFontSize * 2;
+                break;
+
+              case "px":
+                rootValue *= 2;
+                break;
+            }
+            var val = formatSize / rootValue;
+            if (config.unitPrecision >= 0 && config.unitPrecision <= 100) {
+                val = Number(val.toFixed(config.unitPrecision));
+            }
+            return val + config.targetUnit;
         };
     }
     var Taro = {
@@ -5640,19 +5700,24 @@ exports[`sass should set global sass content with source & dir 2`] = `
         "828": 1.81 / 2
     };
     var defaultBaseFontSize = 20;
+    var defaultUnitPrecision = 5;
+    var defaultTargetUnit = "rpx";
     function getInitPxTransform(taro) {
         return function(config) {
-            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize;
+            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize, _config$targetUnit = config.targetUnit, targetUnit = _config$targetUnit === void 0 ? defaultTargetUnit : _config$targetUnit, _config$unitPrecision = config.unitPrecision, unitPrecision = _config$unitPrecision === void 0 ? defaultUnitPrecision : _config$unitPrecision;
             taro.config = taro.config || {};
             taro.config.designWidth = designWidth;
             taro.config.deviceRatio = deviceRatio;
             taro.config.baseFontSize = baseFontSize;
+            taro.config.targetUnit = targetUnit;
+            taro.config.unitPrecision = unitPrecision;
         };
     }
     function getPxTransform(taro) {
         return function(size) {
             var config = taro.config || {};
             var deviceRatio = config.deviceRatio || defaultDesignRatio;
+            var baseFontSize = config.baseFontSize;
             var designWidth = function() {
                 var input = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
                 return isFunction$1(config.designWidth) ? config.designWidth(input) : config.designWidth || defaultDesignWidth;
@@ -5660,7 +5725,22 @@ exports[`sass should set global sass content with source & dir 2`] = `
             if (!(designWidth in deviceRatio)) {
                 throw new Error("deviceRatio 配置中不存在 ".concat(designWidth, " 的设置！"));
             }
-            return parseInt(size, 10) * deviceRatio[designWidth] + "rpx";
+            var formatSize = ~~size;
+            var rootValue = 1 / config.deviceRatio[designWidth];
+            switch (config.targetUnit) {
+              case "rem":
+                rootValue *= baseFontSize * 2;
+                break;
+
+              case "px":
+                rootValue *= 2;
+                break;
+            }
+            var val = formatSize / rootValue;
+            if (config.unitPrecision >= 0 && config.unitPrecision <= 100) {
+                val = Number(val.toFixed(config.unitPrecision));
+            }
+            return val + config.targetUnit;
         };
     }
     var Taro = {
@@ -7116,19 +7196,24 @@ exports[`sass should set global sass content with source 2`] = `
         "828": 1.81 / 2
     };
     var defaultBaseFontSize = 20;
+    var defaultUnitPrecision = 5;
+    var defaultTargetUnit = "rpx";
     function getInitPxTransform(taro) {
         return function(config) {
-            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize;
+            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize, _config$targetUnit = config.targetUnit, targetUnit = _config$targetUnit === void 0 ? defaultTargetUnit : _config$targetUnit, _config$unitPrecision = config.unitPrecision, unitPrecision = _config$unitPrecision === void 0 ? defaultUnitPrecision : _config$unitPrecision;
             taro.config = taro.config || {};
             taro.config.designWidth = designWidth;
             taro.config.deviceRatio = deviceRatio;
             taro.config.baseFontSize = baseFontSize;
+            taro.config.targetUnit = targetUnit;
+            taro.config.unitPrecision = unitPrecision;
         };
     }
     function getPxTransform(taro) {
         return function(size) {
             var config = taro.config || {};
             var deviceRatio = config.deviceRatio || defaultDesignRatio;
+            var baseFontSize = config.baseFontSize;
             var designWidth = function() {
                 var input = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
                 return isFunction$1(config.designWidth) ? config.designWidth(input) : config.designWidth || defaultDesignWidth;
@@ -7136,7 +7221,22 @@ exports[`sass should set global sass content with source 2`] = `
             if (!(designWidth in deviceRatio)) {
                 throw new Error("deviceRatio 配置中不存在 ".concat(designWidth, " 的设置！"));
             }
-            return parseInt(size, 10) * deviceRatio[designWidth] + "rpx";
+            var formatSize = ~~size;
+            var rootValue = 1 / config.deviceRatio[designWidth];
+            switch (config.targetUnit) {
+              case "rem":
+                rootValue *= baseFontSize * 2;
+                break;
+
+              case "px":
+                rootValue *= 2;
+                break;
+            }
+            var val = formatSize / rootValue;
+            if (config.unitPrecision >= 0 && config.unitPrecision <= 100) {
+                val = Number(val.toFixed(config.unitPrecision));
+            }
+            return val + config.targetUnit;
         };
     }
     var Taro = {

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/subpackages.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/subpackages.spec.ts.snap
@@ -1310,19 +1310,24 @@ exports[`subpackages should process subpackages 2`] = `
         "828": 1.81 / 2
     };
     var defaultBaseFontSize = 20;
+    var defaultUnitPrecision = 5;
+    var defaultTargetUnit = "rpx";
     function getInitPxTransform(taro) {
         return function(config) {
-            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize;
+            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize, _config$targetUnit = config.targetUnit, targetUnit = _config$targetUnit === void 0 ? defaultTargetUnit : _config$targetUnit, _config$unitPrecision = config.unitPrecision, unitPrecision = _config$unitPrecision === void 0 ? defaultUnitPrecision : _config$unitPrecision;
             taro.config = taro.config || {};
             taro.config.designWidth = designWidth;
             taro.config.deviceRatio = deviceRatio;
             taro.config.baseFontSize = baseFontSize;
+            taro.config.targetUnit = targetUnit;
+            taro.config.unitPrecision = unitPrecision;
         };
     }
     function getPxTransform(taro) {
         return function(size) {
             var config = taro.config || {};
             var deviceRatio = config.deviceRatio || defaultDesignRatio;
+            var baseFontSize = config.baseFontSize;
             var designWidth = function() {
                 var input = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
                 return isFunction$1(config.designWidth) ? config.designWidth(input) : config.designWidth || defaultDesignWidth;
@@ -1330,7 +1335,22 @@ exports[`subpackages should process subpackages 2`] = `
             if (!(designWidth in deviceRatio)) {
                 throw new Error("deviceRatio 配置中不存在 ".concat(designWidth, " 的设置！"));
             }
-            return parseInt(size, 10) * deviceRatio[designWidth] + "rpx";
+            var formatSize = ~~size;
+            var rootValue = 1 / config.deviceRatio[designWidth];
+            switch (config.targetUnit) {
+              case "rem":
+                rootValue *= baseFontSize * 2;
+                break;
+
+              case "px":
+                rootValue *= 2;
+                break;
+            }
+            var val = formatSize / rootValue;
+            if (config.unitPrecision >= 0 && config.unitPrecision <= 100) {
+                val = Number(val.toFixed(config.unitPrecision));
+            }
+            return val + config.targetUnit;
         };
     }
     var Taro = {

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/ts.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/ts.spec.ts.snap
@@ -1240,19 +1240,24 @@ exports[`typescript should build project with ts 2`] = `
         "828": 1.81 / 2
     };
     var defaultBaseFontSize = 20;
+    var defaultUnitPrecision = 5;
+    var defaultTargetUnit = "rpx";
     function getInitPxTransform(taro) {
         return function(config) {
-            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize;
+            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize, _config$targetUnit = config.targetUnit, targetUnit = _config$targetUnit === void 0 ? defaultTargetUnit : _config$targetUnit, _config$unitPrecision = config.unitPrecision, unitPrecision = _config$unitPrecision === void 0 ? defaultUnitPrecision : _config$unitPrecision;
             taro.config = taro.config || {};
             taro.config.designWidth = designWidth;
             taro.config.deviceRatio = deviceRatio;
             taro.config.baseFontSize = baseFontSize;
+            taro.config.targetUnit = targetUnit;
+            taro.config.unitPrecision = unitPrecision;
         };
     }
     function getPxTransform(taro) {
         return function(size) {
             var config = taro.config || {};
             var deviceRatio = config.deviceRatio || defaultDesignRatio;
+            var baseFontSize = config.baseFontSize;
             var designWidth = function() {
                 var input = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
                 return isFunction$1(config.designWidth) ? config.designWidth(input) : config.designWidth || defaultDesignWidth;
@@ -1260,7 +1265,22 @@ exports[`typescript should build project with ts 2`] = `
             if (!(designWidth in deviceRatio)) {
                 throw new Error("deviceRatio 配置中不存在 ".concat(designWidth, " 的设置！"));
             }
-            return parseInt(size, 10) * deviceRatio[designWidth] + "rpx";
+            var formatSize = ~~size;
+            var rootValue = 1 / config.deviceRatio[designWidth];
+            switch (config.targetUnit) {
+              case "rem":
+                rootValue *= baseFontSize * 2;
+                break;
+
+              case "px":
+                rootValue *= 2;
+                break;
+            }
+            var val = formatSize / rootValue;
+            if (config.unitPrecision >= 0 && config.unitPrecision <= 100) {
+                val = Number(val.toFixed(config.unitPrecision));
+            }
+            return val + config.targetUnit;
         };
     }
     var Taro = {

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue.spec.ts.snap
@@ -1377,19 +1377,24 @@ exports[`vue should build vue app 2`] = `
         "828": 1.81 / 2
     };
     var defaultBaseFontSize = 20;
+    var defaultUnitPrecision = 5;
+    var defaultTargetUnit = "rpx";
     function getInitPxTransform(taro) {
         return function(config) {
-            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize;
+            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize, _config$targetUnit = config.targetUnit, targetUnit = _config$targetUnit === void 0 ? defaultTargetUnit : _config$targetUnit, _config$unitPrecision = config.unitPrecision, unitPrecision = _config$unitPrecision === void 0 ? defaultUnitPrecision : _config$unitPrecision;
             taro.config = taro.config || {};
             taro.config.designWidth = designWidth;
             taro.config.deviceRatio = deviceRatio;
             taro.config.baseFontSize = baseFontSize;
+            taro.config.targetUnit = targetUnit;
+            taro.config.unitPrecision = unitPrecision;
         };
     }
     function getPxTransform(taro) {
         return function(size) {
             var config = taro.config || {};
             var deviceRatio = config.deviceRatio || defaultDesignRatio;
+            var baseFontSize = config.baseFontSize;
             var designWidth = function() {
                 var input = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
                 return isFunction$1(config.designWidth) ? config.designWidth(input) : config.designWidth || defaultDesignWidth;
@@ -1397,7 +1402,22 @@ exports[`vue should build vue app 2`] = `
             if (!(designWidth in deviceRatio)) {
                 throw new Error("deviceRatio 配置中不存在 ".concat(designWidth, " 的设置！"));
             }
-            return parseInt(size, 10) * deviceRatio[designWidth] + "rpx";
+            var formatSize = ~~size;
+            var rootValue = 1 / config.deviceRatio[designWidth];
+            switch (config.targetUnit) {
+              case "rem":
+                rootValue *= baseFontSize * 2;
+                break;
+
+              case "px":
+                rootValue *= 2;
+                break;
+            }
+            var val = formatSize / rootValue;
+            if (config.unitPrecision >= 0 && config.unitPrecision <= 100) {
+                val = Number(val.toFixed(config.unitPrecision));
+            }
+            return val + config.targetUnit;
         };
     }
     var Taro = {

--- a/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue3.spec.ts.snap
+++ b/packages/taro-webpack-runner/src/__tests__/__snapshots__/vue3.spec.ts.snap
@@ -1121,19 +1121,24 @@ exports[`vue3 should build vue3 app 2`] = `
         "828": 1.81 / 2
     };
     var defaultBaseFontSize = 20;
+    var defaultUnitPrecision = 5;
+    var defaultTargetUnit = "rpx";
     function getInitPxTransform(taro) {
         return function(config) {
-            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize;
+            var _config$designWidth = config.designWidth, designWidth = _config$designWidth === void 0 ? defaultDesignWidth : _config$designWidth, _config$deviceRatio = config.deviceRatio, deviceRatio = _config$deviceRatio === void 0 ? defaultDesignRatio : _config$deviceRatio, _config$baseFontSize = config.baseFontSize, baseFontSize = _config$baseFontSize === void 0 ? defaultBaseFontSize : _config$baseFontSize, _config$targetUnit = config.targetUnit, targetUnit = _config$targetUnit === void 0 ? defaultTargetUnit : _config$targetUnit, _config$unitPrecision = config.unitPrecision, unitPrecision = _config$unitPrecision === void 0 ? defaultUnitPrecision : _config$unitPrecision;
             taro.config = taro.config || {};
             taro.config.designWidth = designWidth;
             taro.config.deviceRatio = deviceRatio;
             taro.config.baseFontSize = baseFontSize;
+            taro.config.targetUnit = targetUnit;
+            taro.config.unitPrecision = unitPrecision;
         };
     }
     function getPxTransform(taro) {
         return function(size) {
             var config = taro.config || {};
             var deviceRatio = config.deviceRatio || defaultDesignRatio;
+            var baseFontSize = config.baseFontSize;
             var designWidth = function() {
                 var input = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
                 return isFunction$1(config.designWidth) ? config.designWidth(input) : config.designWidth || defaultDesignWidth;
@@ -1141,7 +1146,22 @@ exports[`vue3 should build vue3 app 2`] = `
             if (!(designWidth in deviceRatio)) {
                 throw new Error("deviceRatio 配置中不存在 ".concat(designWidth, " 的设置！"));
             }
-            return parseInt(size, 10) * deviceRatio[designWidth] + "rpx";
+            var formatSize = ~~size;
+            var rootValue = 1 / config.deviceRatio[designWidth];
+            switch (config.targetUnit) {
+              case "rem":
+                rootValue *= baseFontSize * 2;
+                break;
+
+              case "px":
+                rootValue *= 2;
+                break;
+            }
+            var val = formatSize / rootValue;
+            if (config.unitPrecision >= 0 && config.unitPrecision <= 100) {
+                val = Number(val.toFixed(config.unitPrecision));
+            }
+            return val + config.targetUnit;
         };
     }
     var Taro = {

--- a/packages/taro-webpack-runner/src/config/dev.conf.ts
+++ b/packages/taro-webpack-runner/src/config/dev.conf.ts
@@ -118,7 +118,7 @@ export default function (appPath: string, config: Partial<BuildConfig>, appHelpe
   }
 
   const htmlScript = parseHtmlScript(pxtransformOption)
-  if (process.env.NODE_ENV !== 'production' && Object.hasOwnProperty.call(htmlPluginOption, 'script')) {
+  if (process.env.NODE_ENV !== 'production' && htmlScript !== undefined && Object.hasOwnProperty.call(htmlPluginOption, 'script')) {
     console.warn(
       chalk.yellowBright('配置文件覆盖 htmlPluginOption.script 参数会导致 pxtransform 脚本失效，请慎重使用！')
     )

--- a/packages/taro-webpack-runner/src/config/prod.conf.ts
+++ b/packages/taro-webpack-runner/src/config/prod.conf.ts
@@ -123,7 +123,7 @@ export default function (appPath: string, config: Partial<BuildConfig>, appHelpe
   }
 
   const htmlScript = parseHtmlScript(pxtransformOption)
-  if (process.env.NODE_ENV !== 'production' && Object.hasOwnProperty.call(htmlPluginOption, 'script')) {
+  if (process.env.NODE_ENV !== 'production' && htmlScript !== undefined && Object.hasOwnProperty.call(htmlPluginOption, 'script')) {
     console.warn(
       chalk.yellowBright('配置文件覆盖 htmlPluginOption.script 参数会导致 pxtransform 脚本失效，请慎重使用！')
     )

--- a/packages/taro-webpack-runner/src/utils/index.ts
+++ b/packages/taro-webpack-runner/src/utils/index.ts
@@ -56,7 +56,9 @@ export function parseHtmlScript (pxtransformOption: IPostcssOption['pxtransform'
     ? options.designWidth(input)
     : options.designWidth)(baseFontSize)
   const rootValue = baseFontSize / options.deviceRatio[designWidth] * 2
-  return `!function(n){function f(){var e=n.document.documentElement,w=e.getBoundingClientRect().width,x=${rootValue}*w/${designWidth};e.style.fontSize=x>=${max}?"${max}px":x<=${min}?"${min}px":x+"px"}n.addEventListener("resize",(function(){f()})),f()}(window);`
+  if ((options?.targetUnit ?? 'rem') === 'rem') {
+    return `!function(n){function f(){var e=n.document.documentElement,w=e.getBoundingClientRect().width,x=${rootValue}*w/${designWidth};e.style.fontSize=x>=${max}?"${max}px":x<=${min}?"${min}px":x+"px"}n.addEventListener("resize",(function(){f()})),f()}(window);`
+  }
 }
 
 export * from './app'

--- a/packages/taro-webpack5-runner/src/plugins/MiniPlugin.ts
+++ b/packages/taro-webpack5-runner/src/plugins/MiniPlugin.ts
@@ -60,12 +60,18 @@ interface ITaroMiniPluginOptions {
   onParseCreateElement?: Func
   blended: boolean
   alias: Record<string, string>
-  deviceRatio: any
-  designWidth: number
   loaderMeta?: Record<string, string>
   hot: boolean
   logger?: {
     quiet?: boolean
+  }
+  pxTransformConfig: {
+    baseFontSize: number
+    deviceRatio: any
+    designWidth: number
+    minRootSize: number
+    unitPrecision: number
+    targetUnit: string
   }
 }
 
@@ -226,7 +232,7 @@ export default class TaroMiniPlugin {
        * 往 NormalModule.loaders 中插入对应的 Taro Loader
        */
       compiler.webpack.NormalModule.getCompilationHooks(compilation).loader.tap(PLUGIN_NAME, (_loaderContext, module:/** TaroNormalModule */ any) => {
-        const { framework, loaderMeta, designWidth, deviceRatio } = this.options
+        const { framework, loaderMeta, pxTransformConfig } = this.options
         if (module.miniType === META_TYPE.ENTRY) {
           const loaderName = '@tarojs/taro-loader'
           if (!isLoaderExist(module.loaders, loaderName)) {
@@ -239,12 +245,7 @@ export default class TaroMiniPlugin {
                 config: this.appConfig,
                 runtimePath: this.options.runtimePath,
                 blended: this.options.blended,
-                pxTransformConfig: {
-                  designWidth: designWidth || 750,
-                  deviceRatio: deviceRatio || {
-                    750: 1
-                  }
-                }
+                pxTransformConfig
               }
             })
           }

--- a/packages/taro-webpack5-runner/src/plugins/MiniPlugin.ts
+++ b/packages/taro-webpack5-runner/src/plugins/MiniPlugin.ts
@@ -69,7 +69,6 @@ interface ITaroMiniPluginOptions {
     baseFontSize: number
     deviceRatio: any
     designWidth: number
-    minRootSize: number
     unitPrecision: number
     targetUnit: string
   }

--- a/packages/taro-webpack5-runner/src/postcss/postcss.h5.ts
+++ b/packages/taro-webpack5-runner/src/postcss/postcss.h5.ts
@@ -77,7 +77,7 @@ export const getDefaultPostcssConfig = function ({
   ]
 }
 
-export const getPostcssPlugins = function (appPath: string, option = {} as IPostcssOption) {
+export const getPostcssPlugins = function (appPath: string, option: [string, any, Func?][] = []) {
   option.forEach(([pluginName, pluginOption, pluginPkg]) => {
     if (!pluginOption || ['cssModules'].includes(pluginName)) return
     if (Object.hasOwnProperty.call(pluginOption, 'enable') && !pluginOption.enable) return

--- a/packages/taro-webpack5-runner/src/postcss/postcss.h5.ts
+++ b/packages/taro-webpack5-runner/src/postcss/postcss.h5.ts
@@ -77,7 +77,7 @@ export const getDefaultPostcssConfig = function ({
   ]
 }
 
-export const getPostcssPlugins = function (appPath: string, option: [string, any, Func?][] = []) {
+export const getPostcssPlugins = function (appPath: string, option: [string, TogglableOptions<Record<string, unknown>>, Func?][] = []) {
   option.forEach(([pluginName, pluginOption, pluginPkg]) => {
     if (!pluginOption || ['cssModules'].includes(pluginName)) return
     if (Object.hasOwnProperty.call(pluginOption, 'enable') && !pluginOption.enable) return

--- a/packages/taro-webpack5-runner/src/postcss/postcss.mini.ts
+++ b/packages/taro-webpack5-runner/src/postcss/postcss.mini.ts
@@ -39,8 +39,6 @@ const defaultHtmltransformOption: {
   }
 }
 
-const optionsWithDefaults = ['cssModules']
-
 const plugins = [] as any[]
 
 export const getDefaultPostcssConfig = function ({
@@ -74,11 +72,9 @@ export const getDefaultPostcssConfig = function ({
 }
 
 
-export const getPostcssPlugins = function (appPath: string, postcssOption: [string, any, Func?][] = []) {
-
-  postcssOption.forEach(([pluginName, pluginOption, pluginPkg]) => {
-    if (optionsWithDefaults.includes(pluginName)) return
-    if (!pluginOption) return
+export const getPostcssPlugins = function (appPath: string, option: [string, any, Func?][] = []) {
+  option.forEach(([pluginName, pluginOption, pluginPkg]) => {
+    if (!pluginOption || ['cssModules'].includes(pluginName)) return
     if (Object.hasOwnProperty.call(pluginOption, 'enable') && !pluginOption.enable) return
 
     if (pluginPkg) {
@@ -86,7 +82,8 @@ export const getPostcssPlugins = function (appPath: string, postcssOption: [stri
       return
     }
 
-    if (!isNpmPkg(pluginName)) { // local plugin
+    if (!isNpmPkg(pluginName)) {
+      // local plugin
       pluginName = path.join(appPath, pluginName)
     }
 

--- a/packages/taro-webpack5-runner/src/postcss/postcss.mini.ts
+++ b/packages/taro-webpack5-runner/src/postcss/postcss.mini.ts
@@ -2,7 +2,7 @@ import { isNpmPkg, recursiveMerge } from '@tarojs/helper'
 import path from 'path'
 import { sync as resolveSync } from 'resolve'
 
-import type { IPostcssOption } from '@tarojs/taro/types/compile'
+import type { Func, IPostcssOption } from '@tarojs/taro/types/compile'
 
 const platform = process.env.TARO_ENV
 const defaultAutoprefixerOption = {
@@ -39,15 +39,17 @@ const defaultHtmltransformOption: {
   }
 }
 
-const optionsWithDefaults = ['autoprefixer', 'pxtransform', 'cssModules', 'url', 'htmltransform']
+const optionsWithDefaults = ['cssModules']
 
 const plugins = [] as any[]
 
-export const getPostcssPlugins = function (appPath: string, {
+export const getDefaultPostcssConfig = function ({
   designWidth,
   deviceRatio,
   postcssOption = {} as IPostcssOption
-}) {
+}): [string, any, Func?][] {
+  const { autoprefixer, pxtransform, htmltransform, url, ...options } = postcssOption
+
   if (designWidth) {
     defaultPxtransformOption.config.designWidth = designWidth
   }
@@ -56,31 +58,33 @@ export const getPostcssPlugins = function (appPath: string, {
     defaultPxtransformOption.config.deviceRatio = deviceRatio
   }
 
-  const autoprefixerOption = recursiveMerge({}, defaultAutoprefixerOption, postcssOption.autoprefixer)
-  const pxtransformOption = recursiveMerge({}, defaultPxtransformOption, postcssOption.pxtransform)
-  const htmltransformOption = recursiveMerge({}, defaultHtmltransformOption, postcssOption.htmltransform)
-  const urlOption = recursiveMerge({}, defaultUrlOption, postcssOption.url)
-  if (autoprefixerOption.enable) {
-    const autoprefixer = require('autoprefixer')
-    plugins.push(autoprefixer(autoprefixerOption.config))
-  }
+  const autoprefixerOption = recursiveMerge({}, defaultAutoprefixerOption, autoprefixer)
+  const pxtransformOption = recursiveMerge({}, defaultPxtransformOption, pxtransform)
+  const htmltransformOption = recursiveMerge({}, defaultHtmltransformOption, htmltransform)
+  const urlOption = recursiveMerge({}, defaultUrlOption, url)
 
-  if (pxtransformOption.enable) {
-    const pxtransform = require('postcss-pxtransform')
-    plugins.push(pxtransform(pxtransformOption.config))
-  }
-  if (urlOption.enable) {
-    const url = require('postcss-url')
-    plugins.push(url(urlOption.config))
-  }
-  if (htmltransformOption?.enable) {
-    const htmlTransform = require('postcss-html-transform')
-    plugins.push(htmlTransform(htmltransformOption.config))
-  }
-  plugins.unshift(require('postcss-import'))
-  Object.entries(postcssOption).forEach(([pluginName, pluginOption]) => {
-    if (optionsWithDefaults.indexOf(pluginName) > -1) return
-    if (!pluginOption || !pluginOption.enable) return
+  return [
+    ['postcss-import', {}, require('postcss-import')],
+    ['autoprefixer', autoprefixerOption, require('autoprefixer')],
+    ['postcss-pxtransform', pxtransformOption, require('postcss-pxtransform')],
+    ['postcss-url', urlOption, require('postcss-url')],
+    ['postcss-html-transform', htmltransformOption, require('postcss-html-transform')],
+    ...Object.entries(options)
+  ]
+}
+
+
+export const getPostcssPlugins = function (appPath: string, postcssOption: [string, any, Func?][] = []) {
+
+  postcssOption.forEach(([pluginName, pluginOption, pluginPkg]) => {
+    if (optionsWithDefaults.includes(pluginName)) return
+    if (!pluginOption) return
+    if (Object.hasOwnProperty.call(pluginOption, 'enable') && !pluginOption.enable) return
+
+    if (pluginPkg) {
+      plugins.push(pluginPkg(pluginOption.config || {}))
+      return
+    }
 
     if (!isNpmPkg(pluginName)) { // local plugin
       pluginName = path.join(appPath, pluginName)

--- a/packages/taro-webpack5-runner/src/postcss/postcss.mini.ts
+++ b/packages/taro-webpack5-runner/src/postcss/postcss.mini.ts
@@ -2,7 +2,7 @@ import { isNpmPkg, recursiveMerge } from '@tarojs/helper'
 import path from 'path'
 import { sync as resolveSync } from 'resolve'
 
-import type { Func, IPostcssOption } from '@tarojs/taro/types/compile'
+import type { Func, IPostcssOption, TogglableOptions } from '@tarojs/taro/types/compile'
 
 const platform = process.env.TARO_ENV
 const defaultAutoprefixerOption = {
@@ -72,7 +72,7 @@ export const getDefaultPostcssConfig = function ({
 }
 
 
-export const getPostcssPlugins = function (appPath: string, option: [string, any, Func?][] = []) {
+export const getPostcssPlugins = function (appPath: string, option: [string, TogglableOptions<Record<string, unknown>>, Func?][] = []) {
   option.forEach(([pluginName, pluginOption, pluginPkg]) => {
     if (!pluginOption || ['cssModules'].includes(pluginName)) return
     if (Object.hasOwnProperty.call(pluginOption, 'enable') && !pluginOption.enable) return

--- a/packages/taro-webpack5-runner/src/webpack/H5WebpackPlugin.ts
+++ b/packages/taro-webpack5-runner/src/webpack/H5WebpackPlugin.ts
@@ -97,11 +97,8 @@ export class H5WebpackPlugin {
       : options.designWidth)(baseFontSize)
     const rootValue = baseFontSize / options.deviceRatio[designWidth] * 2
     let htmlScript = ''
-    switch (options?.targetUnit) {
-      case 'vw':
-        break
-      default:
-        htmlScript = `!function(n){function f(){var e=n.document.documentElement,w=e.getBoundingClientRect().width,x=${rootValue}*w/${designWidth};e.style.fontSize=x>=${max}?"${max}px":x<=${min}?"${min}px":x+"px"}n.addEventListener("resize",(function(){f()})),f()}(window);`
+    if ((options?.targetUnit ?? 'rem') === 'rem') {
+      htmlScript = `!function(n){function f(){var e=n.document.documentElement,w=e.getBoundingClientRect().width,x=${rootValue}*w/${designWidth};e.style.fontSize=x>=${max}?"${max}px":x<=${min}?"${min}px":x+"px"}n.addEventListener("resize",(function(){f()})),f()}(window);`
     }
     const args: Record<string, string | string []> = {
       filename: `${entry || 'index'}.html`,

--- a/packages/taro-webpack5-runner/src/webpack/MiniCombination.ts
+++ b/packages/taro-webpack5-runner/src/webpack/MiniCombination.ts
@@ -67,6 +67,7 @@ export class MiniCombination extends Combination<MiniBuildConfig> {
     const module = webpackModule.getModules()
     const [, pxtransformOption] = webpackModule.__postcssOption.find(([name]) => name === 'postcss-pxtransform') || []
     webpackPlugin.pxtransformOption = pxtransformOption as any
+    const plugin = webpackPlugin.getPlugins()
 
     chain.merge({
       entry: webpackEntry,
@@ -76,7 +77,7 @@ export class MiniCombination extends Combination<MiniBuildConfig> {
       resolve: {
         alias: this.getAlias()
       },
-      plugin: webpackPlugin.getPlugins(),
+      plugin,
       module,
       optimization: this.getOptimization()
     })

--- a/packages/taro-webpack5-runner/src/webpack/MiniCombination.ts
+++ b/packages/taro-webpack5-runner/src/webpack/MiniCombination.ts
@@ -64,6 +64,10 @@ export class MiniCombination extends Combination<MiniBuildConfig> {
     const webpackPlugin = new MiniWebpackPlugin(this)
     const webpackModule = new MiniWebpackModule(this)
 
+    const module = webpackModule.getModules()
+    const [, pxtransformOption] = webpackModule.__postcssOption.find(([name]) => name === 'postcss-pxtransform') || []
+    webpackPlugin.pxtransformOption = pxtransformOption as any
+
     chain.merge({
       entry: webpackEntry,
       output: webpackOutput,
@@ -73,7 +77,7 @@ export class MiniCombination extends Combination<MiniBuildConfig> {
         alias: this.getAlias()
       },
       plugin: webpackPlugin.getPlugins(),
-      module: webpackModule.getModules(),
+      module,
       optimization: this.getOptimization()
     })
   }

--- a/packages/taro-webpack5-runner/src/webpack/MiniWebpackModule.ts
+++ b/packages/taro-webpack5-runner/src/webpack/MiniWebpackModule.ts
@@ -11,10 +11,10 @@ import {
 import { cloneDeep } from 'lodash'
 import path from 'path'
 
-import { getPostcssPlugins } from '../postcss/postcss.mini'
+import { getDefaultPostcssConfig, getPostcssPlugins } from '../postcss/postcss.mini'
 import { WebpackModule } from './WebpackModule'
 
-import type { IPostcssOption, PostcssOption } from '@tarojs/taro/types/compile'
+import type { Func, PostcssOption } from '@tarojs/taro/types/compile'
 import type { MiniCombination } from './MiniCombination'
 import type { CssModuleOptionConfig, IRule } from './WebpackModule'
 
@@ -27,23 +27,34 @@ type CSSLoaders = {
 
 export class MiniWebpackModule {
   combination: MiniCombination
+  __postcssOption: [string, any, Func?][]
 
   constructor (combination: MiniCombination) {
     this.combination = combination
   }
 
   getModules () {
-    const { config, sourceRoot, fileType } = this.combination
+    const { appPath, config, sourceRoot, fileType } = this.combination
     const {
       buildAdapter,
       sassLoaderOption,
       lessLoaderOption,
-      stylusLoaderOption
+      stylusLoaderOption,
+      designWidth,
+      deviceRatio
     } = config
 
     const { postcssOption, postcssUrlOption, cssModuleOption } = this.parsePostCSSOptions()
 
-    const cssLoaders = this.getCSSLoaders(postcssOption, cssModuleOption)
+    this.__postcssOption = getDefaultPostcssConfig({
+      designWidth,
+      deviceRatio,
+      postcssOption
+    })
+
+    const postcssPlugins = getPostcssPlugins(appPath, this.__postcssOption)
+
+    const cssLoaders = this.getCSSLoaders(postcssPlugins, cssModuleOption)
     const resolveUrlLoader = WebpackModule.getResolveUrlLoader()
     const sassLoader = WebpackModule.getSassLoader(sassLoaderOption)
     const scssLoader = WebpackModule.getScssLoader(sassLoaderOption)
@@ -118,22 +129,16 @@ export class MiniWebpackModule {
     return cssLoadersCopy
   }
 
-  getCSSLoaders (postcssOption: IPostcssOption, cssModuleOption: PostcssOption.cssModules) {
-    const { appPath, config } = this.combination
+  getCSSLoaders (postcssPlugins: any[], cssModuleOption: PostcssOption.cssModules) {
+    const { config } = this.combination
     const {
-      designWidth = 750,
-      deviceRatio,
       cssLoaderOption
     } = config
     const extractCSSLoader = WebpackModule.getExtractCSSLoader()
     const cssLoader = WebpackModule.getCSSLoader(cssLoaderOption)
     const postCSSLoader = WebpackModule.getPostCSSLoader({
       postcssOptions: {
-        plugins: getPostcssPlugins(appPath, {
-          designWidth,
-          deviceRatio,
-          postcssOption
-        })
+        plugins: postcssPlugins
       }
     })
 

--- a/packages/taro-webpack5-runner/src/webpack/MiniWebpackPlugin.ts
+++ b/packages/taro-webpack5-runner/src/webpack/MiniWebpackPlugin.ts
@@ -1,6 +1,6 @@
 import { PLATFORMS } from '@tarojs/helper'
 import { isArray, isFunction, PLATFORM_TYPE } from '@tarojs/shared'
-import { ICopyOptions } from '@tarojs/taro/types/compile'
+import { ICopyOptions, IPostcssOption } from '@tarojs/taro/types/compile'
 
 import BuildNativePlugin from '../plugins/BuildNativePlugin'
 import MiniPlugin from '../plugins/MiniPlugin'
@@ -11,6 +11,7 @@ import type { MiniCombination } from './MiniCombination'
 
 export class MiniWebpackPlugin {
   combination: MiniCombination
+  pxtransformOption: IPostcssOption['pxtransform']
 
   constructor (combination: MiniCombination) {
     this.combination = combination
@@ -141,6 +142,7 @@ export class MiniWebpackPlugin {
       fileType
     } = this.combination
     const plugin = isBuildNativeComp ? BuildNativePlugin : MiniPlugin
+    const pxTransformConfig = this.pxtransformOption?.config || {}
     const options = {
       /** paths */
       sourceDir,
@@ -153,12 +155,11 @@ export class MiniWebpackPlugin {
       fileType,
       template: config.template,
       commonChunks: this.getCommonChunks(),
-      designWidth: config.designWidth || 750,
-      deviceRatio: config.deviceRatio,
       baseLevel: config.baseLevel || 16,
       minifyXML: config.minifyXML || {},
       alias: config.alias || {},
       constantsReplaceList: definePluginOptions,
+      pxTransformConfig,
       /** building mode */
       hot: false,
       prerender: config.prerender,

--- a/packages/taro/types/compile/config/project.d.ts
+++ b/packages/taro/types/compile/config/project.d.ts
@@ -3,8 +3,8 @@ import type Chain from 'webpack-chain'
 import type { Compiler } from '../compiler'
 import type { IModifyWebpackChain } from '../hooks'
 import type { ICopyOptions, IOption, ISassOptions, TogglableOptions } from "./util"
-import { IH5Config } from './h5'
-import { IMiniAppConfig } from './mini'
+import type { IH5Config } from './h5'
+import type { IMiniAppConfig } from './mini'
 
 export type PluginItem = string | [string, object]
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -501,7 +501,12 @@ importers:
       '@rollup/plugin-node-resolve': ^8.0.0
       '@tarojs/runtime': workspace:*
       '@tarojs/shared': workspace:*
+      jest: ^29.3.1
+      jest-cli: ^29.3.1
+      jest-environment-node: ^29.5.0
       rollup: ^2.79.0
+      ts-jest: ^29.0.5
+      typescript: ^4.7.4
     dependencies:
       '@babel/runtime': registry.npmjs.org/@babel/runtime/7.21.0
       '@tarojs/runtime': link:../taro-runtime
@@ -511,7 +516,12 @@ importers:
       '@rollup/plugin-babel': registry.npmjs.org/@rollup/plugin-babel/5.3.1_b6cdhqm2xsfe2bpl424qdsl4ei
       '@rollup/plugin-commonjs': registry.npmjs.org/@rollup/plugin-commonjs/20.0.0_rollup@2.79.1
       '@rollup/plugin-node-resolve': registry.npmjs.org/@rollup/plugin-node-resolve/8.4.0_rollup@2.79.1
+      jest: registry.npmjs.org/jest/29.5.0
+      jest-cli: registry.npmjs.org/jest-cli/29.5.0
+      jest-environment-node: registry.npmjs.org/jest-environment-node/29.5.0
       rollup: registry.npmjs.org/rollup/2.79.1
+      ts-jest: registry.npmjs.org/ts-jest/29.1.0_rgossuqlslmrpogqankdav3e2e
+      typescript: registry.npmjs.org/typescript/4.9.5
 
   packages/taro-cli:
     specifiers:


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

postcss-pxtransform
- h5 支持 px单位
- weapp 支持 rem 和 px 单位

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #7637 fix #10212
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
