### PR TITLE
fix(h5): use start time if the value prop of Picker is out of range

### DIFF
--- a/packages/taro-components/src/components/picker/picker.tsx
+++ b/packages/taro-components/src/components/picker/picker.tsx
@@ -127,43 +127,45 @@ export class Picker implements ComponentInterface {
     } else if (mode === 'date') {
       const value = this.value as string
 
-      const _value = verifyDate(value) || new Date(new Date().setHours(0, 0, 0, 0)) // 没传值或值的合法性错误默认今天时间
+      let _value = verifyDate(value) || new Date(new Date().setHours(0, 0, 0, 0)) // 没传值或值的合法性错误默认今天时间
       const _start = verifyDate(start) || new Date('1970/01/01')
       const _end = verifyDate(end) || new Date('2999/01/01')
 
       // 时间区间有效性
-      if (_value >= _start && _value <= _end) {
-        const currentYear = _value.getFullYear()
-        const currentMonth = _value.getMonth() + 1
-        const currentDay = _value.getDate()
-        const yearRange = getYearRange(_start.getFullYear(), _end.getFullYear())
-        const monthRange = getMonthRange(_start, _end, currentYear)
-        const dayRange = getDayRange(_start, _end, currentYear, currentMonth)
+      if (!(_start <= _end)) {
+        throw new Error(`Picker start time must be less than end time.`)
+      }
+      if (!(_value >= _start && _value <= _end)) {
+        _value = _start
+      }
+      const currentYear = _value.getFullYear()
+      const currentMonth = _value.getMonth() + 1
+      const currentDay = _value.getDate()
+      const yearRange = getYearRange(_start.getFullYear(), _end.getFullYear())
+      const monthRange = getMonthRange(_start, _end, currentYear)
+      const dayRange = getDayRange(_start, _end, currentYear, currentMonth)
 
-        this.index = [
-          yearRange.indexOf(currentYear),
-          monthRange.indexOf(currentMonth),
-          dayRange.indexOf(currentDay)
-        ]
-        if (
-          !this.pickerDate ||
-          this.pickerDate._value.getTime() !== _value.getTime() ||
-          this.pickerDate._start.getTime() !== _start.getTime() ||
-          this.pickerDate._end.getTime() !== _end.getTime()
-        ) {
-          this.pickerDate = {
-            _value,
-            _start,
-            _end,
-            _updateValue: [
-              currentYear,
-              currentMonth,
-              currentDay
-            ]
-          }
+      this.index = [
+        yearRange.indexOf(currentYear),
+        monthRange.indexOf(currentMonth),
+        dayRange.indexOf(currentDay)
+      ]
+      if (
+        !this.pickerDate ||
+        this.pickerDate._value.getTime() !== _value.getTime() ||
+        this.pickerDate._start.getTime() !== _start.getTime() ||
+        this.pickerDate._end.getTime() !== _end.getTime()
+      ) {
+        this.pickerDate = {
+          _value,
+          _start,
+          _end,
+          _updateValue: [
+            currentYear,
+            currentMonth,
+            currentDay
+          ]
         }
-      } else {
-        throw new Error('Date Interval Error')
       }
     } else {
       throw new Error(`Picker not support "${mode}" mode.`)


### PR DESCRIPTION
#14042

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

当 picker组件传入的 value 不在 start和end 范围内时，默认采用start值，不报错

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #14042
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
