### PR TITLE
fix(alipay): add my.alert success callback compatibility

### DIFF
--- a/packages/taro-alipay/src/apis.ts
+++ b/packages/taro-alipay/src/apis.ts
@@ -205,6 +205,18 @@ const apiDiff: IApiDiff = {
  * key 为 alipay小程序中的api名称
  */
 const asyncResultApiDiff = {
+  alert: {
+    res: {
+      set: [
+        {
+          key: 'confirm',
+          value (res) {
+            return res.success
+          }
+        }
+      ],
+    }
+  },
   getScreenBrightness: {
     res: {
       set: [

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/alipay.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/alipay.spec.ts.snap
@@ -267,6 +267,16 @@ require("./taro");
                 }
             };
             var asyncResultApiDiff = {
+                alert: {
+                    res: {
+                        set: [ {
+                            key: "confirm",
+                            value: function value(res) {
+                                return res.success;
+                            }
+                        } ]
+                    }
+                },
                 getScreenBrightness: {
                     res: {
                         set: [ {

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/tabbar.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/tabbar.spec.ts.snap
@@ -267,6 +267,16 @@ require("./taro");
                 }
             };
             var asyncResultApiDiff = {
+                alert: {
+                    res: {
+                        set: [ {
+                            key: "confirm",
+                            value: function value(res) {
+                                return res.success;
+                            }
+                        } ]
+                    }
+                },
                 getScreenBrightness: {
                     res: {
                         set: [ {

--- a/packages/taro-webpack5-runner/src/__tests__/__snapshots__/mini-platform.spec.ts.snap
+++ b/packages/taro-webpack5-runner/src/__tests__/__snapshots__/mini-platform.spec.ts.snap
@@ -236,6 +236,16 @@ require("./runtime");
             }
         };
         var asyncResultApiDiff = {
+            alert: {
+                res: {
+                    set: [ {
+                        key: "confirm",
+                        value: function value(res) {
+                            return res.success;
+                        }
+                    } ]
+                }
+            },
             getScreenBrightness: {
                 res: {
                     set: [ {

--- a/packages/taro-webpack5-runner/src/__tests__/__snapshots__/tabbar.spec.ts.snap
+++ b/packages/taro-webpack5-runner/src/__tests__/__snapshots__/tabbar.spec.ts.snap
@@ -2176,6 +2176,16 @@ require("./runtime");
             }
         };
         var asyncResultApiDiff = {
+            alert: {
+                res: {
+                    set: [ {
+                        key: "confirm",
+                        value: function value(res) {
+                            return res.success;
+                        }
+                    } ]
+                }
+            },
             getScreenBrightness: {
                 res: {
                     set: [ {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
`Taro.showModal` 方法 `showCancel==false` 时实际调用的是[my.alert](https://opendocs.alipay.com/mini/api/ui-feedback?pathHash=2ad09662)方法，此时，回调只返回了 `{success:true}`，此处作统一兼容，同时返回 `confirm`属性



**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [x] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
