### PR TITLE
feat: [taro-webpack5-runner MiniWebpackModule]小程序非官方维护端平台，支持React与原生组件混写

### DIFF
--- a/packages/taro-helper/src/constants.ts
+++ b/packages/taro-helper/src/constants.ts
@@ -103,10 +103,10 @@ export const REG_IMAGE = /\.(png|jpe?g|gif|bpm|svg|webp)(\?.*)?$/
 export const REG_FONT = /\.(woff2?|eot|ttf|otf)(\?.*)?$/
 export const REG_JSON = /\.json(\?.*)?$/
 export const REG_UX = /\.ux(\?.*)?$/
-export const REG_TEMPLATE = /\.(wxml|axml|ttml|qml|swan|jxml)(\?.*)?$/
 export const REG_WXML_IMPORT = /<import(.*)?src=(?:(?:'([^']*)')|(?:"([^"]*)"))/gi
 export const REG_URL = /^(?:(?:(?:https?|ftp):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]\.)+(?:[a-z\u00a1-\uffff]{2,}\.?))(?::\d{2,5})?(?:[/?#]\S*)?$/i
 export const CSS_IMPORT_REG = /@import (["'])(.+?)\1;/g
+export const DEFAULT_SUPPORT_TEMPLATE: string[] = ['wxml', 'axml', 'ttml', 'qml', 'swan', 'jxml']
 
 export const NODE_MODULES = 'node_modules'
 export const NODE_MODULES_REG = /(.*)node_modules/

--- a/packages/taro-helper/src/utils.ts
+++ b/packages/taro-helper/src/utils.ts
@@ -7,14 +7,14 @@ import * as path from 'path'
 import {
   CSS_EXT,
   CSS_IMPORT_REG,
+  DEFAULT_SUPPORT_TEMPLATE,
   NODE_MODULES_REG,
   PLATFORMS,
   processTypeEnum,
   processTypeMap,
   REG_JSON,
   SCRIPT_EXT,
-  TARO_CONFIG_FOLDER
-} from './constants'
+  TARO_CONFIG_FOLDER } from './constants'
 import { requireWithEsbuild } from './esbuild'
 import { chalk } from './terminal'
 
@@ -692,6 +692,11 @@ export function readConfig<T extends IReadConfigOptions> (configPath: string, op
     result = readPageConfig(configPath)
   }
   return result
+}
+
+export function getMergeLoaderTemplateReg (templ: string) {
+  const tmepls = [...DEFAULT_SUPPORT_TEMPLATE, templ ? templ?.substring(1) : '']
+  return new RegExp(`\\.(${tmepls.join('|')})(\\?.*)?$`)
 }
 
 export { fs }

--- a/packages/taro-mini-runner/src/webpack/chain.ts
+++ b/packages/taro-mini-runner/src/webpack/chain.ts
@@ -1,6 +1,7 @@
 import {
   chalk,
   fs,
+  getMergeLoaderTemplateReg,
   isNodeModule,
   recursiveMerge,
   REG_CSS,
@@ -13,7 +14,6 @@ import {
   REG_SCRIPTS,
   REG_STYLE,
   REG_STYLUS,
-  REG_TEMPLATE,
   resolveMainFilePath,
   SCRIPT_EXT
 } from '@tarojs/helper'
@@ -430,7 +430,7 @@ export const getModule = (appPath: string, {
     },
     script: scriptRule,
     template: {
-      test: REG_TEMPLATE,
+      test: getMergeLoaderTemplateReg(fileType.templ),
       use: [getFileLoader([{
         useRelativePath: true,
         name: (resourcePath: string) => {

--- a/packages/taro-webpack5-runner/src/webpack/MiniWebpackModule.ts
+++ b/packages/taro-webpack5-runner/src/webpack/MiniWebpackModule.ts
@@ -1,12 +1,12 @@
 import {
+  getMergeLoaderTemplateReg,
   isNodeModule,
   recursiveMerge,
   REG_CSS,
   REG_LESS,
   REG_SASS_SASS,
   REG_SASS_SCSS,
-  REG_STYLUS,
-  REG_TEMPLATE
+  REG_STYLUS
 } from '@tarojs/helper'
 import { cloneDeep } from 'lodash'
 import path from 'path'
@@ -87,7 +87,7 @@ export class MiniWebpackModule {
       script: this.getScriptRule(),
 
       template: {
-        test: REG_TEMPLATE,
+        test: getMergeLoaderTemplateReg(fileType.templ),
         type: 'asset/resource',
         generator: {
           filename ({ filename }) {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
非官方维护小程序端平台插件，支持引入端原生模块混写

1、在小红书小程序开发中，在使用react组件与原生自定义组件混写，会报错：ModuleParseError: Module parse failed: Unexpected token。
2、小红书模版格式为xxx.xhsml，查看taro-webpack5-runner和taro-mini-runner中没有对该模版后缀进行正则匹配。
3、该PR增加：端平台插件传入templ，与官方维护端平台插件templs，进行正则merge


![image](https://github.com/user-attachments/assets/ec26baf7-9f29-409a-b240-f6cfb5b611b6)

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
- [x] 小红书小程序
- [x] 快手小程序
