### PR TITLE
fix(h5): inneraudiocontext destroy

### DIFF
--- a/packages/taro-h5/src/api/media/audio/InnerAudioContext.ts
+++ b/packages/taro-h5/src/api/media/audio/InnerAudioContext.ts
@@ -74,7 +74,6 @@ export class InnerAudioContext implements Taro.InnerAudioContext {
   destroy = () => {
     this.stop()
     if (this.Instance) {
-      document.body.removeChild(this.Instance)
       this.Instance = undefined
     }
   }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

在**web**中调用音频实例的销毁方法报错
```ts
const audioContext = Taro.createInnerAudioContext()
audioContext.destroy() // 报错
```
![image](https://github.com/NervJS/taro/assets/45651308/d7fef0ac-617e-41fc-b5c0-23835c0e6c48)

我理解的报错原因是

web实际上就是创建一个`audio`元素去调用方法，但是压根就没有插入body中，destroy却调用了document.body.removeChild，所以就报错了

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
