### PR TITLE
[Harmony-hybrid]Api调用支持缓存监听的机制更新，用于减少通信次数

### DIFF
--- a/packages/taro-platform-harmony-hybrid/src/api/apis/NativeApi.ts
+++ b/packages/taro-platform-harmony-hybrid/src/api/apis/NativeApi.ts
@@ -1,3 +1,4 @@
+import { NativeDataChangeListener, SyncCacheProxyHandler } from './NativeApiSyncCacheProxy'
 // @ts-ignore
 const syncAndRelease = window.MethodChannel && window.MethodChannel.jsBridgeMode({ isAsync: false, autoRelease: true }) || (target => target)
 // @ts-ignore
@@ -8,7 +9,14 @@ const asyncAndRelease = window.MethodChannel && window.MethodChannel.jsBridgeMod
 const asyncAndNotRelease = window.MethodChannel && window.MethodChannel.jsBridgeMode({ isAsync: true, autoRelease: false }) || (target => target)
 
 // export let judgeUseAxios = false
-class NativeApi {
+export class NativeApi {
+  // @ts-ignore
+  @(syncAndNotRelease)
+  // @ts-ignore
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  registerNativeListener (listener: NativeDataChangeListener | null): void {
+  }
+
   // @ts-ignore
   @(syncAndRelease)
   openLocation (options: any): any {
@@ -922,5 +930,6 @@ class AsyncToSyncProxy {
 // }
 
 const nativeApi = new NativeApi()
-const native = new Proxy(nativeApi, new CacheStorageProxy(nativeApi)) // 第一个false是默认走jsb，true是走纯js， 第二个false是不走osChannel
+const cacheNativeApi = new Proxy(nativeApi, new SyncCacheProxyHandler(nativeApi))
+const native = new Proxy(cacheNativeApi, new CacheStorageProxy(cacheNativeApi)) // 第一个false是默认走jsb，true是走纯js， 第二个false是不走osChannel
 export default native

--- a/packages/taro-platform-harmony-hybrid/src/api/apis/NativeApiSyncCacheProxy.ts
+++ b/packages/taro-platform-harmony-hybrid/src/api/apis/NativeApiSyncCacheProxy.ts
@@ -1,0 +1,136 @@
+import { NativeApi } from './NativeApi'
+
+export class NativeDataCache {
+  private cache = new Map<string, any>()
+
+  keys (): string[] {
+    return Array.from(this.cache.keys())
+  }
+
+  set (key: string, value: any) {
+    this.cache.set(key, value)
+  }
+
+  get (key: string) {
+    return this.cache.get(key)
+  }
+
+  delete (key: string): boolean {
+    return this.cache.delete(key)
+  }
+
+  has (key: string): boolean {
+    return this.cache.has(key)
+  }
+}
+
+/**
+ * 系统数据更新监听器
+ */
+export interface NativeDataChangeListener {
+  /**
+   * 更新
+   * @param methodName    要更新的方法名
+   * @param methodArgs    要更新的方法参数，如果是空参，直接传[]
+   */
+  change: (methodName: string, methodArgs: any[]) => void
+  /**
+   * 注册
+   * @param methodName    要注册的方法名列表
+   */
+  register: (methodNames: string[]) => void
+  /**
+   * 解注册
+   * @param methodName    要解注册的方法名列表
+   */
+  unregister:(methodNames: string[]) => void
+
+}
+
+/**
+ * 同步数据缓存ProxyHandler
+ */
+export class SyncCacheProxyHandler {
+  private readonly nativeApi: NativeApi
+  private readonly listener: NativeDataChangeListener
+  private readonly cache: NativeDataCache
+  private enableMethodNames: Set<string> = new Set<string>()
+
+  constructor (nativeApi: NativeApi) {
+    this.nativeApi = nativeApi
+    this.cache = new NativeDataCache()
+    // 绑定类的this到self变量
+    const self = this
+    // 监听Native数据变化
+    this.listener = {
+      register: (methodNames: string[]) => {
+        methodNames.forEach((name: string) => {
+          self.enableMethodNames.add(name)
+        })
+      },
+      unregister: (methodNames: string[]) => {
+        methodNames.forEach((name: string) => {
+          self.enableMethodNames.delete(name)
+        })
+      },
+      change: (methodName: string, methodArgs: any[]) => {
+        if (self.enableMethodNames.has(methodName)) {
+          self.updateNativeData(self.cache, methodName, methodArgs)
+        }
+      }
+    }
+    this.nativeApi.registerNativeListener(this.listener)
+  }
+
+  /**
+   * 更新Native数据
+   * @param cache         缓存数据
+   * @param methodName    要更新的方法名
+   * @param methodArgs    要更新的方法参数
+   */
+  private updateNativeData (cache: NativeDataCache, methodName: string, methodArgs: any[]) {
+    const cacheKey = this.generateCacheKey(methodName, methodArgs)
+    // 删除该key对应的数据
+    cache.delete(cacheKey)
+    // 获取到methodName对应的方法
+    const fun = (this.nativeApi as any)[methodName] as (...args: any[]) => any
+    // 方法存在，可以安全调用，并传入参数
+    if (typeof fun === 'function') {
+      const result = fun(...methodArgs)
+      // 结果存入缓存
+      if (result) {
+        this.cache.set(cacheKey, result)
+      }
+    }
+  }
+
+  /**
+   * 生成cache的存储key
+   * @param methodName    方法名
+   * @param methodArgs    方法参数
+   */
+  private generateCacheKey (methodName: string, methodArgs: any[]): string {
+    return `${methodName}_${JSON.stringify(methodArgs)}`
+  }
+
+  get (target: NativeApi, propKey: string | symbol, receiver: any) {
+    const origMethod = Reflect.get(target, propKey, receiver)
+    const methodName = `${String(propKey)}`
+    if (typeof origMethod === 'function' && this.enableMethodNames.has(methodName)) {
+      return (...args: any[]) => {
+        const cacheKey = this.generateCacheKey(`${String(propKey)}`, args)
+        if (this.cache.has(cacheKey)) {
+          return this.cache.get(cacheKey)
+        } else {
+          const result = origMethod.apply(target, args)
+          if (result) {
+            // 有效值才存入，null或者undefined存入cache没有意义
+            this.cache.set(cacheKey, result)
+          }
+          return result
+        }
+      }
+    }
+    return origMethod
+  }
+}


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
Api调用支持缓存监听的机制更新，用于减少通信次数


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
- [x] Harmony-Hybrid
