### PR TITLE
fix: 修复 file-loader 和 webpack 使用 posix 的路径形式，导致拼接路径在 windows 系统上失效的问题

### DIFF
--- a/packages/taro-mini-runner/src/webpack/chain.ts
+++ b/packages/taro-mini-runner/src/webpack/chain.ts
@@ -443,7 +443,7 @@ export const getModule = (appPath: string, {
           // 因此在 webpack4 中如果包含 sourceDir，证明是在 src 内的路径
           if (resourcePath.includes(sourceDir)) {
             // 直接将 /xxx/src/yyy/zzz.wxml 转换成 yyy/zzz.wxml 即可
-            return resourcePath.replace(sourceDir + path.sep, '').replace(/node_modules/gi, 'npm')
+            return resourcePath.replace(sourceDir + '/', '').replace(/node_modules/gi, 'npm')
           } else {
             // 否则，证明是外层，存在一下两种可能
             // resourcePath /xxx/uuu/aaa/node_modules/yy/zzz.wxml
@@ -451,7 +451,7 @@ export const getModule = (appPath: string, {
             
             // resourcePath /xxx/uuu/aaa/bbb/abc/yy/zzz.wxml
             // --> result: bbb/abc/yy/zzz.wxml
-            return resourcePath.replace(appPath + path.sep, '').replace(/node_modules/gi, 'npm')
+            return resourcePath.replace(appPath + '/', '').replace(/node_modules/gi, 'npm')
           }
         },
         context: sourceDir
@@ -463,9 +463,9 @@ export const getModule = (appPath: string, {
         useRelativePath: true,
         name: (resourcePath) => {
           if (resourcePath.includes(sourceDir)) {
-            return resourcePath.replace(sourceDir + path.sep, '').replace(/node_modules/gi, 'npm')
+            return resourcePath.replace(sourceDir + '/', '').replace(/node_modules/gi, 'npm')
           } else {
-            return resourcePath.replace(appPath + path.sep, '').replace(/node_modules/gi, 'npm')
+            return resourcePath.replace(appPath + '/', '').replace(/node_modules/gi, 'npm')
           }
         },
         context: sourceDir

--- a/packages/taro-webpack5-runner/src/webpack/MiniWebpackModule.ts
+++ b/packages/taro-webpack5-runner/src/webpack/MiniWebpackModule.ts
@@ -92,7 +92,7 @@ export class MiniWebpackModule {
         generator: {
           filename ({ filename }) {
             const extname = path.extname(filename)
-            return filename.replace(sourceRoot + path.sep, '').replace(extname, fileType.templ).replace(/node_modules/gi, 'npm')
+            return filename.replace(sourceRoot + '/', '').replace(extname, fileType.templ).replace(/node_modules/gi, 'npm')
           }
         },
         use: [WebpackModule.getLoader(path.resolve(__dirname, '../loaders/miniTemplateLoader'), {
@@ -105,7 +105,7 @@ export class MiniWebpackModule {
         type: 'asset/resource',
         generator: {
           filename ({ filename }) {
-            return filename.replace(sourceRoot + path.sep, '').replace(/node_modules/gi, 'npm')
+            return filename.replace(sourceRoot + '/', '').replace(/node_modules/gi, 'npm')
           }
         },
         use: [WebpackModule.getLoader(path.resolve(__dirname, '../loaders/miniXScriptLoader'))]


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
- 修复 file-loader 和 webpack 使用 posix 的路径形式，导致拼接路径在 windows 系统上失效的问题


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #14427
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
