### PR TITLE
fix: scriptSource posix issue fail build command

### DIFF
--- a/packages/taro-vite-runner/src/h5/config.ts
+++ b/packages/taro-vite-runner/src/h5/config.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 
-import { defaultMainFields, PLATFORMS, recursiveMerge, REG_NODE_MODULES_DIR } from '@tarojs/helper'
+import { defaultMainFields, PLATFORMS, recursiveMerge, REG_NODE_MODULES_DIR, normalizePath } from '@tarojs/helper'
 import { getSassLoaderOption } from '@tarojs/runner-utils'
 import { isBoolean, isNumber, isObject, isString, PLATFORM_TYPE } from '@tarojs/shared'
 import { get } from 'lodash'
@@ -198,7 +198,7 @@ export default function (viteCompilerContext: ViteH5CompilerContext): PluginOpti
         // mpa 模式关于 html 的处理已经解藕到 mpa.ts
         if (isMultiRouterMode) return html
         const { configPath } = app
-        const scriptSource = configPath.replace(sourceDir, '')
+        const scriptSource = normalizePath(configPath.replace(sourceDir, ''))
         const htmlScript = getHtmlScript(scriptSource, pxtransformOption)
         return html.replace(/<script><%= htmlWebpackPlugin.options.script %><\/script>/, htmlScript)
       },


### PR DESCRIPTION
修复 vite h5 dev & build 路径未转 posix 导致的异常

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修改了路径转换问题导致的build:h5失败


**这个 PR 是什么类型?** (至少选择一个)

- [x ] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
