### PR TITLE
feat(router): 新增H5端app.onShow和app.onHide生命周期

### DIFF
--- a/packages/taro-router/src/router/mpa.ts
+++ b/packages/taro-router/src/router/mpa.ts
@@ -88,4 +88,12 @@ export async function createMultiRouter (
   handler.load(page, pageConfig)
 
   app.onShow?.(launchParam as Record<string, any>)
+
+  window.addEventListener('visibilitychange', ()=>{
+    if (document.visibilityState === 'visible') {
+      app.onShow?.(launchParam as Record<string, any>)
+    }else{
+      app.onHide?.(launchParam as Record<string, any>)
+    }
+  })
 }

--- a/packages/taro-router/src/router/spa.ts
+++ b/packages/taro-router/src/router/spa.ts
@@ -210,5 +210,13 @@ export function createRouter (
 
   app.onShow?.(launchParam as Record<string, any>)
 
+  window.addEventListener('visibilitychange', ()=>{
+    if (document.visibilityState === 'visible') {
+      app.onShow?.(launchParam as Record<string, any>)
+    }else{
+      app.onHide?.(launchParam as Record<string, any>)
+    }
+  })
+
   return history.listen(render)
 }

--- a/packages/taro-router/src/tabbar.ts
+++ b/packages/taro-router/src/tabbar.ts
@@ -10,7 +10,7 @@ export function initTabbar (config: AppConfig, history: History) {
 
   // TODO: custom-tab-bar
   defineCustomElementTaroTabbar()
-  const tabbar: any = document.createElement('taro-tabbar') as HTMLDivElement
+  const tabbar: any = document.createElement('taro-tabbar') as HTMLElement
   const homePage = config.entryPagePath || (config.pages ? config.pages[0] : '')
   tabbar.conf = config.tabBar
   tabbar.conf.homePage = history.location.pathname === '/' ? homePage : history.location.pathname

--- a/packages/taro-runtime/src/dsl/instance.ts
+++ b/packages/taro-runtime/src/dsl/instance.ts
@@ -89,6 +89,7 @@ export interface AppInstance extends Show {
   onPageNotFound? (res: any): void
   onUnhandledRejection? (error: any): void
   onShow?(options?: Record<string, unknown>): void
+  onHide?(options?: Record<string, unknown>): void
   unmount? (id: string, cb?: () => void): void
   taroGlobalData?: Record<any, any>
   config?: Record<any, any>


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

新增 H5 端 app.onShow 和 app.onHide 生命周期支持

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
