### PR TITLE
fix: 修复previewImage索引错误的bug

### DIFF
--- a/packages/taro-platform-harmony-hybrid/src/api/apis/media/image/previewImage.ts
+++ b/packages/taro-platform-harmony-hybrid/src/api/apis/media/image/previewImage.ts
@@ -35,7 +35,7 @@ export const previewImage: typeof Taro.previewImage = async (options) => {
     return Promise.reject(res)
   }
 
-  const { urls = [], current = '', success, fail, complete, showmenu } = options
+  const { urls = [], current, success, fail, complete, showmenu } = options
   const handle = new MethodHandler({ name: 'previewImage', success, fail, complete })
   const container = document.createElement('div')
   const removeHandler = () => {
@@ -150,7 +150,13 @@ export const previewImage: typeof Taro.previewImage = async (options) => {
     swiper.appendChild(child)
   }
 
-  const currentIndex = typeof current === 'number' ? current : urls.indexOf(current)
+  // 根据微信小程序文档标准（https://developers.weixin.qq.com/miniprogram/dev/api/media/image/wx.previewImage.html）
+  // current是一个字符串
+  let currentIndex = 0
+  if (current && typeof current === 'string') {
+    const index = urls.indexOf(current)
+    currentIndex = index > -1 ? index : 0
+  }
 
   swiper.current = currentIndex
 
@@ -173,7 +179,7 @@ export const previewImage: typeof Taro.previewImage = async (options) => {
   indexContainer.style.zIndex = '999' // 确保显示在最上层
   indexDisplay.style.border = '1px solid #111'
   indexContainer.appendChild(indexDisplay)
-  indexDisplay.innerText = `${currentIndex + 2} / ${urls.length}`
+  indexDisplay.innerText = `${currentIndex + 1} / ${urls.length}`
 
   // 监听滑块index并渲染
   swiper.addEventListener('change', (e) => {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复bug：harmony hybrid 模式下 previewImage根据微信小程序api设置了正确的current url时索引多加了一个

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [x] 鸿蒙（harmony）
