### PR TITLE
fix: expo/metro高版本丢失projectRoot的问题

### DIFF
--- a/packages/stylelint-taro-rn/package.json
+++ b/packages/stylelint-taro-rn/package.json
@@ -60,7 +60,8 @@
     "testRegex": ".*\\.test\\.js$|src/.*/__tests__/.*\\.js$"
   },
   "dependencies": {
-    "react-native-known-styling-properties": "^1.0.4"
+    "react-native-known-styling-properties": "^1.0.4",
+    "stylelint": "^15.11.0"
   },
   "devDependencies": {
     "jest": "^29.3.1",

--- a/packages/taro-rn-style-transformer/package.json
+++ b/packages/taro-rn-style-transformer/package.json
@@ -34,7 +34,7 @@
     "prop-types": "^15.7.2",
     "resolve": "^1.22.0",
     "sass": "1.37.5",
-    "stylelint": "^14.9.1",
+    "stylelint": "^15.11.0",
     "stylelint-config-taro-rn": "workspace:*",
     "stylelint-taro-rn": "workspace:*",
     "stylus": "^0.55.0",

--- a/packages/taro-rn-supporter/src/taroResolver.ts
+++ b/packages/taro-rn-supporter/src/taroResolver.ts
@@ -80,7 +80,7 @@ function handleFile (context: ResolutionContext, moduleName, platform, config) {
 function handleTaroFile (context: ResolutionContext, moduleName, platform, config) {
   const newContext = { ...context }
   if(context.originModulePath === require.resolve(entryFilePath)) {
-    newContext.originModulePath = path.join(context.projectRoot, './index.js')
+    newContext.originModulePath = path.join(context.projectRoot??config.projectRoot, './index.js')
   }
   return handleFile(newContext, moduleName, platform, config)
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复expo/metro高版本丢失projectRoot的问题
目前只能算是hack修复, 我尝试找了projectRoot,具体设置的地方,但没有成功.


**stylelint-taro-rn**这个包引用了stylelint但没有明确列出依赖,把它补上了, 发现最新16.x版本不支持,15.x是可以工作的。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
