### PR TITLE
fix(runtime): removeEventListener时组件不在componentsAlias引发报错

### DIFF
--- a/packages/taro-runtime/src/dom/element.ts
+++ b/packages/taro-runtime/src/dom/element.ts
@@ -386,11 +386,20 @@ export class TaroElement extends TaroNode {
     if (sideEffect !== false && !this.isAnyEventBinded() && SPECIAL_NODES.indexOf(name) > -1) {
       const componentsAlias = getComponentsAlias()
       const value = isHasExtractProp(this) ? `static-${name}` : `pure-${name}`
-      const valueAlias = componentsAlias[value]._num
-      this.enqueueUpdate({
-        path: `${this._path}.${Shortcuts.NodeName}`,
-        value: valueAlias
-      })
+      const VALUE_ALIAS_NUM = '_num'
+      // 避免当value不在componentsAlias中时报错
+      if (value in componentsAlias && VALUE_ALIAS_NUM in componentsAlias[value]) {
+        const valueAlias = componentsAlias[value][VALUE_ALIAS_NUM]
+        this.enqueueUpdate({
+          path: `${this._path}.${Shortcuts.NodeName}`,
+          value: valueAlias
+        })
+      }
+      // 当value不在componentsAlias中时抛出警告
+      process.env.NODE_ENV !== 'production' && warn(
+        !(value in componentsAlias && VALUE_ALIAS_NUM in componentsAlias[value]),
+        `${value} 不在组件中。`
+      )
     }
   }
 


### PR DESCRIPTION
## PR信息

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- **这个 PR 做了什么?** (简要描述所做更改) -->

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix)  issue: #16012

**这个 PR 涉及以下平台:**

- [x] 所有小程序

## 最小复现

仓库
https://github.com/liulinboyi/taro-removeEventListener-bug

代码
```tsx
import { View, Text } from '@tarojs/components'
import { useState } from 'react'

export default function Index() {
  const [flag, setFlag] = useState(true)

  return (
    <View className='index'>
      <View className='wrapper'>
        {
          flag ?
            <Text className='box' onClick={() => setFlag(prev => !prev)}>Demo {flag ? '1' : '0'}</Text> :
            <Text className='box'>Other {flag ? '1' : '0'}</Text>
        }
      </View>
    </View>
  )
}

```
上述代码编译后运行在微信小程序中时，点击`Demo 1`时，在控制台会抛出错误如下：


![demo_bug](https://github.com/NervJS/taro/assets/41336612/098b2ab7-511d-4202-96b9-2cb1770d4f56)

## 修复
修复后如下:


![demo_bug_2](https://github.com/NervJS/taro/assets/41336612/1a8d8a92-4efb-4079-a584-270c71f17281)
