### PR TITLE
fix(weapp): 修改Textarea组件confirm-hold属性的类型

### DIFF
--- a/packages/taro-components/types/Textarea.d.ts
+++ b/packages/taro-components/types/Textarea.d.ts
@@ -99,7 +99,7 @@ interface TextareaProps extends StandardProps, FormItemProps {
   /** 点击键盘右下角按钮时是否保持键盘不收起
    * @supported weapp, swan, tt
    */
-  confirmHold?: string
+  confirmHold?: boolean
   /** 组件名字，用于表单提交获取数据。
    * @supported alipay
    */


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

更改`Textarea`组件的`confim-hold`属性的类型

参考: 
微信小程序文档： https://developers.weixin.qq.com/miniprogram/dev/component/textarea.html#%E9%80%9A%E7%94%A8%E5%B1%9E%E6%80%A7

字节小程序文档：
https://developer.open-douyin.com/docs/resource/zh-CN/mini-app/develop/component/list/textarea/




**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [x] 百度小程序
- [x] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
