### PR TITLE
feat: 使用 navigateBack 的时候，在动画开始的时候就展示上一个页面；使用 navigateTo 的时候，在动画结束后再隐藏上一个页面

### DIFF
--- a/packages/taro-router/src/style.ts
+++ b/packages/taro-router/src/style.ts
@@ -66,7 +66,7 @@ ${
 ` : ''}
   .taro_page_shade:has(+.taro_page_stationed),
   .taro_page_shade.taro_tabbar_page,
-  .taro_router > .taro_page.taro_page_show.taro_page_stationed:not(.taro_page_shade):not(.taro_tabbar_page):not(:last-child) {
+  .taro_router > .taro_page.taro_page_show.taro_page_stationed:not(.taro_page_shade):not(.taro_tabbar_page):not(:last-child):has(+.taro_page_stationed) {
     display: none;
   }
 `

--- a/packages/taro-router/src/style.ts
+++ b/packages/taro-router/src/style.ts
@@ -64,7 +64,8 @@ ${
   }
 
 ` : ''}
-  .taro_page_shade,
+  .taro_page_shade:has(+.taro_page_stationed),
+  .taro_page_shade.taro_tabbar_page,
   .taro_router > .taro_page.taro_page_show.taro_page_stationed:not(.taro_page_shade):not(.taro_tabbar_page):not(:last-child) {
     display: none;
   }


### PR DESCRIPTION
使用 navigateBack 的时候，在动画开始的时候就展示上一个页面；使用 navigateTo 的时候，在动画结束后再隐藏上一个页面

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
使用 navigateBack 的时候，在动画开始的时候就展示上一个页面；使用 navigateTo 的时候，在动画结束后再隐藏上一个页面


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
