### PR TITLE
fix(h5): 修复类空判断导致的问题 fix #13781

### DIFF
--- a/packages/taro-components-library-react/src/react-component-lib/utils/attachProps.ts
+++ b/packages/taro-components-library-react/src/react-component-lib/utils/attachProps.ts
@@ -65,10 +65,7 @@ export const attachProps = (node: HTMLElement, newProps: any, oldProps: any = {}
   // some test frameworks don't render DOM elements, so we test here to make sure we are dealing with DOM first
   if (node instanceof Element) {
     // add any classes in className to the class list
-    const className = getClassName(node.classList, newProps, oldProps)
-    if (className !== '') {
-      node.className = className
-    }
+    node.className = getClassName(node.classList, newProps, oldProps)
 
     Object.keys(newProps).forEach((name) => {
       /** Note(taro): 优化 style 属性的处理

--- a/packages/taro-h5/package.json
+++ b/packages/taro-h5/package.json
@@ -13,7 +13,9 @@
     "index.js"
   ],
   "sideEffects": [
+    "*.scss.js",
     "*.scss",
+    "*.css.js",
     "*.css"
   ],
   "scripts": {

--- a/packages/taro-h5/src/api/location/chooseLocation.ts
+++ b/packages/taro-h5/src/api/location/chooseLocation.ts
@@ -5,6 +5,7 @@ import { stringify } from 'query-string'
 
 import { MethodHandler } from '../../utils/handler'
 
+let container: HTMLDivElement | null = null
 function createLocationChooser (handler, key = LOCATION_APIKEY, mapOpt: Taro.chooseLocation.Option['mapOpts'] = {}) {
   const { latitude, longitude, ...opts } = mapOpt
   const query = {
@@ -14,7 +15,8 @@ function createLocationChooser (handler, key = LOCATION_APIKEY, mapOpt: Taro.cho
     referer: 'myapp',
     ...opts
   }
-  const html = `
+  if (!container) {
+    const html = `
 <div class='taro_choose_location'>
   <div class='taro_choose_location_bar'>
     <div class='taro_choose_location_back'></div>
@@ -24,8 +26,9 @@ function createLocationChooser (handler, key = LOCATION_APIKEY, mapOpt: Taro.cho
   <iframe class='taro_choose_location_frame' frameborder='0' src="https://apis.map.qq.com/tools/locpicker?${stringify(query, { arrayFormat: 'comma', skipNull: true })}" />
 </div>
 `
-  const container = document.createElement('div')
-  container.innerHTML = html
+    container = document.createElement('div')
+    container.innerHTML = html
+  }
   const main: HTMLDivElement = container.querySelector('.taro_choose_location') as HTMLDivElement
 
   function show () {
@@ -49,7 +52,8 @@ function createLocationChooser (handler, key = LOCATION_APIKEY, mapOpt: Taro.cho
   }
 
   function remove () {
-    container.remove()
+    container?.remove()
+    container = null
     window.removeEventListener('popstate', back)
   }
 
@@ -61,7 +65,7 @@ function createLocationChooser (handler, key = LOCATION_APIKEY, mapOpt: Taro.cho
   return {
     show,
     remove,
-    container
+    container,
   }
 }
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

- 修复在 web 端使用 react 框架时，classnames 赋值为空时错误判断导致的问题
- 修复地图样式抖动 & 重复注入等问题

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #13781 fix #13808
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
