### PR TITLE
fix(types): 修改用户加密模块类型错误

### DIFF
--- a/packages/taro/types/api/base/crypto.d.ts
+++ b/packages/taro/types/api/base/crypto.d.ts
@@ -42,7 +42,7 @@ declare module '../../index' {
     namespace getLatestUserKey {
       interface Option {
         /** 接口调用成功的回调函数 */
-        success?: (res: TaroGeneral.CallbackResult) => void
+        success?: (res: SuccessCallbackResult) => void
         /** 接口调用失败的回调函数 */
         fail?: (res: TaroGeneral.CallbackResult) => void
         /** 接口调用结束的回调函数（调用成功、失败都会执行） */


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修改了微信小程序用户加密模块 getLatestUserKey success 返回的参数类型。
success 返回的参数类型应为 SuccessCallbackResult 而非 TaroGeneral.CallbackResult。


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [x] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
