### PR TITLE
chore(cli): 移除 Vite 模板中的 tsconfig-paths-webpack-plugin

### DIFF
--- a/examples/taro-list/types/global.d.ts
+++ b/examples/taro-list/types/global.d.ts
@@ -25,5 +25,3 @@ declare namespace NodeJS {
     TARO_APP_ID: string
   }
 }
-
-

--- a/packages/taro-cli/templates/default/config/dev.js
+++ b/packages/taro-cli/templates/default/config/dev.js
@@ -1,4 +1,4 @@
-{{#if typescript }}import type { UserConfigExport } from "@tarojs/cli";
+{{#if typescript }}import type { UserConfigExport } from '@tarojs/cli'
 {{/if}}
 export default {
   {{#if (eq compiler "Webpack5") }} logger: {

--- a/packages/taro-cli/templates/default/config/index.js
+++ b/packages/taro-cli/templates/default/config/index.js
@@ -1,5 +1,5 @@
 import { defineConfig{{#if typescript }}, type UserConfigExport{{/if}} } from '@tarojs/cli'
-{{#if typescript }}import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin'{{/if}}
+{{#if eq compiler "Webpack5" }}{{#if typescript }}import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin'{{/if}}{{/if}}
 import devConfig from './dev'
 import prodConfig from './prod'
 

--- a/packages/taro-cli/templates/default/config/prod.js
+++ b/packages/taro-cli/templates/default/config/prod.js
@@ -1,4 +1,4 @@
-{{#if typescript }}import type { UserConfigExport } from "@tarojs/cli";
+{{#if typescript }}import type { UserConfigExport } from '@tarojs/cli'
 {{/if}}
 export default {
   mini: {},


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

1. 移除 Vite 模板中多余引入的 `tsconfig-paths-webpack-plugin`
2. 美化一部分代码格式


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [x] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
