### PR TITLE
fix(component): 修复H5端创建webComponent标签组件失效问题

### DIFF
--- a/packages/taro-components-library-vue2/src/components-loader.ts
+++ b/packages/taro-components-library-vue2/src/components-loader.ts
@@ -9,7 +9,7 @@ export function initVue2Components (components: Record<string, any> = {}) {
 
   Vue.use(Fragment.Plugin)
   Object.entries(components).forEach(([name, definition]) => {
-    if (typeof definition?.render === 'function') {
+    if (typeof definition === 'function') {
       const tagName = 'taro' + name.replace(new RegExp('([A-Z])', 'g'), '-$1').toLowerCase()
       const comp = Vue.extend(definition)
       Vue.component(tagName, comp)


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

Vue2 语法转 H5 端时，所有的节点都变成了 taro-xxx，没有成功渲染为 taro-xxx-core 的 webComponent 组件，导致所有组件能力都失效。

不正常：
<img width="1031" alt="image" src="https://github.com/NervJS/taro/assets/13111739/e25caba7-a806-433e-b500-0ce3c5861fe1">

预期：
<img width="1186" alt="image" src="https://github.com/NervJS/taro/assets/13111739/ba6df4dc-6db3-4325-bac8-b43497db1eb0">


本次修改，主要调整了组件初始化时的 initVue2Components 函数中的判断逻辑，因为 Vue.extend 返回的亦是一个构造函数，且仅需判断是否存在即可。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
