### PR TITLE
fix(cli): 修复默认模板 Vue3 搭配 pnpm8 低版本使用时报错的问题

### DIFF
--- a/examples/blended-taro-component-vue3/h5/package.json
+++ b/examples/blended-taro-component-vue3/h5/package.json
@@ -60,7 +60,7 @@
     "style-loader": "1.3.0",
     "stylelint": "^14.4.0",
     "typescript": "^4.1.0",
-    "vue-loader": "^17.0.0",
+    "vue-loader": "^17.1.0",
     "webpack": "5.78.0"
   }
 }

--- a/examples/blended-taro-component-vue3/taro-project/package.json
+++ b/examples/blended-taro-component-vue3/taro-project/package.json
@@ -68,7 +68,7 @@
     "ts-node": "^10.9.1",
     "tsconfig-paths-webpack-plugin": "^4.1.0",
     "typescript": "^5.1.0",
-    "vue-loader": "^17.0.0",
+    "vue-loader": "^17.1.0",
     "webpack": "5.78.0"
   }
 }

--- a/packages/taro-cli/templates/default/package.json.tmpl
+++ b/packages/taro-cli/templates/default/package.json.tmpl
@@ -86,7 +86,7 @@
     "@tarojs/test-utils-vue3": "^0.1.1",
     "@vue/babel-plugin-jsx": "^1.0.6",
     "@vue/compiler-sfc": "^3.0.0",
-    "vue-loader": "^17.0.0",
+    "vue-loader": "^17.1.0",
     "eslint-plugin-vue": "^8.0.0",{{/if}}
     "eslint-config-taro": "{{ version }}",
     "eslint": "^8.12.0",{{#if (eq framework "React") }}


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

```
Error: Cannot find module 'vue/compiler-sfc'
```

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #13554
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
