### PR TITLE
fix: 修复输入框事件传入的函数不会更新

### DIFF
--- a/packages/taro-components-rn/src/components/Input/index.tsx
+++ b/packages/taro-components-rn/src/components/Input/index.tsx
@@ -125,7 +125,7 @@ const _Input = (props: InputProps) => {
         setReturnValue(undefined)
       }
     }
-  }, [returnValue])
+  }, [returnValue, props.onInput, props.onChange])
 
   const onFocus = React.useCallback((): void => {
     const { onFocus = noop } = props
@@ -134,7 +134,7 @@ const _Input = (props: InputProps) => {
       target: { value: tmpValue.current || '' },
       detail: { value: tmpValue.current || '' }
     })
-  }, [returnValue])
+  }, [returnValue, props.onFocus])
 
   const onBlur = React.useCallback((): void => {
     const { onBlur = noop } = props
@@ -143,7 +143,7 @@ const _Input = (props: InputProps) => {
       target: { value: tmpValue.current || '' },
       detail: { value: tmpValue.current || '' }
     })
-  }, [])
+  }, [props.onBlur])
 
   /**
    * Callback that is called when a key is pressed.
@@ -168,7 +168,7 @@ const _Input = (props: InputProps) => {
       target: { value: tmpValue.current || '' },
       detail: { value: tmpValue.current || '' }
     })
-  }, [])
+  }, [props.onKeyDown, props.onConfirm])
 
   const onSubmitEditing = React.useCallback((): void => {
     const { onKeyDown = noop, onConfirm = noop } = props
@@ -182,7 +182,7 @@ const _Input = (props: InputProps) => {
       target: { value: tmpValue.current || '' },
       detail: { value: tmpValue.current || '' }
     })
-  }, [_multiline])
+  }, [_multiline, props.onKeyDown, props.onConfirm])
 
   const onContentSizeChange = React.useCallback((event: NativeSyntheticEvent<TextInputContentSizeChangeEventData>): void => {
     const { width, height } = event.nativeEvent.contentSize


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复这样写无法获得最新的post，导致值被重置的问题
```js
<Input onInput={e => setPost({ ...post, key: e.detail.value })} />
```


**这个 PR 是什么类型?** (至少选择一个)

- [+] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [+] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
