### PR TITLE
feat: 优化rn的clickable组件，1000节点增加20%渲染速度

### DIFF
--- a/packages/taro-components-rn/src/__tests__/__snapshots__/camera.spec.tsx.snap
+++ b/packages/taro-components-rn/src/__tests__/__snapshots__/camera.spec.tsx.snap
@@ -1,8 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Camera render Camera with default props 1`] = `
-<View
-  hoverStartTime={20}
-  hoverStayTime={70}
-/>
-`;
+exports[`Camera render Camera with default props 1`] = `<View />`;

--- a/packages/taro-components-rn/src/__tests__/__snapshots__/video.spec.tsx.snap
+++ b/packages/taro-components-rn/src/__tests__/__snapshots__/video.spec.tsx.snap
@@ -126,10 +126,21 @@ exports[`Video render Video 1`] = `
       }
     >
       <Image
-        onClick={[Function]}
         onError={[Function]}
         onLayout={[Function]}
         onLoad={[Function]}
+        onMoveShouldSetResponder={[Function]}
+        onMoveShouldSetResponderCapture={[Function]}
+        onResponderEnd={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderReject={[Function]}
+        onResponderRelease={[Function]}
+        onResponderStart={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        onStartShouldSetResponderCapture={[Function]}
         resizeMode="stretch"
         source={1}
         style={

--- a/packages/taro-components-rn/src/__tests__/__snapshots__/video.spec.tsx.snap
+++ b/packages/taro-components-rn/src/__tests__/__snapshots__/video.spec.tsx.snap
@@ -2,8 +2,6 @@
 
 exports[`Video render Video 1`] = `
 <View
-  hoverStartTime={20}
-  hoverStayTime={70}
   style={
     Array [
       Object {
@@ -18,8 +16,6 @@ exports[`Video render Video 1`] = `
   }
 >
   <View
-    hoverStartTime={20}
-    hoverStayTime={70}
     style={
       Array [
         Object {
@@ -112,8 +108,6 @@ exports[`Video render Video 1`] = `
       />
     </View>
     <View
-      hoverStartTime={20}
-      hoverStayTime={70}
       style={
         Object {
           "alignItems": "center",
@@ -132,22 +126,10 @@ exports[`Video render Video 1`] = `
       }
     >
       <Image
-        mode="scaleToFill"
+        onClick={[Function]}
         onError={[Function]}
         onLayout={[Function]}
         onLoad={[Function]}
-        onMoveShouldSetResponder={[Function]}
-        onMoveShouldSetResponderCapture={[Function]}
-        onResponderEnd={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderReject={[Function]}
-        onResponderRelease={[Function]}
-        onResponderStart={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        onStartShouldSetResponderCapture={[Function]}
         resizeMode="stretch"
         source={1}
         style={

--- a/packages/taro-components-rn/src/components/Image/index.tsx
+++ b/packages/taro-components-rn/src/components/Image/index.tsx
@@ -55,7 +55,8 @@ const _Image: React.ComponentType<ImageProps & ClickableProps> = (props: ImagePr
 
   const [ratio, setRatio] = useState(0)
   const [layoutWidth, setLayoutWidth] = useState(0)
-  const { style, src, mode, svg = false, onLoad, onError } = useClickable(props)
+  const newProps = useClickable(props)
+  const { style, src, mode, svg = false, onLoad, onError } = newProps
 
   const _onError = useCallback(() => {
     if (!onError) return
@@ -171,7 +172,7 @@ const _Image: React.ComponentType<ImageProps & ClickableProps> = (props: ImagePr
       return defaultHeight
     }
   })()
-  const restImageProps = omitProp(props)
+  const restImageProps = omitProp(newProps)
 
   return (
     <Image

--- a/packages/taro-components-rn/src/components/Image/index.tsx
+++ b/packages/taro-components-rn/src/components/Image/index.tsx
@@ -56,7 +56,7 @@ const _Image: React.ComponentType<ImageProps & ClickableProps> = (props: ImagePr
   const [ratio, setRatio] = useState(0)
   const [layoutWidth, setLayoutWidth] = useState(0)
   const newProps = useClickable(props)
-  const { style, src, mode, svg = false, onLoad, onError } = newProps
+  const { style, src, mode = 'scaleToFill', svg = false, onLoad, onError } = newProps
 
   const _onError = useCallback(() => {
     if (!onError) return

--- a/packages/taro-components-rn/src/components/Image/index.tsx
+++ b/packages/taro-components-rn/src/components/Image/index.tsx
@@ -13,12 +13,13 @@
  * @warn Image.resolveAssetSource 会造成重复请求
  * @warn 宽高为 0 的时候，不触发 onLoad，跟小程序不同
  */
-
 import * as React from 'react'
 import { Image, StyleSheet, ImageSourcePropType, LayoutChangeEvent, ImageResolvedAssetSource } from 'react-native'
-import { noop, omit } from '../../utils'
-import ClickableSimplified from '../ClickableSimplified'
-import { ImageProps, ImageState, ResizeModeMap, ResizeMode } from './PropsType'
+import { omit } from '../../utils'
+import { ImageProps, ResizeModeMap, ResizeMode } from './PropsType'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import useClickable from '../hooks/useClickable'
+import { ClickableProps } from '../hooks/PropsType'
 
 // fix: https://github.com/facebook/metro/issues/836
 // 保证 react-native-svg 是最后一个依赖
@@ -44,28 +45,26 @@ try {
   WithLocalSvg = svg.WithLocalSvg
 } catch (e) {}
 
-export class _Image extends React.Component<ImageProps, ImageState> {
-  static defaultProps: ImageProps = {
-    src: '',
-    mode: 'scaleToFill'
-  }
+const _Image: React.ComponentType<ImageProps & ClickableProps> = (props: ImageProps = {
+  src: '',
+  mode: 'scaleToFill'
+}) => {
+  const ref = useRef({
+    hasLayout: false
+  })
 
-  hasLayout = false
+  const [ratio, setRatio] = useState(0)
+  const [layoutWidth, setLayoutWidth] = useState(0)
+  const { style, src, mode, svg = false, onLoad, onError } = useClickable(props)
 
-  state: ImageState = {
-    ratio: 0,
-    layoutWidth: 0
-  }
-
-  onError = (): void => {
-    const { onError = noop } = this.props
+  const _onError = useCallback(() => {
+    if (!onError) return
     onError({
       detail: { errMsg: 'something wrong' }
     })
-  }
+  }, [onError])
 
-  onLoad = (): void => {
-    const { src, onLoad } = this.props
+  const _onLoad = useCallback((): void => {
     if (!onLoad) return
     if (typeof src === 'string') {
       Image.getSize(
@@ -88,138 +87,113 @@ export class _Image extends React.Component<ImageProps, ImageState> {
         detail: { width, height }
       })
     }
-  }
+  }, [onLoad])
 
-  onLayout = (event: LayoutChangeEvent): void => {
-    const { mode, style } = this.props
+  const onLayout = (event: LayoutChangeEvent): void => {
     const { width: layoutWidth } = event.nativeEvent.layout
     const flattenStyle = StyleSheet.flatten(style) || {}
     if (mode === 'widthFix' && typeof flattenStyle.width === 'string') {
-      if (this.hasLayout) return
-      this.setState({
-        layoutWidth
-      })
+      if (ref.current.hasLayout) return
+      setLayoutWidth(layoutWidth)
     }
-    if (this.state.ratio) {
-      this.hasLayout = true
+    if (ratio) {
+      ref.current.hasLayout = true
     }
   }
 
-  loadImg = (props: ImageProps): void => {
-    const { mode, src } = props
+  const loadImg = useCallback((props: ImageProps): void => {
     if (mode !== 'widthFix') return
     if (typeof src === 'string') {
       Image.getSize(
         props.src,
         (width, height) => {
-          if (this.hasLayout) return
-          this.setState({
-            ratio: height / width
-          })
+          if (ref.current.hasLayout) return
+          setRatio(height / width)
         }
       )
     } else {
       const source = typeof props.src === 'string' ? { uri: props.src } : props.src
       const { width, height }: { width: number; height: number } = Image.resolveAssetSource(source) || {}
-      if (this.hasLayout && !!this.state.ratio) return
-      this.setState({
-        ratio: height / width
-      })
+      if (ref.current.hasLayout && !!ratio) return
+      setRatio(height / width)
     }
-  }
+  }, [mode, src, ref])
 
-  componentDidMount(): void {
-    this.loadImg(this.props)
-  }
+  useEffect(() => {
+    ref.current.hasLayout = false
+    loadImg(props)
+  }, [props.src, ref])
 
-  shouldComponentUpdate(nextProps: ImageProps): boolean {
-    if (nextProps.src !== this.props.src) {
-      this.hasLayout = false
-    }
-    return true
-  }
+  const flattenStyle = StyleSheet.flatten(style) || {}
 
-  componentDidUpdate(prevProps: ImageProps): void {
-    if (prevProps.src !== this.props.src) {
-      this.loadImg(this.props)
-    }
-  }
+  const defaultWidth = flattenStyle.width || 300
+  const defaultHeight = flattenStyle.height || 225
 
-  render(): JSX.Element {
-    const { style, src, mode = 'scaleToFill', svg = false } = this.props
-
-    const flattenStyle = StyleSheet.flatten(style) || {}
-
-    const defaultWidth = flattenStyle.width || 300
-    const defaultHeight = flattenStyle.height || 225
-
-    // remote svg image support, svg 图片暂不支持 mode
-    const remoteSvgReg = /(https?:\/\/.*\.(?:svg|svgx))/i
-    if (SvgCssUri && typeof src === 'string' && remoteSvgReg.test(src)) {
-      return (
-        <SvgCssUri
-          uri={src}
-          width={defaultWidth}
-          height={defaultHeight}
-        />
-      )
-    }
-
-    // The parameter passed to require mpxTransformust be a string literal
-    const source: ImageSourcePropType = typeof src === 'string' ? { uri: src } : src
-
-    // local svg image support, svg 图片暂不支持 mode
-    if (WithLocalSvg && svg) {
-      return (
-        <WithLocalSvg
-          asset={source}
-          width={defaultWidth}
-          height={defaultHeight}
-        />
-      )
-    }
-
-    const isWidthFix = mode === 'widthFix'
-    const rMode: ResizeMode = (resizeModeMap[mode] || (isWidthFix ? undefined : 'stretch'))
-
-    const imageHeight = (() => {
-      if (isWidthFix) {
-        if (typeof flattenStyle.width === 'string') {
-          return this.state.layoutWidth * this.state.ratio
-        } else if (typeof flattenStyle.width === 'number') {
-          return flattenStyle.width * this.state.ratio
-        } else {
-          return 300 * this.state.ratio
-        }
-      } else {
-        return defaultHeight
-      }
-    })()
-    const restImageProps = omitProp(this.props)
-
+  // remote svg image support, svg 图片暂不支持 mode
+  const remoteSvgReg = /(https?:\/\/.*\.(?:svg|svgx))/i
+  if (SvgCssUri && typeof src === 'string' && remoteSvgReg.test(src)) {
     return (
-      <Image
-        testID='image'
-        source={source}
-        resizeMode={rMode}
-        onError={this.onError}
-        onLoad={this.onLoad}
-        onLayout={this.onLayout}
-        style={[
-          {
-            width: 300
-          },
-          style,
-          {
-            height: imageHeight
-          }
-        ]}
-        {...restImageProps}
+      <SvgCssUri
+        uri={src}
+        width={defaultWidth}
+        height={defaultHeight}
       />
     )
   }
+
+  // The parameter passed to require mpxTransformust be a string literal
+  const source: ImageSourcePropType = typeof src === 'string' ? { uri: src } : src
+
+  // local svg image support, svg 图片暂不支持 mode
+  if (WithLocalSvg && svg) {
+    return (
+      <WithLocalSvg
+        asset={source}
+        width={defaultWidth}
+        height={defaultHeight}
+      />
+    )
+  }
+
+  const isWidthFix = mode === 'widthFix'
+  const rMode: ResizeMode = (resizeModeMap[mode] || (isWidthFix ? undefined : 'stretch'))
+
+  const imageHeight = (() => {
+    if (isWidthFix) {
+      if (typeof flattenStyle.width === 'string') {
+        return layoutWidth * ratio
+      } else if (typeof flattenStyle.width === 'number') {
+        return flattenStyle.width * ratio
+      } else {
+        return 300 * ratio
+      }
+    } else {
+      return defaultHeight
+    }
+  })()
+  const restImageProps = omitProp(props)
+
+  return (
+    <Image
+      testID='image'
+      source={source}
+      resizeMode={rMode}
+      onError={_onError}
+      onLoad={_onLoad}
+      onLayout={onLayout}
+      style={[
+        {
+          width: 300
+        },
+        style,
+        {
+          height: imageHeight
+        }
+      ]}
+      {...restImageProps}
+    />
+  )
 }
 
-// export { _Image }
-export default ClickableSimplified(_Image)
-// export default _Image
+export { _Image }
+export default _Image

--- a/packages/taro-components-rn/src/components/View/index.tsx
+++ b/packages/taro-components-rn/src/components/View/index.tsx
@@ -9,28 +9,51 @@ import * as React from 'react'
 import {
   View,
   Text,
+  StyleProp,
+  TextStyle,
 } from 'react-native'
 import { extracteTextStyle, omit } from '../../utils'
-import ClickableSimplified, { clickableHandlers } from '../ClickableSimplified'
 import { _ViewProps } from './PropsType'
+import useClickable, { clickableHandlers } from '../hooks/useClickable'
+import { ClickableProps } from '../hooks/PropsType'
 
 const stringToText = (child: any, props: any) => {
   // TODO: 实现小程序中效果
-  return (typeof child === 'string' || typeof child === 'number')
-    ? <Text {...omit(props, clickableHandlers)}>{child}</Text> : child
+  if (typeof child === 'string' || typeof child === 'number') {
+    // textNode节点
+    return <Text {...omit(props, clickableHandlers)}>{child}</Text>
+  }
+  return child
 }
 
-const _View: React.ForwardRefExoticComponent<_ViewProps & React.RefAttributes<any>> = React.forwardRef((props: _ViewProps, ref: React.ForwardedRef<any>) => {
-  const textStyle = extracteTextStyle(props.style)
-  // 兼容View中没用Text包裹的文字 防止报错 直接继承props在安卓中文字会消失？？？
-  const child = Array.isArray(props.children) ? props.children.map((c: any, i: number) => stringToText(c, { key: i, ...props, style: textStyle })) : stringToText(props.children, { ...props, style: textStyle })
+// 兼容View中没用Text包裹的文字 防止报错 直接继承props在安卓中文字会消失？？？
+const renderChildren = (children: React.ReactNode, props: any) => {
+  let textStyle: StyleProp<TextStyle> | null = null
+  if (Array.isArray(children)) {
+    return children.map((child, i) => {
+      if ((typeof child === 'string' || typeof child === 'number') && !textStyle) {
+      // 存在textNode，解析textStyle
+        textStyle = extracteTextStyle(props.style)
+      }
+      return stringToText(child, { key: i, ...props, style: textStyle })
+    })
+  } else {
+    if ((typeof children === 'string' || typeof children === 'number') && !textStyle) {
+      // 存在textNode，解析textStyle
+      textStyle = extracteTextStyle(props.style)
+    }
+    return stringToText(children, { ...props, style: textStyle })
+  }
+}
+
+const _View: React.ForwardRefExoticComponent<_ViewProps & ClickableProps & React.RefAttributes<any>> = React.forwardRef((props: _ViewProps & ClickableProps, ref: React.ForwardedRef<any>) => {
+  const clickable = useClickable(props) // 性能优化：从HOC替换成hooks，减少一层组件实例
   return (
     <View
       ref={ref}
-      style={props.style}
-      {...props}
+      {...clickable}
     >
-      {child}
+      {renderChildren(props.children, props)}
     </View>
   )
 })
@@ -38,4 +61,4 @@ const _View: React.ForwardRefExoticComponent<_ViewProps & React.RefAttributes<an
 _View.displayName = '_View'
 
 export { _View }
-export default ClickableSimplified(_View)
+export default _View

--- a/packages/taro-components-rn/src/components/hooks/PropsType.tsx
+++ b/packages/taro-components-rn/src/components/hooks/PropsType.tsx
@@ -1,0 +1,34 @@
+import { StyleProp, ViewStyle } from 'react-native'
+
+export type NativeEvent = {
+  timestamp: number;
+  target: any;
+  pageX: number;
+  pageY: number;
+  touches: any[];
+  changedTouches: any[];
+}
+
+export type ClickableEventRet = {
+  type: string;
+  timeStamp: number;
+  target: any;
+  currentTarget: any;
+  detail: any;
+  touches: any[];
+  changedTouches: any[];
+}
+
+export interface ClickableProps {
+  className?: string;
+  style?: StyleProp<ViewStyle>;
+  hoverStyle?: StyleProp<ViewStyle>;
+  hoverStartTime?: number;
+  hoverStayTime?: number;
+  onClick?: (event: ClickableEventRet) => void;
+  onLongPress?: (event: ClickableEventRet) => void;
+  onTouchStart?: (event: ClickableEventRet) => void;
+  onTouchMove?: (event: ClickableEventRet) => void;
+  onTouchCancel?: (event: ClickableEventRet) => void;
+  onTouchEnd?: (event: ClickableEventRet) => void;
+}

--- a/packages/taro-components-rn/src/components/hooks/useClickable.tsx
+++ b/packages/taro-components-rn/src/components/hooks/useClickable.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useRef, useState } from 'react'
+
+import {
+  GestureResponderEvent,
+  GestureResponderHandlers, PanResponder
+} from 'react-native'
+import { omit } from '../../utils'
+
+export const clickableHandlers: Array<keyof GestureResponderHandlers> = [
+  'onStartShouldSetResponder',
+  'onMoveShouldSetResponder',
+  'onResponderEnd',
+  'onResponderGrant',
+  'onResponderReject',
+  'onResponderMove',
+  'onResponderRelease',
+  'onResponderStart',
+  'onResponderStart',
+  'onResponderTerminationRequest',
+  'onResponderTerminate',
+  'onMoveShouldSetResponderCapture',
+]
+
+const getWxAppEvent = (event: GestureResponderEvent) => {
+  const nativeEvent = event.nativeEvent
+  const { timestamp, target, pageX, pageY, touches = [], changedTouches = [] } = nativeEvent
+  return {
+    type: 'tap',
+    timeStamp: timestamp,
+    target: {
+      id: target,
+      dataset: {}
+    },
+    currentTarget: {
+      id: target,
+      dataset: {}
+    },
+    detail: {
+      x: pageX,
+      y: pageY
+    },
+    touches: touches.map((item) => {
+      return {
+        identifier: item.identifier,
+        pageX: item.pageX,
+        pageY: item.pageY,
+        clientX: item.locationX,
+        clientY: item.locationY
+      }
+    }),
+    changedTouches: changedTouches.map((item) => {
+      return {
+        identifier: item.identifier,
+        pageX: item.pageX,
+        pageY: item.pageY,
+        clientX: item.locationX,
+        clientY: item.locationY
+      }
+    })
+  }
+}
+const useClickable = (props: any) => {
+  const {
+    style,
+    hoverStyle,
+    // hoverStopPropagation,
+    onClick,
+    onLongPress,
+    onTouchStart,
+    // onTouchMove,
+    // onTouchCancel,
+    onTouchEnd,
+  } = props
+
+  if (
+    !hoverStyle &&
+    // !hoverStopPropagation &&
+    !onClick &&
+    !onLongPress &&
+    !onTouchStart &&
+    // !onTouchMove &&
+    // !onTouchCancel &&
+    !onTouchEnd
+  ) {
+    return props
+  }
+
+  const [isHover, setIsHover] = useState(false)
+
+  const ref = useRef<{
+    startTimestamp: number,
+    startTimer?: ReturnType<typeof setTimeout>
+    stayTimer?: ReturnType<typeof setTimeout>
+  }>({
+    startTimestamp: 0
+  })
+
+  useEffect(() => {
+    return () => {
+      ref.current.startTimer && clearTimeout(ref.current.startTimer)
+      ref.current.stayTimer && clearTimeout(ref.current.stayTimer)
+    }
+  }, [ref])
+
+  const setStartTimer = () => {
+    const { hoverStyle, hoverStartTime } = props
+    if (hoverStyle) {
+      ref.current.startTimer && clearTimeout(ref.current.startTimer)
+      ref.current.startTimer = setTimeout(() => {
+        setIsHover(true)
+      }, hoverStartTime)
+    }
+  }
+
+  const setStayTimer = () => {
+    const { hoverStyle, hoverStayTime } = props
+    if (hoverStyle) {
+      ref.current.stayTimer && clearTimeout(ref.current.stayTimer)
+      ref.current.stayTimer = setTimeout(() => {
+        isHover && setIsHover(false)
+      }, hoverStayTime)
+    }
+  }
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => {
+        const {
+          hoverStyle,
+          onClick,
+          onLongPress,
+          onTouchStart,
+          // onTouchMove,
+          // onTouchCancel,
+          onTouchEnd
+        } = props
+        return !!(hoverStyle || onClick || onLongPress || onTouchStart || onTouchEnd)
+      },
+      onShouldBlockNativeResponder: () => false,
+      onPanResponderGrant: (evt: GestureResponderEvent) => {
+        const { onTouchStart } = props
+        onTouchStart && onTouchStart(getWxAppEvent(evt))
+        ref.current.startTimestamp = evt.nativeEvent.timestamp
+        setStartTimer()
+      },
+      onPanResponderTerminationRequest: () => true,
+      onPanResponderRelease: (evt: GestureResponderEvent, gestureState) => {
+        const { onClick, onLongPress, onTouchEnd } = props
+        onTouchEnd && onTouchEnd(getWxAppEvent(evt))
+        const endTimestamp = evt.nativeEvent.timestamp
+        const gapTime = endTimestamp - ref.current.startTimestamp
+        // 1 =>3, 修复部分android机型(三星折叠屏尤为明显),单击时dx,dy为>1，而被误判为move的情况。
+        const hasMove = Math.abs(gestureState.dx) >= 3 || Math.abs(gestureState.dy) >= 3
+        if (!hasMove) {
+          if (gapTime <= 350) {
+            onClick && onClick(getWxAppEvent(evt))
+          } else {
+            onLongPress && onLongPress(getWxAppEvent(evt))
+          }
+        }
+        setStayTimer()
+      },
+      onPanResponderTerminate: () => {
+        // const { onTouchCancel } = this.props
+        // onTouchCancel && onTouchCancel(this.getWxAppEvent(evt))
+        setStayTimer()
+      }
+    })
+  ).current
+
+  return {
+    ...omit(props, [
+      'style',
+      'hoverStyle',
+      'hoverStartTime',
+      'hoverStayTime',
+      'onClick',
+      'onLongPress',
+      'onTouchStart',
+      // 'onTouchMove',
+      // 'onTouchCancel',
+      'onTouchEnd'
+    ]),
+    ...panResponder.panHandlers,
+    style: [{ backgroundColor: 'transparent' }, style, isHover && hoverStyle]
+  }
+}
+
+export default useClickable

--- a/packages/taro-components/__tests__/__snapshots__/picker-view.spec.tsx.snap
+++ b/packages/taro-components/__tests__/__snapshots__/picker-view.spec.tsx.snap
@@ -105,6 +105,9 @@ exports[`PickerView props valid 1`] = `
     <taro-view-core style="0: h; 1: e; 2: i; 3: g; 4: h; 5: t; 6: :; 7:  ; 8: 6; 9: 0; 10: p; 11: x; 12: ;; 13:  ; 14: l; 15: i; 16: n; 17: e; 18: -; 19: h; 20: e; 21: i; 22: g; 23: h; 24: t; 25: :; 26:  ; 27: 6; 28: 0; 29: p; 30: x; 31: ;; 32:  ; 33: t; 34: e; 35: x; 36: t; 37: -; 38: a; 39: l; 40: i; 41: g; 42: n; 43: :; 44:  ; 45: c; 46: e; 47: n; 48: t; 49: e; 50: r; 51: ;;">
       2023年
     </taro-view-core>
+    <taro-view-core style="0: h; 1: e; 2: i; 3: g; 4: h; 5: t; 6: :; 7:  ; 8: 6; 9: 0; 10: p; 11: x; 12: ;; 13:  ; 14: l; 15: i; 16: n; 17: e; 18: -; 19: h; 20: e; 21: i; 22: g; 23: h; 24: t; 25: :; 26:  ; 27: 6; 28: 0; 29: p; 30: x; 31: ;; 32:  ; 33: t; 34: e; 35: x; 36: t; 37: -; 38: a; 39: l; 40: i; 41: g; 42: n; 43: :; 44:  ; 45: c; 46: e; 47: n; 48: t; 49: e; 50: r; 51: ;;">
+      2024年
+    </taro-view-core>
   </taro-picker-view-column-core>
   <div class="taro-picker-view-mask-container">
     <div class="taro-picker-view-mask-top test_maskClass" style="background-color: rgba(33, 33, 33, 0.5);"></div>


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

RN组件性能优化：火焰图显示ClickableSimplified这个hoc包裹的view和image这两个高频组件，会额外创建新的实例
- 1000节点view耗时为380ms、优化后为295ms（原生269ms）
- 1000节点的image耗时为900ms、优化后为830ms（原生670ms）

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [x] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
