### PR TITLE
fix: eslint(版本更新,已被弃用的 CLIEngine 方法。在最新版本的 ESLint 中，CLIEngine 方法已经被移除…

### DIFF
--- a/packages/taro-transformer-wx/src/eslint.ts
+++ b/packages/taro-transformer-wx/src/eslint.ts
@@ -1,11 +1,11 @@
 // import * as t from '@babel/types'
 import { PluginPass } from '@babel/core'
 import { Visitor } from '@babel/traverse'
-import { CLIEngine } from 'eslint'
+import { ESLint } from 'eslint'
 
 import { codeFrameError } from './utils'
 
-const cli = new CLIEngine({
+const cli = new ESLint({
   baseConfig: {
     extends: ['plugin:taro/transformer'],
   },


### PR DESCRIPTION
…了。相反，您应该使用 ESLint 类来创建一个新的 ESLint 实例，然后调用它的 API。)

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
因为在代码中使用了已被弃用的 CLIEngine 方法。在最新版本的 ESLint 中，CLIEngine 方法已经被移除了。相反，您应该使用 ESLint 类来创建一个新的 ESLint 实例，然后调用它的 API。
复现方法：npx @tarojs/cli-convertor将微信小程序转taro就会复现
<img width="307" alt="image" src="https://github.com/NervJS/taro/assets/14226199/7eacd028-ac04-4217-9896-5c0662c889f0">


**这个 PR 是什么类型?** (至少选择一个)
[ ] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

[ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
