### PR TITLE
fix(h5): 修复 harmony-hybrid 配置导致的 h5 babel 配置覆盖问题

### DIFF
--- a/packages/taro-plugin-react/src/webpack.h5.ts
+++ b/packages/taro-plugin-react/src/webpack.h5.ts
@@ -25,7 +25,7 @@ export function modifyH5WebpackChain (ctx: IPluginContext, framework: Frameworks
     externals,
     module: {
       rule: {
-        'process-import-taro': {
+        'process-import-taro-h5': {
           test: /taro-h5[\\/]dist[\\/]api[\\/]taro/,
           loader: require.resolve('./api-loader')
         }
@@ -37,7 +37,7 @@ export function modifyH5WebpackChain (ctx: IPluginContext, framework: Frameworks
     externals,
     module: {
       rule: {
-        'process-import-taro': {
+        'process-import-taro-harmony-hybrid': {
           test: /taro-platform-harmony-hybrid[\\/]dist[\\/]api[\\/]apis[\\/]taro/,
           loader: require.resolve('./api-loader')
         }

--- a/packages/taro-plugin-vue3/src/webpack.h5.ts
+++ b/packages/taro-plugin-vue3/src/webpack.h5.ts
@@ -93,7 +93,7 @@ function setTaroApiLoader (chain) {
   chain.merge({
     module: {
       rule: {
-        'process-import-taro': {
+        'process-import-taro-h5': {
           test: /taro-h5[\\/]dist[\\/]api[\\/]taro/,
           loader: require.resolve('./api-loader')
         }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)



**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] Web 平台（H5）