### PR TITLE
fix(h5): InnerAudioContext和BackgroundAudioManager出现错误时未触发onError

### DIFF
--- a/packages/taro-h5/src/api/media/audio/InnerAudioContext.ts
+++ b/packages/taro-h5/src/api/media/audio/InnerAudioContext.ts
@@ -14,6 +14,7 @@ export class InnerAudioContext implements Taro.InnerAudioContext {
     this.Instance = new Audio()
     this.errorStack = new CallbackManager()
     this.stopStack = new CallbackManager()
+    this.Instance.onerror = this.errorStack.trigger
 
     Taro.eventCenter.on('__taroRouterChange', () => { this.stop() })
     this.onPlay(() => {

--- a/packages/taro-h5/src/api/media/background-audio/BackgroundAudioManager.ts
+++ b/packages/taro-h5/src/api/media/background-audio/BackgroundAudioManager.ts
@@ -13,6 +13,7 @@ export class BackgroundAudioManager implements Taro.BackgroundAudioManager {
     this.Instance = new Audio()
     this.errorStack = new CallbackManager()
     this.stopStack = new CallbackManager()
+    this.Instance.onerror = this.errorStack.trigger
     this.Instance.autoplay = true
     this.onPlay(() => {
       if (this.currentTime !== this.startTime) {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
Issues: #13945 

修复在 H5 环境中InnerAudioContext和BackgroundAudioManager出现错误时未触发onError监听的事件的问题

- 存在个问题，H5的onerror事件的参数([MediaError - MDN](https://developer.mozilla.org/en-US/docs/Web/API/MediaError))与小程序的[onError](https://developers.weixin.qq.com/miniprogram/dev/api/media/audio/InnerAudioContext.onError.html)是不一样的，如果有更好的写法，可以直接修改。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #13945
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
