### PR TITLE
feat(cli): upgrade `@vue/language-server` for JetBrains IDE

### DIFF
--- a/packages/taro-cli/templates/default/package.json.tmpl
+++ b/packages/taro-cli/templates/default/package.json.tmpl
@@ -81,11 +81,13 @@
     "style-loader": "1.3.0",{{/if}}{{#if (eq framework "Vue") }}
     "@tarojs/test-utils-vue": "^0.1.1",
     "@vue/babel-preset-jsx": "^1.2.4",
+    "@vue/language-server": "^2.0.14",
     "vue-loader": "^15.9.2",
     "eslint-plugin-vue": "^8.x",{{/if}}{{#if (eq framework "Vue3") }}
     "@tarojs/test-utils-vue3": "^0.1.1",
     "@vue/babel-plugin-jsx": "^1.0.6",
     "@vue/compiler-sfc": "^3.0.0",
+    "@vue/language-server": "^2.0.14",
     "vue-loader": "^17.1.0",
     "eslint-plugin-vue": "^8.0.0",{{/if}}
     "eslint-config-taro": "{{ version }}",


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

#### 说明

[JetBrains IDE 2023 版本开始集成 Volar](https://www.jetbrains.com/help/idea/2023.3/vue-js.html#ws_vue_typescript) , 项目中安装 [`@vue/language-server`](https://github.com/vuejs/language-tools) 依赖后再通过配置就可以支持最新的 **Vue 3** 语法检查。（ 比如 `Vue@3.4` 的 [同名简写](https://cn.vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand) ）

> The Vue Language Server (Volar) integration is used for error highlighting only. Code completion and navigation are provided by the IntelliJ IDEA internal support.

<img width="600" alt="" src="https://github.com/NervJS/taro/assets/13103906/6d33016c-35be-4e84-8497-155fff407982">

> [!NOTE]
>
> [目前还不支持自动使用已安装的 `@vue/language-server` ，仍需要手动配置](https://youtrack.jetbrains.com/issue/WEB-61727/Volar-automatically-detect-and-use-installed-Volar)

看了 [Volar VSCode 插件](https://marketplace.visualstudio.com/items?itemName=Vue.volar) 的 [文档](https://github.com/vuejs/language-tools/blob/v2.0.11/extensions/vscode/README.md?plain=1#L19) ， **Vue 2** 也是支持的。

#### 适用范围

- [`2023.1.3`](https://www.jetbrains.com/idea/whatsnew/2023-1/#page__content-web-development) [开始集成 Volar](https://youtrack.jetbrains.com/issue/WEB-60063/Introduce-Volar-support-for-Vue-to-fix-a-problem-with-Typescript-5.0-in-Vue-SFC#focus=Comments-27-7280138.0-0) ( [`481ca95`](https://github.com/JetBrains/intellij-plugins/commit/481ca955d6b207fc8f0f577c811ebda8e070f6a0) )

  项目中 **TypeScript** 版本大于等于 `5.0.0` 时自动启用。

- [`2023.2`](https://www.jetbrains.com/idea/whatsnew/2023-2/#page__content-web-development) [开始支持自定义 Volar 安装包](https://youtrack.jetbrains.com/issue/WEB-61476/Volar-add-an-option-to-specify-the-package) ( [`a65cb40`](https://github.com/JetBrains/intellij-plugins/commit/a65cb40bb1f1989b703adb831ecdc8b8521e821d) )

- [`2023.3`](https://www.jetbrains.com/idea/whatsnew/2023-3/#page__content-web-development) 对 **Vue 3** 支持更加完善

- [`2024.1`](https://www.jetbrains.com/idea/whatsnew/2024-1/#page__content-web-development) [开始默认启用 Vue Language Server (Volar)](https://youtrack.jetbrains.com/issue/WEB-61367/Enable-Vue-Language-Server-Volar-by-default) ( [`2f79a00`](https://github.com/JetBrains/intellij-plugins/commit/2f79a0070ce6843ac9bb20289ecb22c8c2a29b03) )

[IDE 将在后续版本中升级到 `@vue/language-server` v2](https://youtrack.jetbrains.com/issue/WEB-65823/update-to-vue-language-server-v2) ，项目中自己手动安装依赖就不需要等 **IDE** 升级了。

#### 截图

升级前

![升级前](https://github.com/NervJS/taro/assets/13103906/356f4a41-a0d2-46e5-9f6c-fac6c516b6dd)

升级后

![升级后](https://github.com/NervJS/taro/assets/13103906/7dd809ed-3bde-4405-a6bd-3adcd8417dcb)

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
