### PR TITLE
fix(components): add image default height & width

### DIFF
--- a/packages/taro-components/src/components/image/style/index.scss
+++ b/packages/taro-components/src/components/image/style/index.scss
@@ -6,8 +6,8 @@ taro-image-core {
   display: inline-block;
   overflow: hidden;
   position: relative;
-  width: auto;
-  height: auto;
+  width: 320px;
+  height: 240px;
   font-size: 0;
 }
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

按照小程序规范添加 image 组件默认宽高，避免部分模式由于缺少宽高导致无法正常显示

<img width="756" alt="image" src="https://github.com/NervJS/taro/assets/24262362/425210f7-8096-44f9-9a5a-25754d38215b">

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #

**这个 PR 涉及以下平台:**

- [x] Web 平台（H5）
