### PR TITLE
fix: 修复 cli 默认模板存在幽灵依赖的问题

### DIFF
--- a/packages/taro-cli/templates/default/package.json.tmpl
+++ b/packages/taro-cli/templates/default/package.json.tmpl
@@ -68,6 +68,7 @@
     "@tarojs/webpack-runner": "<%= version %>",
     "webpack": "4.46.0",<%} else if (compiler === 'webpack5') {%>
     "webpack": "5.78.0",
+    "@tarojs/taro-loader": "<%= version %>",
     "@tarojs/webpack5-runner": "<%= version %>",<%}%>
     "babel-preset-taro": "<%= version %>",<% if (['vue', 'vue3'].includes(framework)) {%>
     "css-loader": "3.4.2",


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

如 #13798 所说，在开启 webpack cache 之后，执行 `pnpm run dev:weapp` 或者 `build` 都会报异常。
这个 PR 把幽灵依赖显式加入到模板的 `package.json` 中。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #13798
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
