### PR TITLE
fix(sass): fix @use rules sorting problem

### DIFF
--- a/packages/taro-rn-style-transformer/src/transforms/sass.ts
+++ b/packages/taro-rn-style-transformer/src/transforms/sass.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs'
 import * as path from 'path'
 
-import { RenderAdditionalResult, RenderResult, SassConfig, SassGlobalConfig,TransformOptions } from '../types'
-import { getAdditionalData, insertAfter, insertBefore, resolveStyle } from '../utils'
+import { RenderAdditionalResult, RenderResult, SassConfig, SassGlobalConfig, TransformOptions } from '../types'
+import { getAdditionalData, insertAfter, insertBefore, resolveStyle, sortStyle } from '../utils'
 
 /**
  * 用过用户手动安装了 node-sass，启用node-sass，默认使用 sass
@@ -125,6 +125,7 @@ export default function transform (
 ) {
   const additionalData = combineResource(src, filename, config)
   let data = insertBefore(src, additionalData)
+  data = sortStyle(data)
 
   if (!data) {
     data = `\n${data}` // fix empty file error. reference https://github.com/sass/node-sass/blob/91c40a0bf0a3923ab9f91b82dcd479c25486235a/lib/index.js#L430

--- a/packages/taro-rn-style-transformer/src/utils/index.ts
+++ b/packages/taro-rn-style-transformer/src/utils/index.ts
@@ -19,6 +19,34 @@ export function insertBefore (source?: string, additional?: string) {
   return additional + ';\n' + source
 }
 
+/**
+ * sort scss source by \@use
+ * @param source scss source
+ * @returns  sorted scss source
+ */
+export function sortStyle (source) {
+  if (!source) {
+    return ''
+  }
+
+  if (source.indexOf('@use') === -1 && source.indexOf('@import') === -1) {
+    return source
+  }
+
+  // @use highest priority
+  const useReg = /@use\s+['"](.*)['"];/g
+  const useList: string[] = []
+  let match: RegExpExecArray | null = null
+  while ((match = useReg.exec(source))) {
+    useList.push(match[0])
+    source = source.replace(match[0], '')
+  }
+
+  // css last
+  const css = source.trim()
+  return [...useList, css].join('\n')
+}
+
 export function insertAfter (source?: string, additional?: string) {
   if (!source && !additional) {
     return ''
@@ -94,7 +122,7 @@ export function resolveStyle (id: string, opts: ResolveStyleOptions) {
       // like `@import 'taro-ui/dist/base.css';` or `@import '~taro-ui/dist/base.css';`
       file = resolve.sync(path.join(dir, name).replace(/^~/, ''), { basedir, extensions })
     }
-  } catch (error) {} // eslint-disable-line no-empty
+  } catch (error) { } // eslint-disable-line no-empty
 
   if (!file) {
     let includePaths = incPaths


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
当使用 resource 全局注入 scss 时，如果第三方组件中有 `@use` 规则会报错：`@use` rules must be written before any other rules

因此在该 PR 中添加 `sortStyle` 方法将 `@use` 前置

相关问题：https://github.com/NervJS/taro-ui/issues/1746
**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
