### PR TITLE
[harmony-hybrid]继承Taro-H5的api的方式，由匿名继承改为显式继承，匿名继承对于CommonJS模块依赖时需要.default才能处理

### DIFF
--- a/packages/taro-platform-harmony-hybrid/src/api/apis/taro.ts
+++ b/packages/taro-platform-harmony-hybrid/src/api/apis/taro.ts
@@ -1,6 +1,5 @@
 import Taro from '@tarojs/api'
-import DefaultTaroH5 from '@tarojs/taro-h5/dist/api/taro'
-import * as taroH5 from '@tarojs/taro-h5/dist/api/taro'
+import TaroH5, { getAppInfo } from '@tarojs/taro-h5/dist/api/taro'
 
 import {
   getApp,
@@ -23,24 +22,68 @@ const requirePlugin = () => {
   }
 }
 
-const NamedTaroHarmonyHybrid: typeof Taro = {
-  ...DefaultTaroH5,
-  getApp,
+const {
+  Behavior,
+  getEnv,
+  ENV_TYPE,
+  Link,
+  interceptors,
+  interceptorify,
+  Current,
+  options,
+  eventCenter,
+  Events,
+  preload,
+  history,
+  pxTransform,
+  initPxTransform,
+  canIUseWebp
+} = TaroH5 as any
+
+const taro: typeof Taro = {
+  // @ts-ignore
+  Behavior,
+  getEnv,
+  ENV_TYPE,
+  Link,
+  interceptors,
+  interceptorify,
+  Current,
   getCurrentInstance,
-  getCurrentPages,
+  options,
+  nextTick,
+  eventCenter,
+  Events,
+  preload,
+  history,
   navigateBack,
   navigateTo,
-  nextTick,
-  redirectTo,
   reLaunch,
+  redirectTo,
+  getCurrentPages,
   switchTab,
-  requirePlugin
-}
-export default NamedTaroHarmonyHybrid
-// 覆写H5的requirePlugin
-export const taroHarmonyHybrid = {
-  ...taroH5,
-  requirePlugin
+  requirePlugin,
+  getApp
 }
 
+export default taro
 
+export {
+  Behavior,
+  canIUseWebp,
+  Current,
+  ENV_TYPE,
+  eventCenter,
+  Events,
+  getAppInfo,
+  getEnv,
+  history,
+  initPxTransform,
+  interceptorify,
+  interceptors,
+  Link,
+  options,
+  preload,
+  pxTransform,
+  requirePlugin
+}

--- a/packages/taro-platform-harmony-hybrid/src/program.ts
+++ b/packages/taro-platform-harmony-hybrid/src/program.ts
@@ -154,6 +154,11 @@ export default class H5 extends TaroPlatformWeb {
         return args
       })
 
+      // 修改h5平台的rule的正则表达式
+      chain.module
+        .rule('process-import-taro-h5')
+        .test(/(plugin|taro)-platform-harmony-hybrid[\\/]dist[\\/]api[\\/]apis[\\/]taro/)
+
       // Note: 本地调试 stencil 组件库时，如果启用 sourceMap 则需要相关配置
       chain.module
         .rule('map')


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
继承Taro-H5的api的方式，由匿名继承改为显式继承，匿名继承对于CommonJS模块依赖时需要.default才能处理

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
- [x] Harmony-hybrid
