### PR TITLE
feat: [taro-mini-runner]微信小程序tabbar list 中数据类型不匹配时编译时需报错提醒

### DIFF
--- a/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
+++ b/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
@@ -907,6 +907,15 @@ export default class TaroMiniPlugin {
       // eslint-disable-next-line dot-notation
       const list = tabBar['list'] || []
       list.forEach(item => {
+        if (Object.prototype.toString.call(item) !== "[object Object]") {
+          throw new Error(`[ app.json 文件内容错误] app.json: tabBar.list[${index}] 字段需为 object`)
+        }
+        if (!item.hasOwnProperty('pagePath') || item.pagePath === '') {
+            throw new Error(`[ app.json 文件内容错误] app.json: tabBar.list[${index}].pagePath 不能为空`)
+        }
+        if (!item.hasOwnProperty('pagePath') || typeof item.pagePath !== 'string') {
+            throw new Error(`[ app.json 文件内容错误] app.json: tabBar.list[${index}].pagePath 需为 string`)
+        }
         // eslint-disable-next-line dot-notation
         item['iconPath'] && this.tabBarIcons.add(item['iconPath'])
         // eslint-disable-next-line dot-notation

--- a/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
+++ b/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
@@ -910,10 +910,10 @@ export default class TaroMiniPlugin {
         if (Object.prototype.toString.call(item) !== "[object Object]") {
           throw new Error(`[ app.json 文件内容错误] app.json: tabBar.list[${index}] 字段需为 object`)
         }
-        if (!item.hasOwnProperty('pagePath') || item.pagePath === '') {
+        if (!Object.prototype.hasOwnProperty.call(item, "pagePath") || item.pagePath === '') {
             throw new Error(`[ app.json 文件内容错误] app.json: tabBar.list[${index}].pagePath 不能为空`)
         }
-        if (!item.hasOwnProperty('pagePath') || typeof item.pagePath !== 'string') {
+        if (!typeof item.pagePath !== 'string') {
             throw new Error(`[ app.json 文件内容错误] app.json: tabBar.list[${index}].pagePath 需为 string`)
         }
         // eslint-disable-next-line dot-notation

--- a/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
+++ b/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
@@ -906,7 +906,7 @@ export default class TaroMiniPlugin {
     if (tabBar && typeof tabBar === 'object' && !isEmptyObject(tabBar)) {
       // eslint-disable-next-line dot-notation
       const list = tabBar['list'] || []
-      list.forEach(（item, index) => {
+      list.forEach((item, index) => {
         if (Object.prototype.toString.call(item) !== '[object Object]') {
           throw new Error(`[ app.json 文件内容错误] app.json: tabBar.list[${index}] 字段需为 object`)
         }

--- a/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
+++ b/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
@@ -906,7 +906,7 @@ export default class TaroMiniPlugin {
     if (tabBar && typeof tabBar === 'object' && !isEmptyObject(tabBar)) {
       // eslint-disable-next-line dot-notation
       const list = tabBar['list'] || []
-      list.forEach(item => {
+      list.forEach(（item, index) => {
         if (Object.prototype.toString.call(item) !== '[object Object]') {
           throw new Error(`[ app.json 文件内容错误] app.json: tabBar.list[${index}] 字段需为 object`)
         }

--- a/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
+++ b/packages/taro-mini-runner/src/plugins/MiniPlugin.ts
@@ -907,14 +907,14 @@ export default class TaroMiniPlugin {
       // eslint-disable-next-line dot-notation
       const list = tabBar['list'] || []
       list.forEach(item => {
-        if (Object.prototype.toString.call(item) !== "[object Object]") {
+        if (Object.prototype.toString.call(item) !== '[object Object]') {
           throw new Error(`[ app.json 文件内容错误] app.json: tabBar.list[${index}] 字段需为 object`)
         }
-        if (!Object.prototype.hasOwnProperty.call(item, "pagePath") || item.pagePath === '') {
-            throw new Error(`[ app.json 文件内容错误] app.json: tabBar.list[${index}].pagePath 不能为空`)
+        if (!Object.prototype.hasOwnProperty.call(item, 'pagePath') || item.pagePath === '') {
+          throw new Error(`[ app.json 文件内容错误] app.json: tabBar.list[${index}].pagePath 不能为空`)
         }
-        if (!typeof item.pagePath !== 'string') {
-            throw new Error(`[ app.json 文件内容错误] app.json: tabBar.list[${index}].pagePath 需为 string`)
+        if (typeof item.pagePath !== 'string') {
+          throw new Error(`[ app.json 文件内容错误] app.json: tabBar.list[${index}].pagePath 需为 string`)
         }
         // eslint-disable-next-line dot-notation
         item['iconPath'] && this.tabBarIcons.add(item['iconPath'])


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
编译成微信小程序时，若tabbar 的list中存在数据类型不匹配的情况，编译时需做报错提醒


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）

当前情况只会报错：Cannot read properties of null (reading 'iconPath')
