### PR TITLE
feat(component): picker textProps

### DIFF
--- a/packages/taro-components/src/components/picker/picker.tsx
+++ b/packages/taro-components/src/components/picker/picker.tsx
@@ -21,6 +21,11 @@ export type Mode = 'selector' | 'multiSelector' | 'time' | 'date'
 export type Fields = 'day' | 'month' | 'year'
 export type PickerValue = number | number[] | string
 
+export type PickerText = {
+  okText?: string
+  cancelText?: string
+}
+
 export interface PickerDate {
   _value: Date
   _start: Date
@@ -48,6 +53,7 @@ export class Picker implements ComponentInterface {
   @Prop() end = ''
   @Prop() fields: Fields = 'day'
   @Prop() name = ''
+  @Prop() textProps?: PickerText = undefined
 
   @State() pickerValue: PickerValue = []
   @State() height: number[] = []
@@ -492,10 +498,10 @@ export class Picker implements ComponentInterface {
           <div class={clsSlider}>
             <div class='weui-picker__hd'>
               <div class='weui-picker__action' onClick={this.handleCancel}>
-                取消
+                {this.textProps?.cancelText ?? '取消'}
               </div>
               <div class='weui-picker__action' onClick={this.handleChange}>
-                确定
+                {this.textProps?.okText ?? '确定'}
               </div>
             </div>
             <div class='weui-picker__bd'>{pickerGroup}</div>

--- a/packages/taro-components/src/components/picker/picker.tsx
+++ b/packages/taro-components/src/components/picker/picker.tsx
@@ -21,7 +21,7 @@ export type Mode = 'selector' | 'multiSelector' | 'time' | 'date'
 export type Fields = 'day' | 'month' | 'year'
 export type PickerValue = number | number[] | string
 
-export type PickerText = {
+export interface PickerText {
   okText?: string
   cancelText?: string
 }
@@ -53,7 +53,7 @@ export class Picker implements ComponentInterface {
   @Prop() end = ''
   @Prop() fields: Fields = 'day'
   @Prop() name = ''
-  @Prop() textProps?: PickerText = undefined
+  @Prop() textProps: PickerText = {}
 
   @State() pickerValue: PickerValue = []
   @State() height: number[] = []
@@ -498,10 +498,10 @@ export class Picker implements ComponentInterface {
           <div class={clsSlider}>
             <div class='weui-picker__hd'>
               <div class='weui-picker__action' onClick={this.handleCancel}>
-                {this.textProps?.cancelText ?? '取消'}
+                {this.textProps.cancelText ?? '取消'}
               </div>
               <div class='weui-picker__action' onClick={this.handleChange}>
-                {this.textProps?.okText ?? '确定'}
+                {this.textProps.okText ?? '确定'}
               </div>
             </div>
             <div class='weui-picker__bd'>{pickerGroup}</div>

--- a/packages/taro-components/types/Picker.d.ts
+++ b/packages/taro-components/types/Picker.d.ts
@@ -35,6 +35,11 @@ declare namespace PickerStandardProps {
     /** 省市区选择器 */
     region
   }
+
+  interface PickerText {
+    okText?: string
+    cancelText?: string
+  }
 }
 /** 普通选择器：mode = selector */
 interface PickerSelectorProps extends PickerStandardProps {
@@ -74,6 +79,11 @@ interface PickerSelectorProps extends PickerStandardProps {
    * @supported weapp, h5, rn
    */
   onChange: CommonEventFunction<PickerSelectorProps.ChangeEventDetail>
+  /**
+   * 用于替换组件内部文本
+   * @supported h5
+   */
+  textProps?: PickerStandardProps.PickerText
 }
 declare namespace PickerSelectorProps {
   interface ChangeEventDetail {


### PR DESCRIPTION
组件内部文本props，新增textProps对象，为h5，rn等组件解决国际化问题，例Picker 组件， 传入 

```js
textProps={{
     okText: 'ok',
     cancelText: 'cancel'
}}
```

其他组件有类似需求的话，一样通过textProps, 在类型注释和文档中写明对应的可传的值

fix #12489 

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)



**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
