### PR TITLE
fix: move textProps into the PickerStandardProps

### DIFF
--- a/packages/taro-components/types/Picker.d.ts
+++ b/packages/taro-components/types/Picker.d.ts
@@ -25,6 +25,11 @@ interface PickerStandardProps extends StandardProps, FormItemProps {
    * @supported weapp, h5, rn, harmony, harmony_hybrid
    */
   onCancel?: CommonEventFunction
+  /**
+   * 用于替换组件内部文本
+   * @supported h5, harmony, harmony_hybrid
+   */
+  textProps?: PickerStandardProps.PickerText
 }
 declare namespace PickerStandardProps {
   /** 选择器类型 */
@@ -87,11 +92,6 @@ interface PickerSelectorProps extends PickerStandardProps {
    * @supported weapp, h5, rn, harmony, harmony_hybrid
    */
   onChange?: CommonEventFunction<PickerSelectorProps.ChangeEventDetail>
-  /**
-   * 用于替换组件内部文本
-   * @supported h5, harmony, harmony_hybrid
-   */
-  textProps?: PickerStandardProps.PickerText
 }
 declare namespace PickerSelectorProps {
   interface ChangeEventDetail {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
将 textProps 移动到 PickerStandardProps 以获得准确的 ts 提示


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [X] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [X] Web 平台（H5）
- [ ] 移动端（React-Native）
- [X] 鸿蒙（harmony）
