### PR TITLE
fix(types): transform react CamelCase event name to vue Camelcase name

### DIFF
--- a/packages/taro-components/types/index.vue3.d.ts
+++ b/packages/taro-components/types/index.vue3.d.ts
@@ -18,9 +18,9 @@ import { AdCustomProps } from './AdCustom'
 import { AudioProps } from './Audio'
 import { ButtonProps } from './Button'
 import { CameraProps } from './Camera'
+import { CanvasProps } from './Canvas'
 import { ChannelLiveProps } from './ChannelLive'
 import { ChannelVideoProps } from './ChannelVideo'
-import { CanvasProps } from './Canvas'
 import { CheckboxProps } from './Checkbox'
 import { CheckboxGroupProps } from './CheckboxGroup'
 import { StandardProps } from './common'
@@ -30,17 +30,20 @@ import { CustomWrapperProps } from './CustomWrapper'
 import { EditorProps } from './Editor'
 import { FormProps } from './Form'
 import { FunctionalPageNavigatorProps } from './FunctionalPageNavigator'
+import { GridViewProps } from './GridView'
 import { IconProps } from './Icon'
 import { ImageProps } from './Image'
 import { InputProps } from './Input'
 import { KeyboardAccessoryProps } from './KeyboardAccessory'
 import { LabelProps } from './Label'
+import { ListViewProps } from './ListView'
 import { LivePlayerProps } from './LivePlayer'
 import { LivePusherProps } from './LivePusher'
 import { MapProps } from './Map'
 import { MatchMediaProps } from './MatchMedia'
 import { MovableAreaProps } from './MovableArea'
 import { MovableViewProps } from './MovableView'
+import { NativeSlotProps } from './NativeSlot'
 import { NavigationBarProps } from './NavigationBar'
 import { NavigatorProps } from './Navigator'
 import { OfficialAccountProps } from './OfficialAccount'
@@ -52,14 +55,18 @@ import {
   PickerRegionProps, PickerSelectorProps, PickerTimeProps
 } from './Picker'
 import { PickerViewProps } from './PickerView'
+import { PickerViewColumnProps } from './PickerViewColumn'
 import { ProgressProps } from './Progress'
 import { RadioProps } from './Radio'
 import { RadioGroupProps } from './RadioGroup'
 import { RichTextProps } from './RichText'
+import { RootPortalProps } from './RootPortal'
 import { ScrollViewProps } from './ScrollView'
 import { ShareElementProps } from './ShareElement'
 import { SliderProps } from './Slider'
 import { SlotProps } from './Slot'
+import { StickyHeaderProps } from './StickyHeader'
+import { StickySectionProps } from './StickySection'
 import { SwiperProps } from './Swiper'
 import { SwiperItemProps } from './SwiperItem'
 import { SwitchProps } from './Switch'
@@ -69,16 +76,18 @@ import { VideoProps } from './Video'
 import { ViewProps } from './View'
 import { VoipRoomProps } from './VoipRoom'
 import { WebViewProps } from './WebView'
-import { RootPortalProps } from './RootPortal'
-import { PickerViewColumnProps } from './PickerViewColumn'
-import { NativeSlotProps } from './NativeSlot'
-import { GridViewProps } from './GridView'
-import { ListViewProps } from './ListView'
-import { StickyHeaderProps } from './StickyHeader'
-import { StickySectionProps } from './StickySection'
+
+/** 因为react的事件是CamelCase而vue得是Camelcase, 所以需要转换 */
+type OnCamelCaseToOnCamelcase<T extends string> = T extends `on${infer Rest}`
+  ? `on${Capitalize<Lowercase<Rest>>}`
+  : T;
+
+type TransformCamelCase<T extends Record<string, any>> = {
+  [key in keyof T as OnCamelCaseToOnCamelcase<key>]: T[key]
+}
 
 /** 联合类型不能用omit（比如picker） */
-type DistributiveOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K> : never
+type DistributiveOmit<T, K extends keyof T> = T extends unknown ? TransformCamelCase<Omit<T, K>> : never
 
 interface SlimProps {
   class?: any


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

这么久才发现react的事件名和vue的不太一样   #11445 

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #13516
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
