### PR TITLE
fix(prebundle): 兼容 webpack v5.90+ 后新增的 EnvironmentNotSupportAsyncWarn

### DIFF
--- a/packages/taro-webpack5-prebundle/src/web.ts
+++ b/packages/taro-webpack5-prebundle/src/web.ts
@@ -69,6 +69,10 @@ export class WebPrebundle extends BasePrebundle<IWebPrebundleConfig> {
       chunkLoadingGlobal: mainBuildOutput.chunkLoadingGlobal,
       globalObject: mainBuildOutput.globalObject,
       path: this.remoteCacheDir,
+      environment: {
+        // @ts-expect-error 待 webpack 升级后移除注释
+        asyncFunction: true,
+      }
     }
 
     this.metadata.mfHash = getMfHash({


### PR DESCRIPTION
…ing 检查问题

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

**问题描述：**
webpack 升级到 v5.90+ 版本后，编译 h5 时会提示目标环境不支持 `async/await` 的提示
```
WARNING in external "taro_app_library@/remoteEntry.js"

The generated code contains 'async/await' because this module is using "external script".
However, your target environment does not appear to support 'async/await'.
As a result, the code may not run as expected or may cause runtime errors.
```

**问题原因：**
webpack v5.90 版本新增了一个 `async/await` 环境不支持的警告检查逻辑
详见：https://github.com/webpack/webpack/pull/17967

Taro webpack 的默认输出目标是 `['web', 'es5']`，由于 es5 并不支持 `async/await`，所以在开发模式下会产生 `WARNING`
```js
export class BaseConfig {
  private _chain: Chain

  constructor (appPath: string, config: Config) {
    const chain = this._chain = new Chain()
    chain.merge({
      target: ['web', 'es5']
```

问题一：为什么更改了 target 后，用户配置的 `browserslist` 对 `output.environment.asyncFunction` 的设置不生效？
https://github.com/webpack/webpack/discussions/18022#discussioncomment-8305238

webpack 配置中的 `output.environment` 是用于告诉 webpack 在生成的运行时代码中可以使用哪个版本的 ES 特性，这个属性的设置依赖于 `target` 配置。如果用户配置了 target，但属性值中未包含 `browserslist`，webpack 是不会根据用户配置的 `browerslist` 来设置 `environmnent` 属性值的，所以直接修改项目的 `browserslist` 配置并不会关闭这个 `WARNING`。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
