### PR TITLE
feat: 删除默认版本号；不传自定义版本号时， alipay 平台使用默认自增版本号

### DIFF
--- a/packages/taro-plugin-mini-ci/src/AlipayCI.ts
+++ b/packages/taro-plugin-mini-ci/src/AlipayCI.ts
@@ -123,7 +123,7 @@ export default class AlipayCI extends BaseCI {
         appId,
         clientType
       })
-      if (compareVersion(this.version, lasterVersion) <=0) {
+      if (this.version && compareVersion(this.version, lasterVersion) <=0) {
         printLog(processTypeEnum.ERROR, chalk.red(`上传版本号 "${ this.version }" 必须大于最新上传版本 "${ lasterVersion }"`))
       }
       const result = await this.minidev.minidev.upload({

--- a/packages/taro-plugin-mini-ci/src/BaseCi.ts
+++ b/packages/taro-plugin-mini-ci/src/BaseCi.ts
@@ -167,7 +167,7 @@ export default abstract class BaseCI {
         encoding: 'utf8'
       })
     )
-    this.version = pluginOpts.version || packageInfo.taroConfig?.version || '1.0.0'
+    this.version = pluginOpts.version || packageInfo.taroConfig?.version
     this.desc = pluginOpts.desc || packageInfo.taroConfig?.desc || `CI构建自动构建于${new Date().toLocaleTimeString()}`
 
   }


### PR DESCRIPTION
**问题背景：**
使用`@tarojs/plugin-mini-ci`在 CI 中上传小程序时，不传版本号，默认为`1.0.0`
**实际结果：**
导致无法实现官方文档中所说的，不提供版本号时，版本号patch自增
![image](https://github.com/NervJS/taro/assets/5390013/857a7b14-eaca-4e53-a7a5-c222bcd7970d)
**期望结果：**
去掉默认版本号 `1.0.0`

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
去掉默认版本号 `1.0.0`

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #

**这个 PR 涉及以下平台:**

- [x] 所有小程序
