### PR TITLE
feat: 添加对miniCssExtractLoaderOption的支持

### DIFF
--- a/packages/taro-mini-runner/src/webpack/build.conf.ts
+++ b/packages/taro-mini-runner/src/webpack/build.conf.ts
@@ -59,6 +59,8 @@ export default (appPath: string, mode, config: Partial<IBuildConfig>): any => {
     defineConstants = {},
     runtime = {},
     env = {},
+
+    miniCssExtractLoaderOption = {},
     cssLoaderOption = {},
     sassLoaderOption = {},
     lessLoaderOption = {},
@@ -239,7 +241,7 @@ export default (appPath: string, mode, config: Partial<IBuildConfig>): any => {
       deviceRatio,
       enableSourceMap,
       compile: config.compile || {},
-
+      miniCssExtractLoaderOption,
       cssLoaderOption,
       lessLoaderOption,
       sassLoaderOption,

--- a/packages/taro-mini-runner/src/webpack/chain.ts
+++ b/packages/taro-mini-runner/src/webpack/chain.ts
@@ -148,9 +148,10 @@ export const getMiniXScriptLoader = pipe(mergeOption, partial(getLoader, path.re
 export const getMiniTemplateLoader = pipe(mergeOption, partial(getLoader, path.resolve(__dirname, '../loaders/miniTemplateLoader')))
 export const getResolveUrlLoader = pipe(mergeOption, partial(getLoader, 'resolve-url-loader'))
 
-const getExtractCssLoader = () => {
+const getExtractCssLoader = (miniCssExtractLoaderOption = {}) => {
   return {
-    loader: MiniCssExtractPlugin.loader
+    loader: MiniCssExtractPlugin.loader,
+    options: miniCssExtractLoaderOption
   }
 }
 export const getMiniCssExtractPlugin = pipe(mergeOption, listify, partial(getPlugin, MiniCssExtractPlugin))
@@ -215,6 +216,7 @@ export const getModule = (appPath: string, {
   lessLoaderOption,
   sassLoaderOption,
   stylusLoaderOption,
+  miniCssExtractLoaderOption,
   fontUrlLoaderOption,
   imageUrlLoaderOption,
   mediaUrlLoaderOption,
@@ -252,7 +254,7 @@ export const getModule = (appPath: string, {
     ),
     cssLoaderOption
   ]
-  const extractCssLoader = getExtractCssLoader()
+  const extractCssLoader = getExtractCssLoader(miniCssExtractLoaderOption)
   const miniTemplateLoader = getMiniTemplateLoader([{
     buildAdapter
   }])

--- a/packages/taro-webpack-runner/src/config/dev.conf.ts
+++ b/packages/taro-webpack-runner/src/config/dev.conf.ts
@@ -44,6 +44,7 @@ export default function (appPath: string, config: Partial<BuildConfig>, appHelpe
     defineConstants = {},
     env = {},
     styleLoaderOption = {},
+    miniCssExtractLoaderOption = {},
     cssLoaderOption = {},
     sassLoaderOption = {},
     lessLoaderOption = {},
@@ -74,6 +75,7 @@ export default function (appPath: string, config: Partial<BuildConfig>, appHelpe
     enableSourceMap,
 
     styleLoaderOption,
+    miniCssExtractLoaderOption,
     cssLoaderOption,
     lessLoaderOption,
     sassLoaderOption,

--- a/packages/taro-webpack-runner/src/config/prod.conf.ts
+++ b/packages/taro-webpack-runner/src/config/prod.conf.ts
@@ -46,6 +46,7 @@ export default function (appPath: string, config: Partial<BuildConfig>, appHelpe
     defineConstants = {},
     env = {},
     styleLoaderOption = {},
+    miniCssExtractLoaderOption = {},
     cssLoaderOption = {},
     sassLoaderOption = {},
     lessLoaderOption = {},
@@ -77,7 +78,7 @@ export default function (appPath: string, config: Partial<BuildConfig>, appHelpe
     deviceRatio,
     enableExtract,
     enableSourceMap,
-
+    miniCssExtractLoaderOption,
     styleLoaderOption,
     cssLoaderOption,
     lessLoaderOption,

--- a/packages/taro-webpack-runner/src/utils/chain.ts
+++ b/packages/taro-webpack-runner/src/utils/chain.ts
@@ -129,9 +129,10 @@ const getUrlLoader = pipe(
   mergeOption,
   partial(getLoader, 'url-loader')
 )
-const getExtractCssLoader = () => {
+const getExtractCssLoader = (miniCssExtractLoaderOption = {}) => {
   return {
-    loader: MiniCssExtractPlugin.loader
+    loader: MiniCssExtractPlugin.loader,
+    options: miniCssExtractLoaderOption
   }
 }
 const getImportMetaLoader = pipe(
@@ -217,7 +218,7 @@ export const parseModule = (appPath: string, {
   deviceRatio,
   enableExtract,
   enableSourceMap,
-
+  miniCssExtractLoaderOption,
   styleLoaderOption,
   cssLoaderOption,
   lessLoaderOption,
@@ -312,7 +313,7 @@ export const parseModule = (appPath: string, {
     }
   }, styleLoaderOption])
 
-  const extractCssLoader = getExtractCssLoader()
+  const extractCssLoader = getExtractCssLoader(miniCssExtractLoaderOption)
 
   const lastStyleLoader = enableExtract ? extractCssLoader : styleLoader
 

--- a/packages/taro-webpack5-runner/src/__tests__/__snapshots__/framework.spec.ts.snap
+++ b/packages/taro-webpack5-runner/src/__tests__/__snapshots__/framework.spec.ts.snap
@@ -6269,7 +6269,7 @@ require("./runtime");
 "use strict";
 
 (wx["webpackJsonp"] = wx["webpackJsonp"] || []).push([ [ 539 ], {
-    309: function(__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
+    169: function(__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
         var taro_runtime = __webpack_require__(521);
         var render = function render() {
             var _vm = this, _c = _vm._self._c;
@@ -6355,7 +6355,7 @@ require("./runtime");
         return __webpack_require__(__webpack_require__.s = moduleId);
     };
     __webpack_require__.O(0, [ 592 ], (function() {
-        return __webpack_exec__(309);
+        return __webpack_exec__(169);
     }));
     var __webpack_exports__ = __webpack_require__.O();
 } ]);
@@ -8106,7 +8106,7 @@ require("./runtime");
 "use strict";
 
 (wx["webpackJsonp"] = wx["webpackJsonp"] || []).push([ [ 539 ], {
-    75: function(__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
+    356: function(__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
         var taro_runtime = __webpack_require__(521);
         var render = function render() {
             var _vm = this, _c = _vm._self._c;
@@ -8194,7 +8194,7 @@ require("./runtime");
         return __webpack_require__(__webpack_require__.s = moduleId);
     };
     __webpack_require__.O(0, [ 592 ], (function() {
-        return __webpack_exec__(75);
+        return __webpack_exec__(356);
     }));
     var __webpack_exports__ = __webpack_require__.O();
 } ]);

--- a/packages/taro-webpack5-runner/src/webpack/H5WebpackModule.ts
+++ b/packages/taro-webpack5-runner/src/webpack/H5WebpackModule.ts
@@ -47,6 +47,7 @@ export class H5WebpackModule {
   getModules () {
     const {
       styleLoaderOption = {},
+      miniCssExtractLoaderOption = {},
       sassLoaderOption = {},
       lessLoaderOption = {},
       stylusLoaderOption = {},
@@ -63,7 +64,7 @@ export class H5WebpackModule {
 
     const rule: Record<string, IRule> = {
       taroStyle: this.getTaroStyleRule(styleLoaderOption),
-      customStyle: this.getCustomStyleRule(styleLoaderOption),
+      customStyle: this.getCustomStyleRule(styleLoaderOption, miniCssExtractLoaderOption),
       css: {
         test: REG_STYLE,
         oneOf: this.getCSSLoaders(cssModuleOption)
@@ -146,12 +147,12 @@ export class H5WebpackModule {
   }
 
   /** 开发者的样式在尾部注入 */
-  getCustomStyleRule (styleLoaderOption) {
+  getCustomStyleRule (styleLoaderOption, miniCssExtractLoaderOption) {
     const {
       mode,
       enableExtract = mode === 'production'
     } = this.combination.config
-    const extractCssLoader = WebpackModule.getExtractCSSLoader()
+    const extractCssLoader = WebpackModule.getExtractCSSLoader(miniCssExtractLoaderOption)
     const styleLoader = WebpackModule.getStyleLoader(styleLoaderOption)
     const lastStyleLoader = enableExtract ? extractCssLoader : styleLoader
     return {

--- a/packages/taro-webpack5-runner/src/webpack/MiniWebpackModule.ts
+++ b/packages/taro-webpack5-runner/src/webpack/MiniWebpackModule.ts
@@ -41,6 +41,7 @@ export class MiniWebpackModule {
       sassLoaderOption,
       lessLoaderOption,
       stylusLoaderOption,
+      miniCssExtractLoaderOption,
       designWidth,
       deviceRatio
     } = config
@@ -56,7 +57,7 @@ export class MiniWebpackModule {
 
     const postcssPlugins = getPostcssPlugins(appPath, this.__postcssOption)
 
-    const cssLoaders = this.getCSSLoaders(postcssPlugins, cssModuleOption)
+    const cssLoaders = this.getCSSLoaders(postcssPlugins, cssModuleOption, miniCssExtractLoaderOption)
     const resolveUrlLoader = WebpackModule.getResolveUrlLoader()
     const sassLoader = WebpackModule.getSassLoader(sassLoaderOption)
     const scssLoader = WebpackModule.getScssLoader(sassLoaderOption)
@@ -131,12 +132,12 @@ export class MiniWebpackModule {
     return cssLoadersCopy
   }
 
-  getCSSLoaders (postcssPlugins: any[], cssModuleOption: PostcssOption.cssModules) {
+  getCSSLoaders (postcssPlugins: any[], cssModuleOption: PostcssOption.cssModules, miniCssExtractLoaderOption) {
     const { config } = this.combination
     const {
       cssLoaderOption
     } = config
-    const extractCSSLoader = WebpackModule.getExtractCSSLoader()
+    const extractCSSLoader = WebpackModule.getExtractCSSLoader(miniCssExtractLoaderOption)
     const cssLoader = WebpackModule.getCSSLoader(cssLoaderOption)
     const postCSSLoader = WebpackModule.getPostCSSLoader({
       postcssOptions: {

--- a/packages/taro-webpack5-runner/src/webpack/WebpackModule.ts
+++ b/packages/taro-webpack5-runner/src/webpack/WebpackModule.ts
@@ -71,10 +71,11 @@ export class WebpackModule {
     return WebpackModule.getLoader('css-loader', options)
   }
 
-  static getExtractCSSLoader () {
+  static getExtractCSSLoader (miniCssExtractLoaderOption = {}) {
     const MiniCssExtractPlugin = require('mini-css-extract-plugin')
     return {
-      loader: MiniCssExtractPlugin.loader
+      loader: MiniCssExtractPlugin.loader,
+      options: miniCssExtractLoaderOption
     }
   }
 

--- a/packages/taro/types/compile/config/h5.d.ts
+++ b/packages/taro/types/compile/config/h5.d.ts
@@ -74,6 +74,9 @@ export interface IH5Config {
   /** [style-loader](https://github.com/webpack-contrib/style-loader) 的附加配置 */
   styleLoaderOption?: IOption
 
+   /** [MiniCssExtractPlugin.loader](https://github.com/webpack-contrib/mini-css-extract-plugin) 的附加配置 */
+   miniCssExtractLoaderOption?: IOption
+
   /** [sass-loader](https://github.com/webpack-contrib/sass-loader) 的附加配置 */
   sassLoaderOption?: IOption
 

--- a/packages/taro/types/compile/config/mini.d.ts
+++ b/packages/taro/types/compile/config/mini.d.ts
@@ -71,6 +71,10 @@ export interface IMiniAppConfig {
   /** [stylus-loader](https://github.com/shama/stylus-loader) 的附加配置 */
   stylusLoaderOption?: IOption
 
+  /** [MiniCssExtractPlugin.loader](https://github.com/webpack-contrib/mini-css-extract-plugin) 的附加配置 */
+  miniCssExtractLoaderOption?: IOption
+
+
   /** 针对 mp4 | webm | ogg | mp3 | wav | flac | aac 文件的 [url-loader](https://github.com/webpack-contrib/url-loader) 配置 */
   mediaUrlLoaderOption?: IOption
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
1. 在build-config中可以对MiniCssExtractPlugin.loader的options进行配置

为了使用file协议打开编译后的H5，需要将publicPath设置成'./',
当publicPath时，MiniCssExtractPlugin在抽离css时，当css中包含相对路径引用资源时
编译后的路径会多加一层css目录，导致找不到图片,可以通过设置miniCssExtractLoaderOption来解决这个问题
` { h5:
     {
      publicPath: './',
      miniCssExtractLoaderOption: {
         publicPath: '../',
         esModule: true
     }
}`
 
**这个 PR 是什么类型?** (至少选择一个)
- [ ] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
