### PR TITLE
fix(taro-vite-runner): 修复 vite h5 dev & build 路径未转 posix 导致的异常

### DIFF
--- a/packages/taro-vite-runner/src/h5/entry.ts
+++ b/packages/taro-vite-runner/src/h5/entry.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 
-import { fs, isEmptyObject } from '@tarojs/helper'
+import { fs, isEmptyObject, normalizePath } from '@tarojs/helper'
 
 import { getDefaultPostcssConfig } from '../postcss/postcss.h5'
 import { appendVirtualModulePrefix, generateQueryString, getMode, getQueryParams } from '../utils'
@@ -14,7 +14,7 @@ export default function (viteCompilerContext: ViteH5CompilerContext): PluginOpti
   const { taroConfig, app } = viteCompilerContext
   const routerConfig = taroConfig.router || {}
   const isProd = getMode(taroConfig) === 'production'
-
+  const configPath = normalizePath(app.configPath)
   return {
     name: 'taro:vite-h5-entry',
     enforce: 'pre',
@@ -22,7 +22,7 @@ export default function (viteCompilerContext: ViteH5CompilerContext): PluginOpti
     async resolveId (source, importer, options) {
       // mpa 模式关于 入口脚本文件 的处理已经解藕到 mpa.ts
       const resolved = await this.resolve(source, importer, { ...options, skipSelf: true })
-      if (resolved?.id && resolved.id === app.configPath) {
+      if (resolved?.id && resolved.id === configPath) {
         const params = {
           [ENTRY_QUERY]: 'true'
         }
@@ -152,7 +152,7 @@ export default function (viteCompilerContext: ViteH5CompilerContext): PluginOpti
           'import "@tarojs/components/global.css"',
           'import { initPxTransform } from "@tarojs/taro"',
           `import { ${routerCreator}, ${historyCreator}, ${appMountHandler} } from "@tarojs/router"`,
-          `import component from "${app.scriptPath}"`,
+          `import component from "${normalizePath(app.scriptPath)}"`,
           'import { window } from "@tarojs/runtime"',
           `import { ${creator} } from "${creatorLocation}"`,
           importFrameworkStatement,

--- a/packages/taro-vite-runner/src/utils/index.ts
+++ b/packages/taro-vite-runner/src/utils/index.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import querystring from 'node:querystring'
 
-import { isNpmPkg, recursiveMerge, REG_NODE_MODULES, resolveSync } from '@tarojs/helper'
+import { isNpmPkg, normalizePath, recursiveMerge, REG_NODE_MODULES, resolveSync } from '@tarojs/helper'
 import { isFunction, isString } from '@tarojs/shared'
 
 import { backSlashRegEx, MINI_EXCLUDE_POSTCSS_PLUGIN_NAME, needsEscapeRegEx, quoteNewlineRegEx } from './constants'
@@ -118,7 +118,7 @@ export function genRouterResource (page: VitePageMeta) {
     'Object.assign({',
     `  path: '${page.name}',`,
     '  load: async function(context, params) {',
-    `    const page = await import("${page.scriptPath}")`,
+    `    const page = await import("${normalizePath(page.scriptPath)}")`,
     '    return [page, context, params]',
     '  }',
     `}, ${JSON.stringify(page.config)})`


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
windows 环境下，vite h5 dev 和 build 时候，resolveId 根据 configPath 判断是否 app.config.ts，但 resolve 后的路径为 posix，configPath 未转换，导致逻辑失效。

这里将 configPath 路径进行转换，同时对 dev 模式下生成 code 路径进行转换，避免 dev 解析失效


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
