### PR TITLE
fix(runner): 修复 web 端组件导出参数问题

### DIFF
--- a/packages/taro-mini-runner/src/index.ts
+++ b/packages/taro-mini-runner/src/index.ts
@@ -9,13 +9,15 @@ import buildConf from './webpack/build.conf'
 import { makeConfig } from './webpack/chain'
 
 import type { Func } from '@tarojs/taro/types/compile'
+import type { IModifyChainData } from '@tarojs/taro/types/compile/hooks'
 import type { IBuildConfig } from './utils/types'
 
-const customizeChain = async (chain, modifyWebpackChainFunc: Func, customizeFunc?: Func) => {
+const customizeChain = async (chain, modifyWebpackChainFunc: Func, customizeFunc?: IBuildConfig['webpackChain']) => {
+  const data: IModifyChainData = {
+    componentConfig
+  }
   if (modifyWebpackChainFunc instanceof Function) {
-    await modifyWebpackChainFunc(chain, webpack, {
-      componentConfig
-    })
+    await modifyWebpackChainFunc(chain, webpack, data)
   }
   if (customizeFunc instanceof Function) {
     customizeFunc(chain, webpack, META_TYPE)

--- a/packages/taro-service/src/utils/types.ts
+++ b/packages/taro-service/src/utils/types.ts
@@ -1,6 +1,6 @@
 import type helper from '@tarojs/helper'
 import type { IProjectConfig } from '@tarojs/taro/types/compile'
-import type { IModifyWebpackChain } from '@tarojs/taro/types/compile/hooks'
+import type { IModifyChainData } from '@tarojs/taro/types/compile/hooks'
 import type joi from 'joi'
 import type Webpack from 'webpack'
 import type Chain from 'webpack-chain'
@@ -138,7 +138,7 @@ export declare interface IPluginContext {
   /**
    * 编译中修改 webpack 配置，在这个钩子中，你可以对 webpackChain 作出想要的调整，等同于配置 [`webpackChain`](./config-detail.md#miniwebpackchain)
    */
-  modifyWebpackChain: (fn: (args: { chain: Chain, webpack: typeof Webpack, data?: IModifyWebpackChain }) => void) => void
+  modifyWebpackChain: (fn: (args: { chain: Chain, webpack: typeof Webpack, data?: IModifyChainData }) => void) => void
   /**
    * 修改编译后的结果
    */

--- a/packages/taro-webpack-runner/src/index.ts
+++ b/packages/taro-webpack-runner/src/index.ts
@@ -11,14 +11,19 @@ import baseDevServerOption from './config/devServer.conf'
 import prodConf from './config/prod.conf'
 import { addHtmlSuffix, addLeadingSlash, AppHelper, formatOpenHost, parsePublicPath, stripBasename, stripTrailingSlash } from './utils'
 import { makeConfig } from './utils/chain'
+import { componentConfig } from './utils/component'
 import { bindDevLogger, bindProdLogger, printBuildError } from './utils/logHelper'
 
 import type { Func } from '@tarojs/taro/types/compile'
+import type { IModifyChainData } from '@tarojs/taro/types/compile/hooks'
 import type { BuildConfig } from './utils/types'
 
-export const customizeChain = async (chain, modifyWebpackChainFunc: Func, customizeFunc?: Func) => {
+export const customizeChain = async (chain, modifyWebpackChainFunc: Func, customizeFunc?: BuildConfig['webpackChain']) => {
+  const data: IModifyChainData = {
+    componentConfig
+  }
   if (modifyWebpackChainFunc instanceof Function) {
-    await modifyWebpackChainFunc(chain, webpack)
+    await modifyWebpackChainFunc(chain, webpack, data)
   }
   if (customizeFunc instanceof Function) {
     customizeFunc(chain, webpack)

--- a/packages/taro-webpack-runner/src/plugins/TaroComponentsExportsPlugin.ts
+++ b/packages/taro-webpack-runner/src/plugins/TaroComponentsExportsPlugin.ts
@@ -82,7 +82,8 @@ export default class TaroComponentsExportsPlugin {
               const name = toDashed(dependency.name)
               const taroName = `taro-${name}`
               // Note: Vue2 目前无法解析，需要考虑借助 componentConfig.includes 优化
-              if (this.options?.framework === FRAMEWORK_MAP.VUE ? !componentConfig.includes.has(name) : !this.#componentsExports.has(taroName)) {
+              const isIncluded = componentConfig.includes.has(name) || this.#componentsExports.has(taroName)
+              if (!isIncluded || componentConfig.exclude.has(name)) {
                 // Note: 使用 Null 依赖替换不需要的依赖，如果使用 `dependency.disconnect` 移除会抛出 `MODULE_NOT_FOUND` 错误
                 return new NullDependency()
               }

--- a/packages/taro-webpack-runner/src/plugins/TaroComponentsExportsPlugin.ts
+++ b/packages/taro-webpack-runner/src/plugins/TaroComponentsExportsPlugin.ts
@@ -71,7 +71,7 @@ export default class TaroComponentsExportsPlugin {
         const module = Array.from(modules).find((e: any) => e.rawRequest === taroJsComponents) as any
         if (!module) return
         // Note: 仅在生产环境使用
-        if (compiler.options.mode === 'production') {
+        if (compiler.options.mode === 'production' && !componentConfig.includeAll) {
           if (this.#componentsExports.size > 0) {
             compilation.dependencyTemplates.set(
               NullDependency,

--- a/packages/taro-webpack-runner/src/plugins/TaroComponentsExportsPlugin.ts
+++ b/packages/taro-webpack-runner/src/plugins/TaroComponentsExportsPlugin.ts
@@ -4,9 +4,10 @@ import { toDashed } from '@tarojs/shared'
 import { componentConfig } from '../utils/component'
 
 import type { Func } from '@tarojs/taro/types/compile'
+import type AcornWalk from 'acorn-walk'
 import type { Compiler } from 'webpack'
 
-const walk = require('acorn-walk')
+const walk = require('acorn-walk') as typeof AcornWalk
 const NullDependency = require('webpack/lib/dependencies/NullDependency')
 
 const PLUGIN_NAME = 'TaroComponentsExportsPlugin'
@@ -14,6 +15,20 @@ const PLUGIN_NAME = 'TaroComponentsExportsPlugin'
 interface IOptions {
   framework: FRAMEWORK_MAP
   onParseCreateElement?: Func
+}
+
+function isRenderNode (node: acorn.Node, ancestors: any = []): boolean {
+  let renderFn
+  const hasRenderMethod = ancestors.some((ancestor) => {
+    if (ancestor.type === 'FunctionExpression' && ancestor?.id?.name === 'render') {
+      renderFn = ancestor.params[0]?.name
+      return true
+    } else {
+      return false
+    }
+  })
+  // @ts-ignore
+  return hasRenderMethod && node.callee.name === renderFn
 }
 
 export default class TaroComponentsExportsPlugin {
@@ -31,7 +46,8 @@ export default class TaroComponentsExportsPlugin {
       normalModuleFactory.hooks.parser.for('javascript/auto').tap(PLUGIN_NAME, (parser) => {
         parser.hooks.program.tap(PLUGIN_NAME, (program) => {
           walk.simple(program, {
-            CallExpression: node => {
+            CallExpression: (node, ancestors) => {
+              // @ts-ignore
               const callee = node.callee
               if (callee.type === 'MemberExpression') {
                 if (callee.property.name !== 'createElement') {
@@ -40,23 +56,24 @@ export default class TaroComponentsExportsPlugin {
               } else {
                 const nameOfCallee = callee.name
                 if (
-                  // 兼容 react17 new jsx transtrom
+                  // 兼容 react17 new jsx transform
                   nameOfCallee !== '_jsx' && nameOfCallee !== '_jsxs' &&
                   // 兼容 Vue 3.0 渲染函数及 JSX
                   !(nameOfCallee && nameOfCallee.includes('createVNode')) &&
                   !(nameOfCallee && nameOfCallee.includes('createBlock')) &&
                   !(nameOfCallee && nameOfCallee.includes('createElementVNode')) &&
                   !(nameOfCallee && nameOfCallee.includes('createElementBlock')) &&
-                  !(nameOfCallee && nameOfCallee.includes('resolveComponent')) // 收集使用解析函数的组件名称
-                  // TODO: 兼容 vue 2.0 渲染函数及 JSX，函数名 h 与 _c 在压缩后太常见，需要做更多限制后才能兼容
-                  // nameOfCallee !== 'h' && nameOfCallee !== '_c'
+                  !(nameOfCallee && nameOfCallee.includes('resolveComponent')) && // 收集使用解析函数的组件名称
+                  // 兼容 Vue 2.0 渲染函数及 JSX
+                  !isRenderNode(node, ancestors)
                 ) {
                   return
                 }
               }
 
+              // @ts-ignore
               const type = node.arguments[0]
-              if (type.value) {
+              if (type?.value) {
                 this.onParseCreateElement?.(type.value, componentConfig)
                 this.#componentsExports.add(type.value)
               }

--- a/packages/taro-webpack5-runner/src/plugins/TaroComponentsExportsPlugin.ts
+++ b/packages/taro-webpack5-runner/src/plugins/TaroComponentsExportsPlugin.ts
@@ -82,7 +82,8 @@ export default class TaroComponentsExportsPlugin {
               const name = toDashed(dependency.name)
               const taroName = `taro-${name}`
               // Note: Vue2 目前无法解析，需要考虑借助 componentConfig.includes 优化
-              if (this.options?.framework === FRAMEWORK_MAP.VUE ? !componentConfig.includes.has(name) : !this.#componentsExports.has(taroName)) {
+              const isIncluded = componentConfig.includes.has(name) || this.#componentsExports.has(taroName)
+              if (!isIncluded || componentConfig.exclude.has(name)) {
                 /** Note: 使用 Null 依赖替换不需要的依赖
                  * - 果使用 `compilation.moduleGraph.removeConnection` 移除会导致引用问题；
                  * - 使用 compilation.moduleGraph.getConnection(dependency)?.setActive 会残留依赖名称，轻微影包胞体大小

--- a/packages/taro-webpack5-runner/src/plugins/TaroComponentsExportsPlugin.ts
+++ b/packages/taro-webpack5-runner/src/plugins/TaroComponentsExportsPlugin.ts
@@ -71,7 +71,7 @@ export default class TaroComponentsExportsPlugin {
         const module: NormalModule = Array.from(modules).find((e: any) => e.rawRequest === taroJsComponents) as any
         if (!module) return
         // Note: 仅在生产环境使用
-        if (compiler.options.mode === 'production') {
+        if (compiler.options.mode === 'production' && !componentConfig.includeAll) {
           if (this.#componentsExports.size > 0) {
             compilation.dependencyTemplates.set(
               NullDependency,

--- a/packages/taro-webpack5-runner/src/plugins/TaroComponentsExportsPlugin.ts
+++ b/packages/taro-webpack5-runner/src/plugins/TaroComponentsExportsPlugin.ts
@@ -4,9 +4,10 @@ import { toDashed } from '@tarojs/shared'
 import { componentConfig } from '../utils/component'
 
 import type { Func } from '@tarojs/taro/types/compile'
+import type AcornWalk from 'acorn-walk'
 import type { Compiler, NormalModule } from 'webpack'
 
-const walk = require('acorn-walk')
+const walk = require('acorn-walk') as typeof AcornWalk
 const NullDependency = require('webpack/lib/dependencies/NullDependency')
 
 const PLUGIN_NAME = 'TaroComponentsExportsPlugin'
@@ -16,6 +17,21 @@ interface IOptions {
   onParseCreateElement?: Func
 }
 
+export function isRenderNode (node: acorn.Node, ancestors: any = []): boolean {
+  let renderFn
+  const hasRenderMethod = ancestors.some((ancestor) => {
+    if (ancestor.type === 'FunctionExpression' && ancestor?.id?.name === 'render') {
+      renderFn = ancestor.params[0]?.name
+      return true
+    } else {
+      return false
+    }
+  })
+  // @ts-ignore
+  return hasRenderMethod && node.callee.name === renderFn
+}
+
+// TODO 合并 TaroNormalModulesPlugin 逻辑
 export default class TaroComponentsExportsPlugin {
   onParseCreateElement?: Func
   #componentsExports: Set<string>
@@ -31,8 +47,10 @@ export default class TaroComponentsExportsPlugin {
       normalModuleFactory.hooks.parser.for('javascript/auto').tap(PLUGIN_NAME, (parser) => {
         parser.hooks.program.tap(PLUGIN_NAME, (program) => {
           walk.simple(program, {
-            CallExpression: node => {
+            CallExpression: (node, ancestors) => {
+              // @ts-ignore
               const callee = node.callee
+
               if (callee.type === 'MemberExpression') {
                 if (callee.property.name !== 'createElement') {
                   return
@@ -40,23 +58,24 @@ export default class TaroComponentsExportsPlugin {
               } else {
                 const nameOfCallee = callee.name
                 if (
-                  // 兼容 react17 new jsx transtrom
+                  // 兼容 react17 new jsx transform
                   nameOfCallee !== '_jsx' && nameOfCallee !== '_jsxs' &&
                   // 兼容 Vue 3.0 渲染函数及 JSX
                   !(nameOfCallee && nameOfCallee.includes('createVNode')) &&
                   !(nameOfCallee && nameOfCallee.includes('createBlock')) &&
                   !(nameOfCallee && nameOfCallee.includes('createElementVNode')) &&
                   !(nameOfCallee && nameOfCallee.includes('createElementBlock')) &&
-                  !(nameOfCallee && nameOfCallee.includes('resolveComponent')) // 收集使用解析函数的组件名称
-                  // TODO: 兼容 vue 2.0 渲染函数及 JSX，函数名 h 与 _c 在压缩后太常见，需要做更多限制后才能兼容
-                  // nameOfCallee !== 'h' && nameOfCallee !== '_c'
+                  !(nameOfCallee && nameOfCallee.includes('resolveComponent')) && // 收集使用解析函数的组件名称
+                  // 兼容 Vue 2.0 渲染函数及 JSX
+                  !isRenderNode(node, ancestors)
                 ) {
                   return
                 }
               }
 
+              // @ts-ignore
               const type = node.arguments[0]
-              if (type.value) {
+              if (type?.value) {
                 this.onParseCreateElement?.(type.value, componentConfig)
                 this.#componentsExports.add(type.value)
               }

--- a/packages/taro-webpack5-runner/src/plugins/TaroNormalModulesPlugin.ts
+++ b/packages/taro-webpack5-runner/src/plugins/TaroNormalModulesPlugin.ts
@@ -1,26 +1,15 @@
 import TaroSingleEntryDependency from '../dependencies/TaroSingleEntryDependency'
 import { componentConfig, componentNameSet, elementNameSet } from '../utils/component'
+import { isRenderNode } from './TaroComponentsExportsPlugin'
 import TaroNormalModule, { TaroBaseNormalModule } from './TaroNormalModule'
 
 import type { Func } from '@tarojs/taro/types/compile'
+import type AcornWalk from 'acorn-walk'
 import type { Compiler } from 'webpack'
 
-const walk = require('acorn-walk')
+const walk = require('acorn-walk') as typeof AcornWalk
 
 const PLUGIN_NAME = 'TaroNormalModulesPlugin'
-
-function isRenderNode (node, ancestors): boolean {
-  let renderFn
-  const hasRenderMethod = ancestors.some((ancestor) => {
-    if (ancestor.type === 'FunctionExpression' && ancestor?.id?.name === 'render') {
-      renderFn = ancestor.params[0]?.name
-      return true
-    } else {
-      return false
-    }
-  })
-  return hasRenderMethod && node.callee.name === renderFn
-}
 
 export default class TaroNormalModulesPlugin {
   isCache = true
@@ -70,6 +59,7 @@ export default class TaroNormalModulesPlugin {
 
           walk.ancestor(ast, {
             CallExpression: (node, ancestors) => {
+              // @ts-ignore
               const callee = node.callee
 
               if (callee.type === 'MemberExpression') {
@@ -79,7 +69,7 @@ export default class TaroNormalModulesPlugin {
               } else {
                 const nameOfCallee = callee.name
                 if (
-                  // 兼容 react17 new jsx transtrom
+                  // 兼容 react17 new jsx transform
                   nameOfCallee !== '_jsx' && nameOfCallee !== '_jsxs' &&
                   // 兼容 Vue 3.0 渲染函数及 JSX
                   !(nameOfCallee && nameOfCallee.includes('createVNode')) &&
@@ -94,6 +84,7 @@ export default class TaroNormalModulesPlugin {
                 }
               }
 
+              // @ts-ignore
               const [type, prop] = node.arguments
               const componentName = type.name
 
@@ -121,9 +112,9 @@ export default class TaroNormalModulesPlugin {
               const props = prop.properties
                 .filter(p => p.type === 'Property' && p.key.type === 'Identifier' && p.key.name !== 'children' && p.key.name !== 'id')
               const res = props.map(p => p.key.name).join('|')
-        
+
               props.forEach(p => attrs.add(p.key.name))
-          
+
               currentModule.collectProps[type.value] = res
             },
           })

--- a/packages/taro-webpack5-runner/src/webpack/Combination.ts
+++ b/packages/taro-webpack5-runner/src/webpack/Combination.ts
@@ -6,6 +6,7 @@ import webpack from 'webpack'
 
 import { componentConfig } from '../utils/component'
 
+import type { IModifyChainData } from '@tarojs/taro/types/compile/hooks'
 import type { IPrebundle } from '@tarojs/webpack5-prebundle'
 import type Chain from 'webpack-chain'
 import type { CommonBuildConfig, H5BuildConfig, MiniBuildConfig } from '../utils/types'
@@ -50,7 +51,7 @@ export class Combination<T extends MiniBuildConfig | H5BuildConfig = CommonBuild
     this.process(this.config)
     await this.post(this.config, this.chain)
   }
-  
+
   process (_config: Partial<T>) {}
 
   async pre (rawConfig: T) {
@@ -69,8 +70,11 @@ export class Combination<T extends MiniBuildConfig | H5BuildConfig = CommonBuild
 
   async post (config: T, chain: Chain) {
     const { modifyWebpackChain, webpackChain, onWebpackChainReady } = config
+    const data: IModifyChainData = {
+      componentConfig
+    }
     if (isFunction(modifyWebpackChain)) {
-      await modifyWebpackChain(chain, webpack, { componentConfig })
+      await modifyWebpackChain(chain, webpack, data)
     }
     if (isFunction(webpackChain)) {
       webpackChain(chain, webpack, META_TYPE)

--- a/packages/taro/types/compile/config/project.d.ts
+++ b/packages/taro/types/compile/config/project.d.ts
@@ -2,7 +2,7 @@ import type Webpack from 'webpack'
 import type Chain from 'webpack-chain'
 import { type Input } from 'postcss'
 import type { Compiler } from '../compiler'
-import type { IModifyWebpackChain } from '../hooks'
+import type { IModifyChainData } from '../hooks'
 import type { ICopyOptions, IOption, ISassOptions, TogglableOptions } from './util'
 import type { IH5Config } from './h5'
 import type { IMiniAppConfig } from './mini'
@@ -179,7 +179,7 @@ export interface IProjectBaseConfig {
   /**
    * 编译中修改 webpack 配置，在这个钩子中，你可以对 webpackChain 作出想要的调整，等同于配置 [`webpackChain`](./config-detail#miniwebpackchain)
    */
-  modifyWebpackChain?: (chain: Chain, webpack: typeof Webpack, data: IModifyWebpackChain) => Promise<any>
+  modifyWebpackChain?: (chain: Chain, webpack: typeof Webpack, data: IModifyChainData) => Promise<any>
 
   /**
    * 修改编译过程中的页面组件配置

--- a/packages/taro/types/compile/hooks.d.ts
+++ b/packages/taro/types/compile/hooks.d.ts
@@ -8,6 +8,6 @@ export interface IComponentConfig {
   includeAll: boolean
 }
 
-export interface IModifyWebpackChain {
+export interface IModifyChainData {
   componentConfig?: IComponentConfig
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

- 修复 webpack-runner 钩子不支持修改 componentConfig 问题
- 修复 h5 端 componentConfig.includeAll 参数失效问题
- 优化 modifyConfig 参数类型，预备 modifyViteConfig 使用

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: https://github.com/NervJS/taro/issues/14382#issuecomment-1681755247
- [x] TypeScript 类型定义修改(Typings)

**这个 PR 涉及以下平台:**

- [x] Web 平台（H5）