### PR TITLE
fix(webpack5): 修复 app 样式引用 common 样式的语法问题

### DIFF
--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/common-style.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/common-style.spec.ts.snap
@@ -1,9 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`common style should extract common styles 1`] = `19`;
+exports[`common style should extract common styles 1`] = `20`;
 
 exports[`common style should extract common styles 2`] = `
 "
+/** filePath: dist/app-origin.wxss **/
+.body{background-color:#e8e8ed}
+
 /** filePath: dist/app.js **/
 require("./runtime");
 
@@ -541,8 +544,9 @@ require("./taro");
 {"pages":["pages/index/index","pages/about/index"],"window":{"backgroundTextStyle":"light","navigationBarBackgroundColor":"#fff","navigationBarTitleText":"WeChat","navigationBarTextStyle":"black"}}
 
 /** filePath: dist/app.wxss **/
-.body{background-color:#e8e8ed}
+@import "./app-origin.wxss";
 @import "./common.wxss";
+
 
 /** filePath: dist/base.wxml **/
 <wxs module="xs" src="./utils.wxs" />

--- a/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
+++ b/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
@@ -1185,22 +1185,27 @@ export default class TaroMiniPlugin {
 
     if (!assets[appStyle]) return
 
-    const originSource: string = assets[appStyle].source()
-    const source = new ConcatSource()
-    source.add(originSource)
+    const commons = new ConcatSource('')
 
     // 组件公共样式需要放在 app 全局样式之后：https://github.com/NervJS/taro/pull/6125
     Object.keys(assets).forEach(assetName => {
       const fileName = path.basename(assetName, path.extname(assetName))
       if ((REG_STYLE.test(assetName) || REG_STYLE_EXT.test(assetName)) && this.options.commonChunks.includes(fileName)) {
-        source.add('\n')
-        source.add(`@import ${JSON.stringify(urlToRequest(assetName))};`)
-        assets[appStyle] = {
-          size: () => source.source().length,
-          source: () => source.source()
-        }
+        commons.add('\n')
+        commons.add(`@import ${JSON.stringify(urlToRequest(assetName))};`)
       }
     })
+
+    if (commons.size() > 0) {
+      const APP_STYLE_NAME = 'app-origin' + styleExt
+      const originSource = assets[appStyle]
+      assets[APP_STYLE_NAME] = new ConcatSource(originSource)
+      const source = new ConcatSource('')
+      source.add(`@import ${JSON.stringify(urlToRequest(APP_STYLE_NAME))};`)
+      source.add(commons)
+      source.add('\n')
+      assets[appStyle] = source
+    }
   }
 
   addTarBarFilesToDependencies (compilation: webpack.compilation.Compilation) {

--- a/packages/taro-webpack5-runner/src/__tests__/__snapshots__/mini-split-chunks.spec.ts.snap
+++ b/packages/taro-webpack5-runner/src/__tests__/__snapshots__/mini-split-chunks.spec.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`mini-split-chunks should process mini-split-chunks 1`] = `31`;
+exports[`mini-split-chunks should process mini-split-chunks 1`] = `32`;

--- a/packages/taro-webpack5-runner/src/plugins/MiniPlugin.ts
+++ b/packages/taro-webpack5-runner/src/plugins/MiniPlugin.ts
@@ -1159,16 +1159,25 @@ export default class TaroMiniPlugin {
     if (!assets[appStyle]) return
 
     const originSource = assets[appStyle]
-    const source = new ConcatSource(originSource)
+    const commons = new ConcatSource('')
 
     Object.keys(assets).forEach(assetName => {
       const fileName = path.basename(assetName, path.extname(assetName))
       if ((REG_STYLE.test(assetName) || REG_STYLE_EXT.test(assetName)) && this.options.commonChunks.includes(fileName)) {
-        source.add('\n')
-        source.add(`@import ${JSON.stringify(urlToRequest(assetName))};`)
-        assets[appStyle] = source
+        commons.add('\n')
+        commons.add(`@import ${JSON.stringify(urlToRequest(assetName))};`)
       }
     })
+
+    if (commons.size() > 0) {
+      const APP_STYLE_NAME = 'app-origin' + styleExt
+      assets[APP_STYLE_NAME] = new ConcatSource(originSource)
+      const source = new ConcatSource('')
+      source.add(`@import ${JSON.stringify(urlToRequest(APP_STYLE_NAME))};`)
+      source.add(commons)
+      source.add('\n')
+      assets[appStyle] = source
+    }
   }
 
   addTarBarFilesToDependencies (compilation: Compilation) {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复 app 样式引用 common 样式的语法问题

修复前，位于样式文件底部的 `@import` 不符合规范，容易导致各种错误：

```css
/* app.wxss */

/* some app global styles */
.global {...}

/* common styles */
@import "./common.wxss";
```

修复后，当存在 common 样式时，抽取 app 样式到一个独立的文件，app样式文件只保留 `@import` 语句。这样可以兼顾样式层叠顺序和 css 语法的准确性：

```css
/* app.wxss */
@import "./app-core.wxss";
@import "./common.wxss";

```

```css
/* app-core.wxss */
.global {...}
```

（顺着处理了 #13764 的语法问题）

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
