### PR TITLE
feat: 为京东小程序的 Textarea 组件补充 disable-default-padding 属性

### DIFF
--- a/packages/taro-jd/src/components.ts
+++ b/packages/taro-jd/src/components.ts
@@ -23,5 +23,6 @@ export const components = {
   Textarea: {
     'show-confirm-bar': 'true',
     'adjust-position': 'true',
+    'disable-default-padding': 'false',
   },
 }

--- a/packages/taro-mini-runner/src/__tests__/__snapshots__/jd.spec.ts.snap
+++ b/packages/taro-mini-runner/src/__tests__/__snapshots__/jd.spec.ts.snap
@@ -86,7 +86,8 @@ require("./taro");
             },
             Textarea: {
                 "show-confirm-bar": "true",
-                "adjust-position": "true"
+                "adjust-position": "true",
+                "disable-default-padding": "false"
             }
         };
         const hostConfig = {

--- a/packages/taro-webpack5-runner/src/__tests__/__snapshots__/mini-platform.spec.ts.snap
+++ b/packages/taro-webpack5-runner/src/__tests__/__snapshots__/mini-platform.spec.ts.snap
@@ -2985,7 +2985,8 @@ require("./runtime");
             },
             Textarea: {
                 "show-confirm-bar": "true",
-                "adjust-position": "true"
+                "adjust-position": "true",
+                "disable-default-padding": "false"
             }
         };
         const hostConfig = {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
为京东小程序的 Textarea 组件补充 disable-default-padding 属性


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [x] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
