### PR TITLE
fix(cli): 修复 tsc 错误以及项目启动时的警告 , close #15321

### DIFF
--- a/packages/taro-cli/templates/default/tsconfig.json
+++ b/packages/taro-cli/templates/default/tsconfig.json
@@ -22,7 +22,8 @@
       "node_modules/@types"
     ],
     "paths": {
-      "@/*": ["src/*"]
+      // TS5090 leading './'
+      "@/*": ["./src/*"]
     }
   },
   "include": ["./src", "./types", "./config"],


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

上一个 PR #15069 忘了跑一下项目，还遗留了一个启动时的警告：

```
[WARNING] Non-relative path "src/*" is not allowed when "baseUrl" is not set (did you forget a leading "./"?) [tsconfig.json]
```

对应的 TSC 错误：

```
TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
```

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #15321
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
