### PR TITLE
fix(h5): 修复 flushSync 导致低版本 react 抛出错误

### DIFF
--- a/packages/taro-components-library-react/src/component-lib/reactify-wc.ts
+++ b/packages/taro-components-library-react/src/component-lib/reactify-wc.ts
@@ -81,7 +81,7 @@ function updateProp (ctx, comp, propKey, prevProps, props) {
     }
     return
   }
-  if (/^data-.+/.test(propKey)) {
+  if (/^(aria|data)-.+/.test(propKey)) {
     dom.setAttribute(propKey, val)
   }
   if (comp === SCROLL_VIEW) {

--- a/packages/taro-components-library-react/src/react-component-lib/createOverlayComponent.tsx
+++ b/packages/taro-components-library-react/src/react-component-lib/createOverlayComponent.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 
 import { OverlayEventDetail } from './interfaces'
-import { attachProps, dashToPascalCase, defineCustomElement, setRef,StencilReactForwardedRef } from './utils'
+import { attachProps, dashToPascalCase, defineCustomElement, setRef, StencilReactForwardedRef } from './utils'
 
 interface OverlayElement extends HTMLElement {
   present: () => Promise<void>

--- a/packages/taro-components-library-react/src/react-component-lib/utils/attachProps.ts
+++ b/packages/taro-components-library-react/src/react-component-lib/utils/attachProps.ts
@@ -84,7 +84,7 @@ function finishedEventHandler (node: HTMLElement) {
   if (!controlledValue) return
 
   // 立即执行事件回调中用户可能触发了的 React 更新
-  flushSync()
+  flushSync(() => {})
 
   // 组件在 React 更新后的 React props
   const newProps = getPropsAfterReactUpdate(node)


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

- 修复 flushSync 引入导致低版本 react 抛出错误

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #

**这个 PR 涉及以下平台:**

- [x] Web 平台（H5）