### PR TITLE
fix: h5模式下app.config.js中animation：false路由调整问题修复

### DIFF
--- a/packages/taro-router/src/style.ts
+++ b/packages/taro-router/src/style.ts
@@ -23,11 +23,7 @@ export function loadAnimateStyle (ms = 300) {
 .taro_router > .taro_page.taro_page_show {
   transform: translate(0, 0);
 }
-
-.taro_page_shade,
-.taro_router > .taro_page.taro_page_show.taro_page_stationed:not(.taro_page_shade):not(.taro_tabbar_page):not(:last-child) {
-  display: none;
-}`
+`
   addStyle(css)
 }
 
@@ -61,7 +57,8 @@ export function loadRouterStyle (usingWindowScroll: boolean) {
     max-height: calc(100vh - var(--taro-tabbar-height) - constant(safe-area-inset-bottom));
     max-height: calc(100vh - var(--taro-tabbar-height) - env(safe-area-inset-bottom));
   }
-  .taro_page_shade{
+  .taro_page_shade,
+  .taro_router > .taro_page.taro_page_show.taro_page_stationed:not(.taro_page_shade):not(.taro_tabbar_page):not(:last-child) {
     display: none;
   }
 `

--- a/packages/taro-router/src/style.ts
+++ b/packages/taro-router/src/style.ts
@@ -57,6 +57,7 @@ export function loadRouterStyle (usingWindowScroll: boolean) {
     max-height: calc(100vh - var(--taro-tabbar-height) - constant(safe-area-inset-bottom));
     max-height: calc(100vh - var(--taro-tabbar-height) - env(safe-area-inset-bottom));
   }
+
   .taro_page_shade,
   .taro_router > .taro_page.taro_page_show.taro_page_stationed:not(.taro_page_shade):not(.taro_tabbar_page):not(:last-child) {
     display: none;

--- a/packages/taro-router/src/style.ts
+++ b/packages/taro-router/src/style.ts
@@ -61,6 +61,9 @@ export function loadRouterStyle (usingWindowScroll: boolean) {
     max-height: calc(100vh - var(--taro-tabbar-height) - constant(safe-area-inset-bottom));
     max-height: calc(100vh - var(--taro-tabbar-height) - env(safe-area-inset-bottom));
   }
+  .taro_page_shade{
+    display: none;
+  }
 `
   addStyle(css)
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

当配置了app.config.js中的animation为false的情况下，发生路由跳转。上一个页面元素节点没有被隐藏

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #14674
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
