### PR TITLE
fix: h5模式下页面返回destroyed、onShow生命周期时序修复

### DIFF
--- a/packages/taro-router/src/router/page.ts
+++ b/packages/taro-router/src/router/page.ts
@@ -243,12 +243,16 @@ export default class PageHandler {
       this.unloadTimer = setTimeout(() => {
         this.unloadTimer = null
         this.lastUnloadPage?.onUnload?.()
+        eventCenter.trigger('taro_page_onShow_afterDestroyed')
       }, this.animationDuration)
     } else {
       const pageEl = this.getPageContainer(page)
       pageEl?.classList.remove('taro_page_stationed')
       pageEl?.classList.remove('taro_page_show')
       page?.onUnload?.()
+      setTimeout(()=>{
+        eventCenter.trigger('taro_page_onShow_afterDestroyed')
+      })
     }
     if (delta >= 1) this.unload(stacks.last, delta)
   }

--- a/packages/taro-router/src/router/spa.ts
+++ b/packages/taro-router/src/router/spa.ts
@@ -143,7 +143,9 @@ export function createRouter (
       if (currentPage !== stacks.getItem(prevIndex)) {
         handler.unload(currentPage, delta, prevIndex > -1)
         if (prevIndex > -1) {
-          handler.show(stacks.getItem(prevIndex), pageConfig, prevIndex)
+          eventCenter.on('taro_page_onShow_afterDestroyed',()=>{
+            handler.show(stacks.getItem(prevIndex), pageConfig, prevIndex)
+          })
         } else {
           shouldLoad = true
         }

--- a/packages/taro-router/src/router/spa.ts
+++ b/packages/taro-router/src/router/spa.ts
@@ -145,6 +145,7 @@ export function createRouter (
         if (prevIndex > -1) {
           eventCenter.on('taro_page_onShow_afterDestroyed',()=>{
             handler.show(stacks.getItem(prevIndex), pageConfig, prevIndex)
+            eventCenter.off('taro_page_onShow_afterDestroyed')
           })
         } else {
           shouldLoad = true


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复web平台下，页面返回（PageB 返回 PageA）时，生命周期 destroyed 和 onShow 时序与小程序不一致问题
现状：小程序下 PageB.destroyed -> PageA.onShow; h5端  PageA.onShow -> PageB.destroyed 
修复之后两端一致


**这个 PR 是什么类型?** (至少选择一个)

- [X] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [X] Web 平台（H5）
- [] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
