### PR TITLE
fix(plugin-inject): 修复@tarojs/plugin-inject配置在H5端编译报错问题

### DIFF
--- a/packages/taro-plugin-inject/src/index.ts
+++ b/packages/taro-plugin-inject/src/index.ts
@@ -1,5 +1,5 @@
 
-import { isArray, isFunction, isObject, isString, isWebPlatform } from '@tarojs/shared'
+import { isArray, isFunction, isObject, isString } from '@tarojs/shared'
 import * as path from 'path'
 
 import type { IPluginContext, TaroPlatformBase } from '@tarojs/service'
@@ -18,7 +18,6 @@ export interface IOptions {
 }
 
 export default (ctx: IPluginContext, options: IOptions) => {
-  if(isWebPlatform()) return
   const fs = ctx.helper.fs
 
   ctx.modifyWebpackChain(({ chain }) => {
@@ -41,7 +40,8 @@ export default (ctx: IPluginContext, options: IOptions) => {
       } = options
 
       const template = platform.template
-
+      if(!template) return
+      
       if (isArray(voidComponents)) {
         voidComponents.forEach(el => template.voidElements.add(el))
       } else if (isFunction(voidComponents)) {

--- a/packages/taro-plugin-inject/src/index.ts
+++ b/packages/taro-plugin-inject/src/index.ts
@@ -1,5 +1,5 @@
 
-import { isArray, isFunction, isObject, isString } from '@tarojs/shared'
+import { isArray, isFunction, isObject, isString, isWebPlatform } from '@tarojs/shared'
 import * as path from 'path'
 
 import type { IPluginContext, TaroPlatformBase } from '@tarojs/service'
@@ -18,6 +18,7 @@ export interface IOptions {
 }
 
 export default (ctx: IPluginContext, options: IOptions) => {
+  if(isWebPlatform()) return
   const fs = ctx.helper.fs
 
   ctx.modifyWebpackChain(({ chain }) => {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
通过 @tarojs/plugin-inject 添加自定义组件配置之后，运行 H5 端编译时会报错。
配置：
<img width="422" alt="image" src="https://github.com/NervJS/taro/assets/13111739/e5e65a35-c8f9-4ef8-9c8b-c3414b945083">
报错：
<img width="729" alt="image" src="https://github.com/NervJS/taro/assets/13111739/65d65f81-8359-4807-abeb-64bb48eb4fb7">

原因：主要是 @tarojs/service 模块的 platform-plugin-base 做了 mini 和 web 拆分之后，web 端也会调用 onSetupClose 方法，并最终触发了 plugin-inject 中的自定义组件注册逻辑。
<img width="909" alt="image" src="https://github.com/NervJS/taro/assets/13111739/096747c9-aa7d-45bd-983b-2f9686fae298">

处理方式： web 端不需要执行 plugin-inject 逻辑，所以判断平台类型进行拦截即可。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
