### PR TITLE
[harmony-hybrid]Taro Api采用继承export的方式，不再复制taro-h5、taro-plugin-react、taro-plugin-vue3里的代码，解决vue框架下缺少的api

### DIFF
--- a/packages/taro-platform-harmony-hybrid/src/api/apis/comments.ts
+++ b/packages/taro-platform-harmony-hybrid/src/api/apis/comments.ts
@@ -49,6 +49,18 @@
  */
 
 /**
+ * 判断能否使用WebP格式
+ *
+ * @canUse canIUseWebp
+ */
+
+/**
+ * 跳转预加载 API
+ *
+ * @canUse preload
+ */
+
+/**
  * 创建 video 上下文 VideoContext 对象。
  *
  * @canUse createVideoContext

--- a/packages/taro-platform-harmony-hybrid/src/api/apis/taro.ts
+++ b/packages/taro-platform-harmony-hybrid/src/api/apis/taro.ts
@@ -1,13 +1,10 @@
-import Taro from '@tarojs/plugin-platform-h5/dist/runtime/apis'
-import { history } from '@tarojs/router'
-import { isFunction, PLATFORM_TYPE } from '@tarojs/shared'
-import { toByteArray } from 'base64-js'
+import Taro from '@tarojs/api'
+import DefaultTaroH5 from '@tarojs/taro-h5/dist/api/taro'
 
 import {
   getApp,
   getCurrentInstance,
   getCurrentPages,
-  initLaunchOptions,
   navigateBack,
   navigateTo,
   nextTick,
@@ -15,98 +12,7 @@ import {
   reLaunch,
   switchTab,
 } from './index'
-import native from './NativeApi'
-import { invertColor } from './utils/colorConvert'
-// import { permanentlyNotSupport } from './utils'
 
-// @ts-ignore
-window.base64ToArrayBuffer = (base64: string) => toByteArray(base64).buffer
-
-const {
-  Behavior,
-  getEnv,
-  ENV_TYPE,
-  Link,
-  interceptors,
-  interceptorify,
-  Current,
-  options,
-  eventCenter,
-  Events,
-  preload,
-  useAddToFavorites,
-  useDidHide,
-  useDidShow,
-  useError,
-  useLaunch,
-  useLoad,
-  useOptionMenuClick,
-  usePageNotFound,
-  usePageScroll,
-  usePullDownRefresh,
-  usePullIntercept,
-  useReachBottom,
-  useReady,
-  useResize,
-  useRouter,
-  useSaveExitState,
-  useShareAppMessage,
-  useShareTimeline,
-  useTabItemTap,
-  useTitleClick,
-  useScope,
-  useUnhandledRejection,
-  useUnload
-} = Taro as any
-
-const taro: typeof Taro = {
-  // @ts-ignore
-  Behavior,
-  getEnv,
-  ENV_TYPE,
-  Link,
-  interceptors,
-  interceptorify,
-  Current,
-  getCurrentInstance,
-  options,
-  nextTick,
-  eventCenter,
-  Events,
-  preload,
-  history,
-  navigateBack,
-  navigateTo,
-  reLaunch,
-  redirectTo,
-  getCurrentPages,
-  switchTab,
-  useAddToFavorites,
-  useDidHide,
-  useDidShow,
-  useError,
-  useLaunch,
-  useLoad,
-  useOptionMenuClick,
-  usePageNotFound,
-  usePageScroll,
-  usePullDownRefresh,
-  usePullIntercept,
-  useReachBottom,
-  useReady,
-  useResize,
-  useRouter,
-  useSaveExitState,
-  useShareAppMessage,
-  useShareTimeline,
-  useTabItemTap,
-  useTitleClick,
-  useScope,
-  useUnhandledRejection,
-  useUnload
-}
-
-// export const requirePlugin = permanentlyNotSupport('requirePlugin')
 const requirePlugin = () => {
   return {
     world: '',
@@ -116,304 +22,25 @@ const requirePlugin = () => {
   }
 }
 
-function getConfig (): Record<string, any> {
-  if (this?.pxTransformConfig) return this.pxTransformConfig
-  return ((taro as any).config ||= {})
+const NamedTaroHarmonyHybrid: typeof Taro = {
+  ...DefaultTaroH5,
+  getApp,
+  getCurrentInstance,
+  getCurrentPages,
+  navigateBack,
+  navigateTo,
+  nextTick,
+  redirectTo,
+  reLaunch,
+  switchTab,
+  requirePlugin
 }
 
-const defaultDesignWidth = 750
-const defaultDesignRatio: TaroGeneral.TDeviceRatio = {
-  640: 2.34 / 2,
-  750: 1,
-  828: 1.81 / 2,
-}
-const defaultBaseFontSize = 20
-const defaultUnitPrecision = 5
-const defaultTargetUnit = 'rem'
+export * from '@tarojs/taro-h5/dist/api/taro'
 
-const initPxTransform = function ({
-  designWidth = defaultDesignWidth,
-  deviceRatio = defaultDesignRatio,
-  baseFontSize = defaultBaseFontSize,
-  unitPrecision = defaultUnitPrecision,
-  targetUnit = defaultTargetUnit,
-}) {
-  const config = getConfig.call(this)
-  config.designWidth = designWidth
-  config.deviceRatio = deviceRatio
-  config.baseFontSize = baseFontSize
-  config.targetUnit = targetUnit
-  config.unitPrecision = unitPrecision
-}
-
-const pxTransform = function (size = 0) {
-  const config = getConfig.call(this)
-  const baseFontSize = config.baseFontSize || defaultBaseFontSize
-  const deviceRatio = config.deviceRatio || defaultDesignRatio
-  const designWidth = ((input = 0) =>
-    isFunction(config.designWidth) ? config.designWidth(input) : config.designWidth)(size)
-  if (!(designWidth in config.deviceRatio)) {
-    throw new Error(`deviceRatio 配置中不存在 ${designWidth} 的设置！`)
-  }
-  const targetUnit = config.targetUnit || defaultTargetUnit
-  const unitPrecision = config.unitPrecision || defaultUnitPrecision
-  const formatSize = ~~size
-  let rootValue = 1 / deviceRatio[designWidth]
-  switch (targetUnit) {
-    case 'vw':
-      rootValue = designWidth / 100
-      break
-    case 'px':
-      rootValue *= 2
-      break
-    default:
-      // rem
-      rootValue *= baseFontSize * 2
-  }
-  let val: number | string = formatSize / rootValue
-  if (unitPrecision >= 0 && unitPrecision <= 100) {
-    // Number(val): 0.50000 => 0.5
-    val = Number(val.toFixed(unitPrecision))
-  }
-  return val + targetUnit
-}
-
-/**
- * 判断能否使用WebP格式
- *
- * @canUse canIUseWebp
- */
-const canIUseWebp = function () {
-  const canvas = document.createElement('canvas')
-  return canvas.toDataURL('image/webp').indexOf('data:image/webp') === 0
-}
-
-const getAppInfo = function () {
-  const config = getConfig.call(this)
-  return {
-    platform: process.env.TARO_PLATFORM || PLATFORM_TYPE.WEB,
-    taroVersion: process.env.TARO_VERSION || 'unknown',
-    designWidth: config.designWidth,
-  }
-}
-
-// 同步小程序启动时的参数
-Taro.eventCenter.once('__taroRouterLaunch', initLaunchOptions)
-
-if (typeof window !== 'undefined') {
-  // @ts-ignore
-  window.currentNavigation = {}
-}
-
-// 更新导航栏状态
-Taro.eventCenter.on('__taroSetNavigationStyle', (style, textStyle, backgroundColor) => {
-  if (typeof window !== 'undefined') {
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      // 当前处于深色模式，对textStyle和backgroundColor进行反转
-      textStyle = textStyle === 'black' ? 'white' : 'black'
-      backgroundColor = invertColor(backgroundColor)
-    }
-    native.setNavigationStyle({ style, textStyle, backgroundColor })
-    // @ts-ignore
-    Object.assign(window.currentNavigation, {
-      style,
-      textStyle,
-      backgroundColor,
-    })
-    // @ts-ignore
-    if (typeof window.originCapsuleState !== 'undefined') {
-      // @ts-ignore
-      window.native?.setCapsuleState?.(window.originCapsuleState)
-    }
-  }
-})
-
-// 进入全屏时隐藏导航栏和胶囊按钮
-eventCenter.on('__taroEnterFullScreen', () => {
-  native.setNavigationStyle({
-    style: 'custom',
-    textStyle: 'black',
-    backgroundColor: '#000000',
-  })
-  // @ts-ignore
-  if (typeof window.originCapsuleState === 'undefined') {
-    // @ts-ignore
-    window.originCapsuleState = window.native?.getCapsuleState().visible
-  }
-  // @ts-ignore
-  window.native?.setCapsuleState?.(false)
-})
-
-// 退出全屏时恢复导航栏和胶囊按钮
-eventCenter.on('__taroExitFullScreen', () => {
-  // @ts-ignore
-  const { style, textStyle, backgroundColor } = window.currentNavigation
-  native.setNavigationStyle({ style, textStyle, backgroundColor })
-  // @ts-ignore
-  if (typeof window.originCapsuleState !== 'undefined') {
-    // @ts-ignore
-    window.native?.setCapsuleState?.(window.originCapsuleState)
-  }
-})
-
-// 根据是否有导航栏设置页面样式
-function loadNavigationSytle () {
-  if (typeof window === 'undefined') {
-    return
-  }
-  // @ts-ignore
-  const naviHeight = window.navigationHeight ? window.navigationHeight : 0
-  const css = `
-.taro_router .taro_page.taro_navigation_page {
-  padding-top: ${naviHeight}px;
-}
-
-.taro-tabbar__container .taro_page.taro_navigation_page {
-  max-height: calc(100vh - ${naviHeight}px);
-}
-
-.taro-tabbar__container .taro_page.taro_tabbar_page.taro_navigation_page {
-  max-height: calc(100vh - 50px - ${naviHeight}px);
-}`
-
-  const style = document.createElement('style')
-  style.innerHTML = css
-  document.getElementsByTagName('head')[0].appendChild(style)
-}
-
-loadNavigationSytle()
-
-// 设置位置选择样式
-function loadChooseLocationStyle () {
-  const css = `
-.taro_choose_location {
-  display: flex;
-  position: fixed;
-  top: 100%;
-  z-index: 1;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  background-color: #fff;
-  transition: ease top 0.3s;
-}
-.taro_choose_location_bar {
-  display: flex;
-  flex: 0 60px;
-  height: 60px;
-  background-color: #ededed;
-  color: #090909;
-  align-items: center;
-}
-.taro_choose_location_back {
-  position: relative;
-  flex: 0 40px;
-  margin-left: 10px;
-  width: 25px;
-  height: 30px;
-}
-.taro_choose_location_back::before {
-  display: block;
-  position: absolute;
-  left: 0;
-  top: 0;
-  border: solid 15px;
-  border-color: transparent #090909 transparent transparent;
-  width: 0;
-  height: 0;
-  content: "";
-}
-.taro_choose_location_back::after {
-  display: block;
-  position: absolute;
-  left: 3px;
-  top: 0;
-  border: solid 15px;
-  border-color: transparent #ededed transparent transparent;
-  width: 0;
-  height: 0;
-  content: "";
-}
-.taro_choose_location_title {
-  flex: 1;
-  padding-left: 30px;
-  line-height: 60px;
-}
-.taro_choose_location_submit {
-  margin-right: 25px;
-  padding: 0;
-  border: none;
-  width: 75px;
-  height: 40px;
-  background-color: #08bf62;
-  line-height: 40px;
-  font-size: 20px;
-  color: #fff;
-}
-.taro_choose_location_frame {
-  flex: 1;
-}
-`
-
-  const style = document.createElement('style')
-  style.innerHTML = css
-  document.getElementsByTagName('head')[0].appendChild(style)
-}
-
-loadChooseLocationStyle()
-
-taro.requirePlugin = requirePlugin
-taro.getApp = getApp
-taro.pxTransform = pxTransform
-taro.initPxTransform = initPxTransform
-taro.canIUseWebp = canIUseWebp
-
-export default taro
-
-/**
- * 跳转预加载 API
- *
- * @canUse preload
- */
+// 覆写H5的requirePlugin
 export {
-  Behavior,
-  canIUseWebp,
-  Current,
-  ENV_TYPE,
-  eventCenter,
-  Events,
-  getAppInfo,
-  getEnv,
-  history,
-  initPxTransform,
-  interceptorify,
-  interceptors,
-  Link,
-  options,
-  preload,
-  pxTransform,
-  requirePlugin,
-  useAddToFavorites,
-  useDidHide,
-  useDidShow,
-  useError,
-  useLaunch,
-  useLoad,
-  useOptionMenuClick,
-  usePageNotFound,
-  usePageScroll,
-  usePullDownRefresh,
-  usePullIntercept,
-  useReachBottom,
-  useReady,
-  useResize,
-  useRouter,
-  useSaveExitState,
-  useScope,
-  useShareAppMessage,
-  useShareTimeline,
-  useTabItemTap,
-  useTitleClick,
-  useUnhandledRejection,
-  useUnload
+  requirePlugin
 }
