### PR TITLE
fix(route): 不显示最后一个注入以外的非 tab 页面 fix #14478

### DIFF
--- a/packages/taro-components/src/components/tabbar/style/index.scss
+++ b/packages/taro-components/src/components/tabbar/style/index.scss
@@ -3,6 +3,10 @@ body {
   height: 100%;
 }
 
+:root {
+  --taro-tabbar-height: 50px;
+}
+
 #app {
   height: 100%;
 }
@@ -33,7 +37,7 @@ body {
   &__tabbar {
     position: relative;
     width: 100%;
-    height: 50px;
+    height: var(--taro-tabbar-height);
     transition: bottom 0.2s, top 0.2s;
 
     &-top {

--- a/packages/taro-router/src/router/page.ts
+++ b/packages/taro-router/src/router/page.ts
@@ -13,12 +13,6 @@ import stacks from './stack'
 import type { PageConfig, RouterAnimate } from '@tarojs/taro'
 import type { Route, SpaRouterConfig } from '../../types/router'
 
-function setDisplay (el?: HTMLElement | null, type = '') {
-  if (el) {
-    el.style.display = type
-  }
-}
-
 export default class PageHandler {
   protected config: SpaRouterConfig
   protected readonly defaultAnimation: RouterAnimate = { duration: 300, delay: 50 }
@@ -202,7 +196,7 @@ export default class PageHandler {
     const param = this.getQuery(stampId, '', page.options)
     let pageEl = this.getPageContainer(page)
     if (pageEl) {
-      setDisplay(pageEl)
+      pageEl.classList.remove('taro_page_shade')
       this.isTabBar(this.pathname) && pageEl.classList.add('taro_tabbar_page')
       this.addAnimation(pageEl, pageNo === 0)
       page.onShow?.()
@@ -263,7 +257,7 @@ export default class PageHandler {
     const param = this.getQuery(page['$taroParams']['stamp'], '', page.options)
     let pageEl = this.getPageContainer(page)
     if (pageEl) {
-      setDisplay(pageEl)
+      pageEl.classList.remove('taro_page_shade')
       this.addAnimation(pageEl, pageNo === 0)
       page.onShow?.()
       this.bindPageEvents(page, pageConfig)
@@ -289,12 +283,12 @@ export default class PageHandler {
       if (this.hideTimer) {
         clearTimeout(this.hideTimer)
         this.hideTimer = null
-        setDisplay(this.lastHidePage, 'none')
+        pageEl.classList.add('taro_page_shade')
       }
       this.lastHidePage = pageEl
       this.hideTimer = setTimeout(() => {
         this.hideTimer = null
-        setDisplay(this.lastHidePage, 'none')
+        pageEl.classList.add('taro_page_shade')
       }, this.animationDuration + this.animationDelay)
       page.onHide?.()
     } else {

--- a/packages/taro-router/src/style.ts
+++ b/packages/taro-router/src/style.ts
@@ -3,7 +3,7 @@
  */
 export function loadAnimateStyle (ms = 300) {
   const css = `
-.taro_router .taro_page {
+.taro_router > .taro_page {
   position: absolute;
   left: 0;
   top: 0;
@@ -15,13 +15,17 @@ export function loadAnimateStyle (ms = 300) {
   z-index: 0;
 }
 
-.taro_router .taro_page.taro_tabbar_page,
-.taro_router .taro_page.taro_page_show.taro_page_stationed {
+.taro_router > .taro_page.taro_tabbar_page,
+.taro_router > .taro_page.taro_page_show.taro_page_stationed {
   transform: none;
 }
 
-.taro_router .taro_page.taro_page_show {
+.taro_router > .taro_page.taro_page_show {
   transform: translate(0, 0);
+}
+
+.taro_router > .taro_page.taro_page_show.taro_page_stationed:not(.taro_tabbar_page):not(:last-child) {
+  display: none;
 }`
   addStyle(css)
 }

--- a/packages/taro-router/src/style.ts
+++ b/packages/taro-router/src/style.ts
@@ -24,7 +24,8 @@ export function loadAnimateStyle (ms = 300) {
   transform: translate(0, 0);
 }
 
-.taro_router > .taro_page.taro_page_show.taro_page_stationed:not(.taro_tabbar_page):not(:last-child) {
+.taro_page_shade,
+.taro_router > .taro_page.taro_page_show.taro_page_stationed:not(.taro_page_shade):not(.taro_tabbar_page):not(:last-child) {
   display: none;
 }`
   addStyle(css)

--- a/packages/taro-router/src/style.ts
+++ b/packages/taro-router/src/style.ts
@@ -54,10 +54,8 @@ export function loadRouterStyle (usingWindowScroll) {
 
   .taro-tabbar__container .taro-tabbar__panel {
     overflow: hidden;
-  }
-
-  .taro-tabbar__container .taro_page.taro_tabbar_page {
-    max-height: calc(100vh - 50px);
+    max-height: calc(100vh - var(--taro-tabbar-height) - constant(safe-area-inset-bottom));
+    max-height: calc(100vh - var(--taro-tabbar-height) - env(safe-area-inset-bottom));
   }
 `
   addStyle(css)


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

- 通过 css 选择器控制，避免多个非 tab 页面同时显示
  > 如果 style 切换失败，则通过修改 class 也会在该情况下失效，故而选择改用 css 控制（理论上不存在除去 tabbar 页面以外，需要显示前序路由的情况）
- 改用 css 变量控制 tabbar 高度

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #14478
- [x] 代码重构(Refactor)

**这个 PR 涉及以下平台:**
- [x] Web 平台（H5）
