### PR TITLE
feat(helper): inject env to esbuild phase

### DIFF
--- a/packages/taro-helper/src/esbuild/index.ts
+++ b/packages/taro-helper/src/esbuild/index.ts
@@ -31,6 +31,8 @@ export function requireWithEsbuild (id: string, {
       absWorkingDir: cwd,
       bundle: true,
       define: defaults(customConfig.define, {
+        // 注入 process.env.NODE_ENV，与其他场景保持一致
+        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
         // AMD 被 esbuild 转 ESM 后，是套着 ESM 外皮的 AMD 语法模块。
         // Webpack HarmonyDetectionParserPlugin 会阻止 AMDDefineDependencyParserPlugin 对这些模块的处理。
         // 导致这些模块报错（如 lodash）。目前的办法是把 define 置为 false，不支持 AMD 导出。


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

在 `esbuild` 编译文件时，注入 `process.env.NODE_ENV`，使之与其他场景保持一致

closes: #14240 

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
