### PR TITLE
fix: 从普通页面返回 tabbar 页面时展示动画

### DIFF
--- a/packages/taro-router/src/router/page.ts
+++ b/packages/taro-router/src/router/page.ts
@@ -221,6 +221,7 @@ export default class PageHandler {
       const pageEl = this.getPageContainer(page)
       pageEl?.classList.remove('taro_page_stationed')
       pageEl?.classList.remove('taro_page_show')
+      pageEl?.style.zIndex = 1
 
       this.unloadTimer = setTimeout(() => {
         this.unloadTimer = null

--- a/packages/taro-router/src/router/page.ts
+++ b/packages/taro-router/src/router/page.ts
@@ -221,7 +221,9 @@ export default class PageHandler {
       const pageEl = this.getPageContainer(page)
       pageEl?.classList.remove('taro_page_stationed')
       pageEl?.classList.remove('taro_page_show')
-      pageEl?.style.zIndex = 1
+      if (pageEl) {
+        pageEl.style.zIndex = '1'
+      }
 
       this.unloadTimer = setTimeout(() => {
         this.unloadTimer = null

--- a/packages/taro-router/src/router/spa.ts
+++ b/packages/taro-router/src/router/spa.ts
@@ -121,10 +121,10 @@ export function createRouter (
       } else if (stacks.length > 0) {
         const firstIns = stacks.getItem(0)
         if (handler.isTabBar(firstIns.path!)) {
-          handler.unload(currentPage, stacks.length - 1)
+          handler.unload(currentPage, stacks.length - 1, true)
           stacks.pushTab(firstIns.path!.split('?')[0])
         } else {
-          handler.unload(currentPage, stacks.length)
+          handler.unload(currentPage, stacks.length, true)
         }
       }
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

在 h5 中，从普通页面返回 tabbar 页面的时候，动画会消失，这个 PR 会修复这个问题，有 2 个场景：

1. 从 tabbar 页面进入普通页面，然后返回；
2. 直接进入普通页面，点击返回 tabbar 页面 。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
