### PR TITLE
fix: 优化loadFontFace成功回调信息以及setTabBarBadge上标显示

### DIFF
--- a/packages/taro-h5/__tests__/ui/tab-bar.test.tsx
+++ b/packages/taro-h5/__tests__/ui/tab-bar.test.tsx
@@ -120,7 +120,7 @@ describe('tabbar', () => {
 
   it('should be able to switchTab', done => {
     Taro.switchTab({
-      url: '/pages/about/about'
+      url: '/pages/about/index'
     }).then((res: any) => {
       expect(res.errMsg).toBe('switchTab:ok')
       done()

--- a/packages/taro-h5/__tests__/utils.ts
+++ b/packages/taro-h5/__tests__/utils.ts
@@ -22,7 +22,7 @@ const appConfig: any = {
     list: [{
       pagePath: '/pages/index/index', text: '首页'
     }, {
-      pagePath: '/pages/about/about', text: '关于我们'
+      pagePath: '/pages/about/index', text: '关于我们'
     }],
     mode: 'hash',
     basename: '/test/app',

--- a/packages/taro-h5/src/api/ui/fonts.ts
+++ b/packages/taro-h5/src/api/ui/fonts.ts
@@ -15,10 +15,11 @@ export const loadFontFace: typeof Taro.loadFontFace = async options => {
     try {
       await fontFace.load()
       fonts.add(fontFace)
-      return handle.success({})
+      return handle.success({ status: 'loaded' })
     } catch (error) {
       return handle.fail({
-        errMsg: error.message || error
+        status: 'error',
+        errMsg: error.message || error,
       })
     }
   } else {
@@ -59,6 +60,6 @@ export const loadFontFace: typeof Taro.loadFontFace = async options => {
 
     style.innerText = `@font-face{${innerText}}`
     document.head.appendChild(style)
-    return handle.success()
+    return handle.success({ status: 'loaded' })
   }
 }

--- a/packages/taro-h5/src/api/ui/tab-bar.ts
+++ b/packages/taro-h5/src/api/ui/tab-bar.ts
@@ -217,7 +217,7 @@ export const setTabBarBadge: typeof Taro.setTabBarBadge = (options) => {
   return new Promise((resolve, reject) => {
     Taro.eventCenter.trigger('__taroSetTabBarBadge', {
       index,
-      text,
+      text: text.replace(/[\u0391-\uFFE5]/g, 'aa').length > 4 ? '...' : text,
       successHandler: (res = {}) => handle.success(res, { resolve, reject }),
       errorHandler: (res = {}) => handle.fail(res, { resolve, reject })
     })


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
- 修改taro-h5的loadFontFace接口成功回调时反馈的信息，与微信小程序保持一致
- 修改taro-h5的setTabBarBadge接口可显示中文的长度不超过两字符


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
