### PR TITLE
fix(covertWeb2Hm.ts): 修复 flexGrow 值转换错误导致的鸿蒙渲染无效

### DIFF
--- a/packages/taro-platform-harmony/src/runtime-ets/dom/stylesheet/covertWeb2Hm.ts
+++ b/packages/taro-platform-harmony/src/runtime-ets/dom/stylesheet/covertWeb2Hm.ts
@@ -98,13 +98,13 @@ export default function convertWebStyle2HmStyle(webStyle: CSSProperties, node?: 
             res[index] = index < 2 ? Number(item) : item
           })
         }
-        hmStyle.flexGrow = getUnit(res[0])
+        hmStyle.flexGrow = Number(res[0])
         hmStyle.flexShrink = Number(res[1])
         hmStyle.flexBasis = Number(res[2])
         break
       }
       case 'flexGrow': {
-        hmStyle.flexGrow = getUnit(value)
+        hmStyle.flexGrow = Number(value)
         break
       }
       case 'flexShrink': {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
鸿蒙样式转换时对 flexGrow 增加了单位，导致最终无效，移除单位，转为数字


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [x] 鸿蒙（harmony）
