### PR TITLE
fix(rs): 文件经过 copy 或者 write 后，在 Unix 系统上继承原文件的权限

### DIFF
--- a/crates/taro_init/src/constants.rs
+++ b/crates/taro_init/src/constants.rs
@@ -68,7 +68,7 @@ pub static PACKAGES_MANAGEMENT: Lazy<HashMap<&NpmType, PackageCommand>> = Lazy::
 });
 
 pub static MEDIA_REGEX: Lazy<regex::Regex> =
-  Lazy::new(|| regex::Regex::new(r"\.(png|jpe?g|gif|svg|webp)$").unwrap());
+  Lazy::new(|| regex::Regex::new(r"\.(png|jpe?g|gif|svg|webp|jar)$").unwrap());
 
 pub static TEMPLATE_CREATOR: &str = "template_creator.js";
 

--- a/crates/taro_init/src/utils.rs
+++ b/crates/taro_init/src/utils.rs
@@ -38,7 +38,10 @@ pub async fn generate_with_template(from_path: &str, dest_path: &str, data: &imp
   };
   let dir_name = Path::new(dest_path).parent().unwrap().to_string_lossy().to_string();
   async_fs::create_dir_all(&dir_name).await.with_context(|| format!("文件夹创建失败: {}", dir_name))?;
+  let metadata = async_fs::metadata(from_path).await.with_context(|| format!("文件读取失败: {}", from_path))?;
   async_fs::write(dest_path, template).await.with_context(|| format!("文件写入失败: {}", dest_path))?;
+  #[cfg(unix)]
+  async_fs::set_permissions(dest_path, metadata.permissions()).await.with_context(|| format!("文件权限设置失败: {}", dest_path))?;
   Ok(())
 }
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复 init 项目时，文件权限丢失的问题


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
