### PR TITLE
fix(mini-runner): 修复TSC编译的括号函数表达式转换原生组件属性问题

### DIFF
--- a/packages/taro-mini-runner/src/plugins/TaroNormalModulesPlugin.ts
+++ b/packages/taro-mini-runner/src/plugins/TaroNormalModulesPlugin.ts
@@ -50,6 +50,16 @@ export default class TaroNormalModulesPlugin {
                 if (callee.property.name !== 'createElement') {
                   return
                 }
+              } else if (callee.type === 'SequenceExpression') {
+                // (0, jsx_runtime_1.jsx)('comp-name', { ...props })
+                const nameNode = (callee.expressions || [])[1]
+                const { object, property } = nameNode || {}
+                if (
+                  !(object && object.name === 'jsx_runtime_1' &&
+                  property && property.name === 'jsx')
+                ) {
+                  return
+                }
               } else {
                 const nameOfCallee = callee.name
                 if (


### PR DESCRIPTION
引入自定义原生组件发现属性并未传递，生成的组件模板缺少属性赋值。

通过源码分析，定位到taro编译器解析ast树提取原生组件属性时未支持括号函数表达式注册的原生组件。

当通过tsc前置编译的项目函数名会变成括号函数表达式，例如`foo()`编译后为`(0, foo)()` ，组件注册对象`jsx`编译后为`(0, jsx_runtime_1.jsx)()`。 

> 组件的表达式示例
```js
(0, jsx_runtime_1.jsx)('comp-name', { ...props })
```

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #14327
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
