### PR TITLE
[harmony-hybrid]解决容器共用时，Taro的navigate和原生loadUrl混用问题

### DIFF
--- a/packages/taro-platform-harmony-hybrid/src/api/apis/NativeApi.ts
+++ b/packages/taro-platform-harmony-hybrid/src/api/apis/NativeApi.ts
@@ -619,6 +619,9 @@ export class NativeApi {
   callInstanceAsync (option: any): any {
     return option
   }
+
+  @(asyncAndNotRelease)
+  onNativeNavigate(_options: any): void{}
 }
 
 export interface Status {

--- a/packages/taro-platform-harmony-hybrid/src/api/apis/NativeApi.ts
+++ b/packages/taro-platform-harmony-hybrid/src/api/apis/NativeApi.ts
@@ -621,7 +621,7 @@ export class NativeApi {
   }
 
   @(asyncAndNotRelease)
-  onNativeNavigate(_options: any): void{}
+  onNativeNavigate (_options: any): void {}
 }
 
 export interface Status {

--- a/packages/taro-platform-harmony-hybrid/src/api/apis/taro.ts
+++ b/packages/taro-platform-harmony-hybrid/src/api/apis/taro.ts
@@ -15,7 +15,7 @@ import {
   reLaunch,
   switchTab,
 } from './index'
-import native from "./NativeApi";
+import native from './NativeApi'
 
 const requirePlugin = () => {
   return {
@@ -29,10 +29,10 @@ const requirePlugin = () => {
 
 // 监听原生的Navigate方法
 native.onNativeNavigate({
-  nativeNavigateTo: (url: string)=>{
+  nativeNavigateTo: (url: string) => {
     navigateTo({
       url: url,
-      success: function ( ) {}
+      success: function () {}
     })
   },
   nativeNavigateBack: (delta: number) => {

--- a/packages/taro-platform-harmony-hybrid/src/api/apis/taro.ts
+++ b/packages/taro-platform-harmony-hybrid/src/api/apis/taro.ts
@@ -15,6 +15,7 @@ import {
   reLaunch,
   switchTab,
 } from './index'
+import native from "./NativeApi";
 
 const requirePlugin = () => {
   return {
@@ -24,6 +25,22 @@ const requirePlugin = () => {
     }
   }
 }
+
+
+// 监听原生的Navigate方法
+native.onNativeNavigate({
+  nativeNavigateTo: (url: string)=>{
+    navigateTo({
+      url: url,
+      success: function ( ) {}
+    })
+  },
+  nativeNavigateBack: (delta: number) => {
+    navigateBack({
+      delta: delta
+    })
+  }
+})
 
 loadNavigationStyle()
 registerNavigationStyleHandler()


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
harmony-hybrid平台框架里，js侧向原生侧暴露nativeNavigateTo和nativeNavigateBack Api，支持在容器共用场景的混合路由使用


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
- [x] Harmony-hybrid
