### PR TITLE
fix(webpack5): 修复 CSS 内静态资源路径 alias 不生效的问题，fix #13906

### DIFF
--- a/packages/taro-webpack5-runner/src/postcss/postcss-alias.ts
+++ b/packages/taro-webpack5-runner/src/postcss/postcss-alias.ts
@@ -1,0 +1,37 @@
+import { isAliasPath, replaceAliasPath } from '@tarojs/helper'
+
+const pattern = /(url\(\s*['"]?)([^"')]+)(["']?\s*\))/g
+
+interface IOptions {
+  alias?: Record<string, string>
+}
+
+const postcssAlias = (options: IOptions = {}) => {
+  return {
+    postcssPlugin: 'postcss-alias',
+    Once (styles, { result }) {
+      if (!options.alias || !Object.keys(options.alias).length) return
+
+      const opts = result.opts
+      const from = opts.from
+
+      styles.walkDecls(decl => {
+        if (pattern.test(decl.value)) {
+          decl.value = decl.value.replace(pattern, (matched, before, url, after) => {
+            url = url.replace(/^~/, '')
+            if (isAliasPath(url, options.alias)) {
+              const newUrl = replaceAliasPath(from, url, options.alias)
+              return `${before}${newUrl}${after}`
+            } else {
+              return matched
+            }
+          })
+        }
+      })
+    }
+  }
+}
+
+postcssAlias.postcss = true
+
+export default postcssAlias

--- a/packages/taro-webpack5-runner/src/postcss/postcss.h5.ts
+++ b/packages/taro-webpack5-runner/src/postcss/postcss.h5.ts
@@ -51,7 +51,8 @@ const plugins: any[] = []
 export const getDefaultPostcssConfig = function ({
   designWidth,
   deviceRatio,
-  option = {} as IPostcssOption
+  option = {} as IPostcssOption,
+  alias = {}
 }): [string, any, Func?][] {
   const { autoprefixer, pxtransform, htmltransform, url, ...options } = option
   if (designWidth) {
@@ -72,6 +73,7 @@ export const getDefaultPostcssConfig = function ({
     ['postcss-pxtransform', pxtransformOption, require('postcss-pxtransform')],
     ['postcss-html-transform', htmltransformOption, require('postcss-html-transform')],
     ['postcss-plugin-constparse', defaultConstparseOption, require('postcss-plugin-constparse')],
+    ['postcss-alias', { config: { alias } }, require('./postcss-alias').default],
     ['postcss-url', urlOption, require('postcss-url')],
     ...Object.entries(options)
   ]

--- a/packages/taro-webpack5-runner/src/postcss/postcss.mini.ts
+++ b/packages/taro-webpack5-runner/src/postcss/postcss.mini.ts
@@ -44,7 +44,8 @@ const plugins = [] as any[]
 export const getDefaultPostcssConfig = function ({
   designWidth,
   deviceRatio,
-  postcssOption = {} as IPostcssOption
+  postcssOption = {} as IPostcssOption,
+  alias = {}
 }): [string, any, Func?][] {
   const { autoprefixer, pxtransform, htmltransform, url, ...options } = postcssOption
 
@@ -65,6 +66,7 @@ export const getDefaultPostcssConfig = function ({
     ['postcss-import', {}, require('postcss-import')],
     ['autoprefixer', autoprefixerOption, require('autoprefixer')],
     ['postcss-pxtransform', pxtransformOption, require('postcss-pxtransform')],
+    ['postcss-alias', { config: { alias } }, require('./postcss-alias').default],
     ['postcss-url', urlOption, require('postcss-url')],
     ['postcss-html-transform', htmltransformOption, require('postcss-html-transform')],
     ...Object.entries(options)

--- a/packages/taro-webpack5-runner/src/webpack/H5WebpackModule.ts
+++ b/packages/taro-webpack5-runner/src/webpack/H5WebpackModule.ts
@@ -230,7 +230,8 @@ export class H5WebpackModule {
     this.__postcssOption = getDefaultPostcssConfig({
       designWidth,
       deviceRatio,
-      option: postcssOption
+      option: postcssOption,
+      alias: config.alias,
     })
     const postcssLoader = WebpackModule.getPostCSSLoader({
       postcssOptions: {

--- a/packages/taro-webpack5-runner/src/webpack/MiniWebpackModule.ts
+++ b/packages/taro-webpack5-runner/src/webpack/MiniWebpackModule.ts
@@ -49,7 +49,8 @@ export class MiniWebpackModule {
     this.__postcssOption = getDefaultPostcssConfig({
       designWidth,
       deviceRatio,
-      postcssOption
+      postcssOption,
+      alias: config.alias,
     })
 
     const postcssPlugins = getPostcssPlugins(appPath, this.__postcssOption)


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复 CSS 内静态资源路径 alias 不生效的问题，fix #13906

新增 postcss 插件，在 postcss-url 处理之前先把 alias 后的静态资源路径进行还原

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #13906 
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
