### PR TITLE
【harmony-hybrid】解决返回时上一个页面瞬间白屏的问题

### DIFF
--- a/packages/taro-router/src/router/page.ts
+++ b/packages/taro-router/src/router/page.ts
@@ -218,6 +218,8 @@ export default class PageHandler {
         pageEl.style.zIndex = '1'
       }
 
+      eventCenter.trigger('__taroPageWillShowAfterDestroyed')
+
       this.unloadTimer = setTimeout(() => {
         this.unloadTimer = null
         this.lastUnloadPage?.onUnload?.()
@@ -233,6 +235,14 @@ export default class PageHandler {
       }, 0)
     }
     if (delta >= 1) this.unload(stacks.last, delta)
+  }
+
+  willShow (page?: PageInstance | null) {
+    if (!page) return
+    const pageEl = this.getPageContainer(page)
+    if (pageEl) {
+      pageEl.classList.remove('taro_page_shade')
+    }
   }
 
   show (page?: PageInstance | null, pageConfig: Route = {}, pageNo = 0) {

--- a/packages/taro-router/src/router/spa.ts
+++ b/packages/taro-router/src/router/spa.ts
@@ -155,6 +155,12 @@ export function createRouter (
       const delta = stacks.getDelta(pathname)
       // NOTE: Safari 内核浏览器在非应用页面返回上一页时，会触发额外的 POP 事件，此处需避免当前页面被错误卸载
       if (currentPage !== stacks.getItem(prevIndex)) {
+        eventCenter.once('__taroPageWillShowAfterDestroyed', () => {
+          if (prevIndex > -1) {
+            const pageInstance = stacks.getItem(prevIndex)
+            pageInstance && handler.willShow(pageInstance)
+          }
+        })
         handler.unload(currentPage, delta, prevIndex > -1)
         if (prevIndex > -1) {
           eventCenter.once('__taroPageOnShowAfterDestroyed', () => {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

解决返回时上一个页面瞬间白屏的问题

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
