### PR TITLE
fix: request接口js实现添加onHeadersReceived和offHeadersReceived监听

### DIFF
--- a/packages/taro-platform-harmony-hybrid/src/api/apis/NativeApi.ts
+++ b/packages/taro-platform-harmony-hybrid/src/api/apis/NativeApi.ts
@@ -10,6 +10,7 @@ const asyncAndRelease = window.MethodChannel && window.MethodChannel.jsBridgeMod
 // @ts-ignore
 const asyncAndNotRelease = window.MethodChannel && window.MethodChannel.jsBridgeMode({ isAsync: true, autoRelease: false }) || (target => target)
 
+export let judgeUseAxios = false
 class NativeApi {
   // @ts-ignore
   @(syncAndRelease)
@@ -893,6 +894,7 @@ class HybridProxy {
   get (_target: any, prop: string) {
     return (...args: any) => {
       if (this.useAxios && prop === this.requestApi) {
+        judgeUseAxios = this.useAxios
         // @ts-ignore
         return new RequestTask(...args)
       }

--- a/packages/taro-platform-harmony-hybrid/src/api/apis/network/request/index.ts
+++ b/packages/taro-platform-harmony-hybrid/src/api/apis/network/request/index.ts
@@ -2,7 +2,7 @@ import Taro from '@tarojs/api'
 import { isFunction } from '@tarojs/shared'
 
 import { NativeRequest } from '../../interface/NativeRequest'
-import native from '../../NativeApi'
+import native, { judgeUseAxios } from '../../NativeApi'
 import { getParameterError, shouldBeObject } from '../../utils'
 
 export const _request = (options) => {
@@ -46,7 +46,7 @@ export const _request = (options) => {
         reject(res)
       },
     })
-    task = NativeRequest.getRequestTask(taskID)
+    task = judgeUseAxios ? taskID : NativeRequest.getRequestTask(taskID)
   }) as any
 
   result.onHeadersReceived = task.onHeadersReceived.bind(task)


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
request接口js实现添加onHeadersReceived和offHeadersReceived监听


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 新功能(Feature)

**这个 PR 涉及以下平台:**

- [ ] Web 平台（H5）
- [ ] 鸿蒙（harmony）
