### PR TITLE
fix: 视频组件，浏览器退出全屏出错

### DIFF
--- a/packages/taro-components/src/components/video/video.tsx
+++ b/packages/taro-components/src/components/video/video.tsx
@@ -548,9 +548,9 @@ export class Video implements ComponentInterface {
         this.videoRef[screenFn.requestFullscreen]({ navigationUI: 'auto' })
       }, 0)
     } else if (!fromBrowser) {
+      // 全屏后，"退出全屏"是浏览器按钮是浏览器内部按钮，非html按钮，点击"退出全屏"按钮是浏览器内部实现功能。此时再次调用exitFullscreen反而会报错，因此不再调用
       document[screenFn.exitFullscreen]()
     }
-    // 全屏后，"退出全屏"是浏览器按钮是浏览器内部按钮，非html按钮，点击"退出全屏"按钮是浏览器内部实现功能。此时再次调用exitFullscreen反而会报错，因此不再调用
   }
 
   toggleMute = (e: MouseEvent) => {

--- a/packages/taro-components/src/components/video/video.tsx
+++ b/packages/taro-components/src/components/video/video.tsx
@@ -548,7 +548,7 @@ export class Video implements ComponentInterface {
         this.videoRef[screenFn.requestFullscreen]({ navigationUI: 'auto' })
       }, 0)
     } else if (!fromBrowser) {
-      // 全屏后，"退出全屏"是浏览器按钮是浏览器内部按钮，非html按钮，点击"退出全屏"按钮是浏览器内部实现功能。此时再次调用exitFullscreen反而会报错，因此不再调用
+      // Note: 全屏后，"退出全屏"是浏览器按钮是浏览器内部按钮，非html按钮，点击"退出全屏"按钮是浏览器内部实现功能。此时再次调用exitFullscreen反而会报错，因此不再调用
       document[screenFn.exitFullscreen]()
     }
   }

--- a/packages/taro-components/src/components/video/video.tsx
+++ b/packages/taro-components/src/components/video/video.tsx
@@ -547,7 +547,7 @@ export class Video implements ComponentInterface {
       setTimeout(() => {
         this.videoRef[screenFn.requestFullscreen]({ navigationUI: 'auto' })
       }, 0)
-    } else if(!fromBrowser){
+    } else if (!fromBrowser) {
       document[screenFn.exitFullscreen]()
     }
     // 全屏后，"退出全屏"是浏览器按钮是浏览器内部按钮，非html按钮，点击"退出全屏"按钮是浏览器内部实现功能。此时再次调用exitFullscreen反而会报错，因此不再调用

--- a/packages/taro-components/src/components/video/video.tsx
+++ b/packages/taro-components/src/components/video/video.tsx
@@ -531,11 +531,11 @@ export class Video implements ComponentInterface {
     // 全屏后，"退出"走的是浏览器事件，在此同步状态
     const timestamp = new Date().getTime()
     if (!e.detail && this.isFullScreen && !document[screenFn.fullscreenElement] && timestamp - this.fullScreenTimestamp > 100) {
-      this.toggleFullScreen(false)
+      this.toggleFullScreen(false, true)
     }
   }
 
-  toggleFullScreen = (isFullScreen = !this.isFullScreen) => {
+  toggleFullScreen = (isFullScreen = !this.isFullScreen, fromBrowser = false) => {
     this.isFullScreen = isFullScreen // this.videoRef?.['webkitDisplayingFullscreen']
     this.controlsRef.toggleVisibility(true)
     this.fullScreenTimestamp = new Date().getTime()
@@ -547,9 +547,10 @@ export class Video implements ComponentInterface {
       setTimeout(() => {
         this.videoRef[screenFn.requestFullscreen]({ navigationUI: 'auto' })
       }, 0)
-    } else {
+    } else if(!fromBrowser){
       document[screenFn.exitFullscreen]()
     }
+    // 全屏后，"退出全屏"是浏览器按钮是浏览器内部按钮，非html按钮，点击"退出全屏"按钮是浏览器内部实现功能。此时再次调用exitFullscreen反而会报错，因此不再调用
   }
 
   toggleMute = (e: MouseEvent) => {


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

**问题：** 视频组件中，全屏后点击浏览器的退出全屏按钮报错：Uncaught (in promise) TypeError : Failed to execute ‘exitFullScreen’ on ‘Document’: Document not active
**原因：** 全屏后，"退出全屏"是浏览器按钮是浏览器内部按钮，非html按钮，点击"退出全屏"按钮是浏览器内部实现功能。此时再次调用exitFullscreen反而会报错。
**修复方案：** 区分出退出全屏方法是由浏览器调用还是api调用，对浏览器调用来源的不再执行exitFullscreen方法。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
