### PR TITLE
fix(style): use 100% instand of 100vh

### DIFF
--- a/packages/taro-components-react/src/components/pull-down-refresh/style/index.css
+++ b/packages/taro-components-react/src/components/pull-down-refresh/style/index.css
@@ -2,13 +2,12 @@
   transform-origin: left top 0px;
 }
 .rmc-pull-to-refresh-content-wrapper {
-  min-height: 100vh;
+  min-height: 100%;
 }
 
 .rmc-pull-to-refresh-transition {
   transition: transform 0.3s;
 }
-
 
 @keyframes rmc-pull-to-refresh-indicator {
   50% {

--- a/packages/taro-components/src/components/pull-to-refresh/style/index.scss
+++ b/packages/taro-components/src/components/pull-to-refresh/style/index.scss
@@ -3,7 +3,7 @@
 }
 
 .rmc-pull-to-refresh-content-wrapper {
-  min-height: 100vh;
+  min-height: 100%;
 }
 
 .rmc-pull-to-refresh-transition {

--- a/packages/taro-components/src/components/video/style/index.scss
+++ b/packages/taro-components/src/components/video/style/index.scss
@@ -48,6 +48,7 @@
   width: 100%;
   height: 100%;
   object-position: inherit;
+  display: block;
 }
 
 .taro-video-cover {

--- a/packages/taro-components/src/global.css
+++ b/packages/taro-components/src/global.css
@@ -1,1 +1,7 @@
 @import url(../node_modules/weui/dist/style/weui.min.css);
+
+html,
+body {
+  width: 100%;
+  height: 100%;
+}

--- a/packages/taro-router/src/style.ts
+++ b/packages/taro-router/src/style.ts
@@ -37,10 +37,6 @@ export function loadRouterStyle (usingWindowScroll) {
     height: 100%;
   }
 
-  .taro-tabbar__container .taro_router {
-    min-height: calc(100vh - 50px);
-  }
-
   .taro_page {
     width: 100%;
     height: 100%;

--- a/packages/taro-router/src/style.ts
+++ b/packages/taro-router/src/style.ts
@@ -35,7 +35,6 @@ export function loadRouterStyle (usingWindowScroll) {
     position: relative;
     width: 100%;
     height: 100%;
-    min-height: 100vh;
   }
 
   .taro-tabbar__container .taro_router {


### PR DESCRIPTION
There will be scrollbar if use min-height:100vh on Chrome. Better choice is use height:100%.

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

使用 height:100% 代替 min-height:100vh 解决 chrome浏览器会有滚动条问题；
给 video 标签设置 display:block 以便于调整大小和定位

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #14312
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
