### PR TITLE
fix(miniapp): 修复小程序Input组件使用async onInput回调时输入框闪烁的问题

### DIFF
--- a/packages/shared/src/runtime-hooks.ts
+++ b/packages/shared/src/runtime-hooks.ts
@@ -239,6 +239,7 @@ type ITaroHooks = {
 
   dispatchTaroEvent: (event, element) => void
   dispatchTaroEventFinish: (event, element) => void
+  modifyTaroEventReturn: (node, event, returnVal) => any
 
   modifyDispatchEvent: (event, element) => void
   injectNewStyleProperties: (styleProperties: string[]) => void
@@ -339,6 +340,8 @@ export const hooks = new TaroHooks<ITaroHooks>({
   }),
 
   dispatchTaroEventFinish: TaroHook(HOOK_TYPE.MULTI),
+
+  modifyTaroEventReturn: TaroHook(HOOK_TYPE.SINGLE, () => undefined),
 
   modifyDispatchEvent: TaroHook(HOOK_TYPE.MULTI),
 

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/bytedance.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/bytedance.spec.ts.snap
@@ -269,6 +269,13 @@ require("./taro");
                 if (event.type === "regionchange") {
                     event.type = event.detail.type;
                 }
+            },
+            modifyTaroEventReturn: function modifyTaroEventReturn(node, event, returnVal) {
+                if (node.nodeName === "pay-button") {
+                    if (event.type === "applyrefund" || event.type === "getgoodsinfo") {
+                        return returnVal;
+                    }
+                }
             }
         };
         mergeReconciler(hostConfig);

--- a/packages/taro-runtime/src/dom/element.ts
+++ b/packages/taro-runtime/src/dom/element.ts
@@ -333,7 +333,8 @@ export class TaroElement extends TaroNode {
       }
 
       if (!isUndefined(result) && event.mpEvent) {
-        event.mpEvent[EVENT_CALLBACK_RESULT] = result
+        const res = hooks.call('modifyTaroEventReturn', this, event, result)
+        if (res) { event.mpEvent[EVENT_CALLBACK_RESULT] = result }
       }
 
       if (event._end && event._stop) {

--- a/packages/taro-tt/src/runtime-utils.ts
+++ b/packages/taro-tt/src/runtime-utils.ts
@@ -5,9 +5,16 @@ export * from './apis-list'
 export * from './components'
 export const hostConfig = {
   initNativeApi,
-  modifyMpEventImpl: (event) => {
+  modifyMpEventImpl (event) {
     if (event.type === 'regionchange') {
       event.type = event.detail.type
+    }
+  },
+  modifyTaroEventReturn (node, event, returnVal) {
+    if (node.nodeName === 'pay-button') {
+      if (event.type === 'applyrefund' || event.type === 'getgoodsinfo') {
+        return returnVal
+      }
     }
   }
 }

--- a/packages/taro-webpack5-runner/src/__tests__/__snapshots__/mini-platform.spec.ts.snap
+++ b/packages/taro-webpack5-runner/src/__tests__/__snapshots__/mini-platform.spec.ts.snap
@@ -1995,6 +1995,13 @@ require("./runtime");
                 if (event.type === "regionchange") {
                     event.type = event.detail.type;
                 }
+            },
+            modifyTaroEventReturn: function modifyTaroEventReturn(node, event, returnVal) {
+                if (node.nodeName === "pay-button") {
+                    if (event.type === "applyrefund" || event.type === "getgoodsinfo") {
+                        return returnVal;
+                    }
+                }
             }
         };
         mergeReconciler(hostConfig);


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复小程序 `Input` 组件使用 async onInput 回调时输入框闪烁的问题

原因：
https://github.com/NervJS/taro/pull/13191 在修复 #13166 的时候，把所有 React 事件回调函数的返回值作为小程序事件回调的返回。但对于 Input 等表单组件来说，在小程序规范中，回调的返回值会修改输入框的值。因此使用 async onInput 时，React 事件回调返回了 Promise，接着这个 Promise 又被作为小程序回调的返回值，进而错误地修改了输入框的值。
因此，此 PR 新增了一个 Taro Runtime 钩子，让各个平台定义哪些组件的哪些事件可以透传出返回值。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
