### PR TITLE
fix: esbuild-loader 的 ast 兼容问题

### DIFF
--- a/packages/taro-mini-runner/src/plugins/TaroNormalModulesPlugin.ts
+++ b/packages/taro-mini-runner/src/plugins/TaroNormalModulesPlugin.ts
@@ -55,8 +55,8 @@ export default class TaroNormalModulesPlugin {
               } else {
                 const nameOfCallee = callee.name
                 if (
-                  // 兼容 react17 new jsx transform
-                  nameOfCallee !== '_jsx' && nameOfCallee !== '_jsxs' &&
+                  // 兼容 react17 new jsx transtrom 以及esbuild-loader的ast兼容问题
+                  !/^_?jsxs?$/.test(nameOfCallee) &&
                   // 兼容 Vue 3.0 渲染函数及 JSX
                   !(nameOfCallee && nameOfCallee.includes('createVNode')) &&
                   !(nameOfCallee && nameOfCallee.includes('createBlock')) &&

--- a/packages/taro-webpack-runner/src/plugins/TaroComponentsExportsPlugin.ts
+++ b/packages/taro-webpack-runner/src/plugins/TaroComponentsExportsPlugin.ts
@@ -56,8 +56,8 @@ export default class TaroComponentsExportsPlugin {
               } else {
                 const nameOfCallee = callee.name
                 if (
-                  // 兼容 react17 new jsx transform
-                  nameOfCallee !== '_jsx' && nameOfCallee !== '_jsxs' &&
+                  // 兼容 react17 new jsx transtrom 以及esbuild-loader的ast兼容问题
+                  !/^_?jsxs?$/.test(nameOfCallee) &&
                   // 兼容 Vue 3.0 渲染函数及 JSX
                   !(nameOfCallee && nameOfCallee.includes('createVNode')) &&
                   !(nameOfCallee && nameOfCallee.includes('createBlock')) &&

--- a/packages/taro-webpack5-runner/src/plugins/TaroComponentsExportsPlugin.ts
+++ b/packages/taro-webpack5-runner/src/plugins/TaroComponentsExportsPlugin.ts
@@ -58,8 +58,8 @@ export default class TaroComponentsExportsPlugin {
               } else {
                 const nameOfCallee = callee.name
                 if (
-                  // 兼容 react17 new jsx transform
-                  nameOfCallee !== '_jsx' && nameOfCallee !== '_jsxs' &&
+                  // 兼容 react17 new jsx transtrom 以及esbuild-loader的ast兼容问题
+                  !/^_?jsxs?$/.test(nameOfCallee) &&
                   // 兼容 Vue 3.0 渲染函数及 JSX
                   !(nameOfCallee && nameOfCallee.includes('createVNode')) &&
                   !(nameOfCallee && nameOfCallee.includes('createBlock')) &&

--- a/packages/taro-webpack5-runner/src/plugins/TaroNormalModulesPlugin.ts
+++ b/packages/taro-webpack5-runner/src/plugins/TaroNormalModulesPlugin.ts
@@ -69,8 +69,8 @@ export default class TaroNormalModulesPlugin {
               } else {
                 const nameOfCallee = callee.name
                 if (
-                  // 兼容 react17 new jsx transform
-                  nameOfCallee !== '_jsx' && nameOfCallee !== '_jsxs' &&
+                  // 兼容 react17 new jsx transtrom 以及esbuild-loader的ast兼容问题
+                  !/^_?jsxs?$/.test(nameOfCallee) &&
                   // 兼容 Vue 3.0 渲染函数及 JSX
                   !(nameOfCallee && nameOfCallee.includes('createVNode')) &&
                   !(nameOfCallee && nameOfCallee.includes('createBlock')) &&


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
esbuild-loader 会影响到 taroNormalModulesPlugin 中对于 ast 的解析处理：
![image](https://github.com/NervJS/taro/assets/39721932/f8023018-0124-46cc-a9f2-c7fecdc1bce0)
正常这里是可以获取到所有的标签 name 的，但是使用了 esbuild-loader 之后，只有一个 View 了，导致解析到的标签只有一个View：
![image](https://github.com/NervJS/taro/assets/39721932/5cb9c1d5-c04e-418b-b1c7-90d2e263f469)

同样的代码 不用这个配置，所有的标签模版都会解析到：
![image](https://github.com/NervJS/taro/assets/39721932/cdc086fa-fdcc-4f27-8fc7-79a5d3dab5a4)

webpack 这里拿到的 ast ，使用这种配置和不使用时，不一样，要加个兼容， esbuild 这里是没有 _ 的
![image](https://github.com/NervJS/taro/assets/39721932/6a0bbf48-bf66-4e26-9993-a71229dd7786)


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [x] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