+
+export default NamedTaroHarmonyHybrid

--- a/packages/taro-platform-harmony-hybrid/src/api/apis/taro.ts
+++ b/packages/taro-platform-harmony-hybrid/src/api/apis/taro.ts
@@ -1,5 +1,6 @@
 import Taro from '@tarojs/api'
 import DefaultTaroH5 from '@tarojs/taro-h5/dist/api/taro'
+import * as taroH5 from '@tarojs/taro-h5/dist/api/taro'
 
 import {
   getApp,
@@ -35,12 +36,11 @@ const NamedTaroHarmonyHybrid: typeof Taro = {
   switchTab,
   requirePlugin
 }
-
-export * from '@tarojs/taro-h5/dist/api/taro'
-
+export default NamedTaroHarmonyHybrid
 // 覆写H5的requirePlugin
-export {
+export const taroHarmonyHybrid = {
+  ...taroH5,
   requirePlugin
 }
 
-export default NamedTaroHarmonyHybrid
+

--- a/packages/taro-platform-harmony-hybrid/src/runtime/apis/index.ts
+++ b/packages/taro-platform-harmony-hybrid/src/runtime/apis/index.ts
@@ -27,3 +27,177 @@ export function canIUse (scheme = '') {
 }
 
 export default Taro
+
+import native from 'src/api/apis/NativeApi'
+import { invertColor } from 'src/api/apis/utils/colorConvert'
+import { initLaunchOptions } from 'src/api/apis'
+
+// 同步小程序启动时的参数
+Taro.eventCenter.once('__taroRouterLaunch', initLaunchOptions)
+
+if (typeof window !== 'undefined') {
+  // @ts-ignore
+  window.currentNavigation = {}
+}
+
+
+// 更新导航栏状态
+Taro.eventCenter.on('__taroSetNavigationStyle', (style, textStyle, backgroundColor) => {
+  if (typeof window !== 'undefined') {
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      // 当前处于深色模式，对textStyle和backgroundColor进行反转
+      textStyle = textStyle === 'black' ? 'white' : 'black'
+      backgroundColor = invertColor(backgroundColor)
+    }
+    native.setNavigationStyle({ style, textStyle, backgroundColor })
+    // @ts-ignore
+    Object.assign(window.currentNavigation, {
+      style,
+      textStyle,
+      backgroundColor,
+    })
+    // @ts-ignore
+    if (typeof window.originCapsuleState !== 'undefined') {
+      // @ts-ignore
+      window.native?.setCapsuleState?.(window.originCapsuleState)
+    }
+  }
+})
+
+
+// 进入全屏时隐藏导航栏和胶囊按钮
+Taro.eventCenter.on('__taroEnterFullScreen', () => {
+  native.setNavigationStyle({
+    style: 'custom',
+    textStyle: 'black',
+    backgroundColor: '#000000',
+  })
+  // @ts-ignore
+  if (typeof window.originCapsuleState === 'undefined') {
+    // @ts-ignore
+    window.originCapsuleState = window.native?.getCapsuleState().visible
+  }
+  // @ts-ignore
+  window.native?.setCapsuleState?.(false)
+})
+
+
+// 退出全屏时恢复导航栏和胶囊按钮
+Taro.eventCenter.on('__taroExitFullScreen', () => {
+  // @ts-ignore
+  const { style, textStyle, backgroundColor } = window.currentNavigation
+  native.setNavigationStyle({ style, textStyle, backgroundColor })
+  // @ts-ignore
+  if (typeof window.originCapsuleState !== 'undefined') {
+    // @ts-ignore
+    window.native?.setCapsuleState?.(window.originCapsuleState)
+  }
+})
+
+
+// 根据是否有导航栏设置页面样式
+function loadNavigationSytle () {
+  if (typeof window === 'undefined') {
+    return
+  }
+  // @ts-ignore
+  const naviHeight = window.navigationHeight ? window.navigationHeight : 0
+  const css = `
+.taro_router .taro_page.taro_navigation_page {
+  padding-top: ${naviHeight}px;
+}
+
+.taro-tabbar__container .taro_page.taro_navigation_page {
+  max-height: calc(100vh - ${naviHeight}px);
+}
+
+.taro-tabbar__container .taro_page.taro_tabbar_page.taro_navigation_page {
+  max-height: calc(100vh - 50px - ${naviHeight}px);
+}`
+
+  const style = document.createElement('style')
+  style.innerHTML = css
+  document.getElementsByTagName('head')[0].appendChild(style)
+}
+
+loadNavigationSytle()
+
+
+// 设置位置选择样式
+function loadChooseLocationStyle () {
+  const css = `
+.taro_choose_location {
+  display: flex;
+  position: fixed;
+  top: 100%;
+  z-index: 1;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background-color: #fff;
+  transition: ease top 0.3s;
+}
+.taro_choose_location_bar {
+  display: flex;
+  flex: 0 60px;
+  height: 60px;
+  background-color: #ededed;
+  color: #090909;
+  align-items: center;
+}
+.taro_choose_location_back {
+  position: relative;
+  flex: 0 40px;
+  margin-left: 10px;
+  width: 25px;
+  height: 30px;
+}
+.taro_choose_location_back::before {
+  display: block;
+  position: absolute;
+  left: 0;
+  top: 0;
+  border: solid 15px;
+  border-color: transparent #090909 transparent transparent;
+  width: 0;
+  height: 0;
+  content: "";
+}
+.taro_choose_location_back::after {
+  display: block;
+  position: absolute;
+  left: 3px;
+  top: 0;
+  border: solid 15px;
+  border-color: transparent #ededed transparent transparent;
+  width: 0;
+  height: 0;
+  content: "";
+}
+.taro_choose_location_title {
+  flex: 1;
+  padding-left: 30px;
+  line-height: 60px;
+}
+.taro_choose_location_submit {
+  margin-right: 25px;
+  padding: 0;
+  border: none;
+  width: 75px;
+  height: 40px;
+  background-color: #08bf62;
+  line-height: 40px;
+  font-size: 20px;
+  color: #fff;
+}
+.taro_choose_location_frame {
+  flex: 1;
+}
+`
+
+  const style = document.createElement('style')
+  style.innerHTML = css
+  document.getElementsByTagName('head')[0].appendChild(style)
+}
+
+loadChooseLocationStyle()

--- a/packages/taro-platform-harmony-hybrid/src/runtime/apis/index.ts
+++ b/packages/taro-platform-harmony-hybrid/src/runtime/apis/index.ts
@@ -1,6 +1,9 @@
 import definition from '@tarojs/plugin-platform-harmony-hybrid/dist/definition.json'
 import isMatchWith from 'lodash-es/isMatchWith'
 import setWith from 'lodash-es/setWith'
+import { initLaunchOptions } from 'src/api/apis'
+import native from 'src/api/apis/NativeApi'
+import { invertColor } from 'src/api/apis/utils/colorConvert'
 
 import Taro from './taro'
 
@@ -27,10 +30,6 @@ export function canIUse (scheme = '') {
 }
 
 export default Taro
-
-import native from 'src/api/apis/NativeApi'
-import { invertColor } from 'src/api/apis/utils/colorConvert'
-import { initLaunchOptions } from 'src/api/apis'
 
 // 同步小程序启动时的参数
 Taro.eventCenter.once('__taroRouterLaunch', initLaunchOptions)


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
Taro Api采用继承export的方式，不再复制taro-h5、taro-plugin-react、taro-plugin-vue3里的代码，解决vue框架下缺少的api

问题复现方法：vue3框架的Taro程序，在harmony-hybrid平台下，Taro.setGlobalDataPlugin为undefined

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [x] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
- [x] harmony-hybrid
