### PR TITLE
fix: Virtural Waterfall 默认值问题

### DIFF
--- a/packages/taro-components-advanced/src/components/virtual-waterfall/list-map.ts
+++ b/packages/taro-components-advanced/src/components/virtual-waterfall/list-map.ts
@@ -52,11 +52,11 @@ export default class ListMap {
   }
 
   get length () {
-    return this.props.itemCount || 100
+    return this.props.itemCount ?? 100
   }
 
   get overscan () {
-    return this.props.overscanDistance || 50
+    return this.props.overscanDistance ?? 50
   }
 
   get columnsSize () {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复Virtual Waterfall默认值问题
原本的默认值采取的是`value||default`的方式取得的，如果传入值为0会导致丢失，改为了`value??default`。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #14367 
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
