### PR TITLE
fix: 修复button组件丢失warn

### DIFF
--- a/packages/taro-components/src/components/button/style/index.scss
+++ b/packages/taro-components/src/components/button/style/index.scss
@@ -40,6 +40,12 @@ $weuiBtnPlainDefaultBorderColor: rgb(53 53 53 / 100%);
 $weuiBtnPlainDefaultActiveColor: rgb(53 53 53 / 60%);
 $weuiBtnPlainDefaultActiveBorderColor: rgb(53 53 53 / 60%);
 
+// Button Plain Warn
+$weuiBtnPlainWarnColor: #e64340;
+$weuiBtnPlainWarnBorderColor: #e64340;
+$weuiBtnPlainWarnActiveColor: rgba(230 67 64 / 60%);
+$weuiBtnPlainWarnActiveBorderColor: rgba(230 67 64 / 60%);
+
 taro-button-core {
   display: block;
   overflow: hidden;
@@ -162,6 +168,21 @@ taro-button-core {
       border-color: $weuiBtnPlainPrimaryActiveBorderColor;
       background-color: transparent;
       color: $weuiBtnPlainPrimaryActiveColor;
+    }
+
+    &::after {
+      border-width: 0;
+    }
+  }
+  
+  &[plain][type="warn"] {
+    border: 1px solid $weuiBtnPlainWarnBorderColor;
+    color: $weuiBtnPlainWarnColor;
+
+    &:not([disabled]):active {
+      border-color: $weuiBtnPlainWarnActiveBorderColor;
+      background-color: transparent;
+      color: $weuiBtnPlainWarnActiveColor;
     }
 
     &::after {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复h5中components下的btn组件丢失warn样式


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
