### PR TITLE
fix: window平台开启prebuild后 路径解析错误导致 app required 路径错误

### DIFF
--- a/packages/taro-webpack5-prebundle/src/utils/webpack.ts
+++ b/packages/taro-webpack5-prebundle/src/utils/webpack.ts
@@ -12,7 +12,7 @@ const { ConcatSource } = sources
 export function addRequireToSource (id: string, modules: sources.Source, commonChunks: (Chunk | { name: string })[]) {
   const source = new ConcatSource()
   commonChunks.forEach(chunkItem => {
-    source.add(`require(${JSON.stringify(promoteRelativePath(path.relative(id, chunkItem.name)))});\n`)
+    source.add(`require(${JSON.stringify(promoteRelativePath(path.normalize(path.relative(id, chunkItem.name))))});\n`)
   })
   source.add('\n')
   source.add(modules)


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

window 平台构建开启 prebuild后，dist/app.js 中 require prebuild 路径有问题
<img width="901" alt="image" src="https://github.com/NervJS/taro/assets/18748635/b2b4618f-25c5-4d81-98fd-f28c2bc1128b">

需要require前兼容window路径

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
