### PR TITLE
feat: 为微信小程序添加 openOfficialAccountArticle 接口

### DIFF
--- a/examples/mini-program-example/src/pages/api/redirection/index.tsx
+++ b/examples/mini-program-example/src/pages/api/redirection/index.tsx
@@ -17,6 +17,10 @@ export default class Index extends React.Component {
         func: null,
       },
       {
+        id: 'openOfficialAccountArticle',
+        func: null
+      },
+      {
         id: 'openEmbeddedMiniProgram',
         func: null,
       },

--- a/packages/babel-plugin-transform-taroapi/__tests__/__mocks__/harmony-definition.json
+++ b/packages/babel-plugin-transform-taroapi/__tests__/__mocks__/harmony-definition.json
@@ -1287,6 +1287,11 @@
       "success": "void",
       "return": "Promise<Partial<CallbackResult> & Record<string, unknown> & CallbackResult>"
     },
+    "openOfficialAccountArticle": {
+      "object": "*",
+      "success": "void",
+      "return": "Promise<Partial<CallbackResult> & Record<string, unknown> & CallbackResult>"
+    },
     "openEmbeddedMiniProgram": {
       "object": "*",
       "success": "void",

--- a/packages/taro-h5/src/api/navigate/index.ts
+++ b/packages/taro-h5/src/api/navigate/index.ts
@@ -1,6 +1,7 @@
 import { temporarilyNotSupport } from '../../utils'
 
 // 跳转
+export const openOfficialAccountArticle = /* @__PURE__ */ temporarilyNotSupport('openOfficialAccountArticle')
 export const openEmbeddedMiniProgram = /* @__PURE__ */ temporarilyNotSupport('openEmbeddedMiniProgram')
 export const navigateToMiniProgram = /* @__PURE__ */ temporarilyNotSupport('navigateToMiniProgram')
 export const navigateBackMiniProgram = /* @__PURE__ */ temporarilyNotSupport('navigateBackMiniProgram')

--- a/packages/taro-platform-harmony-hybrid/build/config/harmony-definition.json
+++ b/packages/taro-platform-harmony-hybrid/build/config/harmony-definition.json
@@ -1547,6 +1547,7 @@
     "openChannelsUserProfile": true,
     "openCustomerServiceChat": false,
     "openDocument": true,
+    "openOfficialAccountArticle": false,
     "openEmbeddedMiniProgram": false,
     "openLocation": {
       "object": {

--- a/packages/taro-platform-harmony-hybrid/src/api/apis/comments.ts
+++ b/packages/taro-platform-harmony-hybrid/src/api/apis/comments.ts
@@ -1171,6 +1171,12 @@
  */
 
 /**
+ * 通过小程序打开任意公众号文章
+ *
+ * @canNotUse openOfficialAccountArticle
+ */
+
+/**
  * 打开半屏小程序
  *
  * @canNotUse openEmbeddedMiniProgram

--- a/packages/taro-platform-harmony/src/apis/navigate/index.ts
+++ b/packages/taro-platform-harmony/src/apis/navigate/index.ts
@@ -1,6 +1,7 @@
 import { temporarilyNotSupport } from '../utils'
 
 // 跳转
+export const openOfficialAccountArticle = /* @__PURE__ */ temporarilyNotSupport('openOfficialAccountArticle')
 export const openEmbeddedMiniProgram = /* @__PURE__ */ temporarilyNotSupport('openEmbeddedMiniProgram')
 export const navigateToMiniProgram = /* @__PURE__ */ temporarilyNotSupport('navigateToMiniProgram')
 export const navigateBackMiniProgram = /* @__PURE__ */ temporarilyNotSupport('navigateBackMiniProgram')

--- a/packages/taro-platform-weapp/src/apis-list.ts
+++ b/packages/taro-platform-weapp/src/apis-list.ts
@@ -30,4 +30,5 @@ export const needPromiseApis = new Set([
   'setWindowSize',
   'sendBizRedPacket',
   'startFacialRecognitionVerify',
+  'openOfficialAccountArticle'
 ])

--- a/packages/taro-platform-weapp/src/apis-list.ts
+++ b/packages/taro-platform-weapp/src/apis-list.ts
@@ -23,12 +23,12 @@ export const needPromiseApis = new Set([
   'openChannelsLive',
   'openChannelsUserProfile',
   'openCustomerServiceChat',
+  'openOfficialAccountArticle',
   'openVideoEditor',
   'saveFileToDisk',
   'scanItem',
   'setEnable1v1Chat',
   'setWindowSize',
   'sendBizRedPacket',
-  'startFacialRecognitionVerify',
-  'openOfficialAccountArticle'
+  'startFacialRecognitionVerify'
 ])

--- a/packages/taro/types/api/navigate/index.d.ts
+++ b/packages/taro/types/api/navigate/index.d.ts
@@ -6,9 +6,9 @@ declare module '../../index' {
       /** 需要打开的公众号地址 **/
       url: string
       /** 接口调用成功的回调函数 **/
-      success?: (res: TaroGeneral.CallbackResult) => void
+      success?: (res: SuccessCallbackResult) => void
       /** 接口调用失败的回调函数 */
-      fail?: (res: TaroGeneral.CallbackResult) => void
+      fail?: (res: FailCallbackResult) => void
       /** 接口调用结束的回调函数（调用成功、失败都会执行） */
       complete?: (res: TaroGeneral.CallbackResult) => void
     }
@@ -18,7 +18,10 @@ declare module '../../index' {
       cancel: boolean
       /** 为 true 时，表示用户点击了确定按钮 */
       confirm: boolean
-      /** 调用结果 */
+    }
+
+    interface FailCallbackResult extends TaroGeneral.CallbackResult {
+      /** 错误信息 */
       errMsg: string
       /** 错误码 */
       errCode: number

--- a/packages/taro/types/api/navigate/index.d.ts
+++ b/packages/taro/types/api/navigate/index.d.ts
@@ -253,7 +253,7 @@ declare module '../../index' {
      * @supported weapp
      * @see https://developers.weixin.qq.com/miniprogram/dev/api/navigate/wx.openOfficialAccountArticle.html
      */
-    openOfficialAccountArticle(option: openOfficialAccountArticle.Option): Promise<openOfficialAccountArticle.SuccessCallbackResult>
+    openOfficialAccountArticle(option: openOfficialAccountArticle.Option): Promise<openOfficialAccountArticle.SuccessCallbackResult | openOfficialAccountArticle.FailCallbackResult>
 
     /** 打开半屏小程序。接入指引请参考 [半屏小程序能力](https://developers.weixin.qq.com/miniprogram/dev/framework/open-ability/openEmbeddedMiniProgram.html)。
      * @supported weapp

--- a/packages/taro/types/api/navigate/index.d.ts
+++ b/packages/taro/types/api/navigate/index.d.ts
@@ -12,6 +12,17 @@ declare module '../../index' {
       /** 接口调用结束的回调函数（调用成功、失败都会执行） */
       complete?: (res: TaroGeneral.CallbackResult) => void
     }
+
+    interface SuccessCallbackResult extends TaroGeneral.CallbackResult {
+      /** 为 true 时，表示用户点击了取消（用于 Android 系统区分点击蒙层关闭还是点击取消按钮关闭） */
+      cancel: boolean
+      /** 为 true 时，表示用户点击了确定按钮 */
+      confirm: boolean
+      /** 调用结果 */
+      errMsg: string
+      /** 错误码 */
+      errCode: number
+    }
   }
 
   namespace openEmbeddedMiniProgram {
@@ -235,6 +246,12 @@ declare module '../../index' {
   }
 
   interface TaroStatic {
+    /** 通过小程序打开任意公众号文章（不包括临时链接等异常状态下的公众号文章）
+     * @supported weapp
+     * @see https://developers.weixin.qq.com/miniprogram/dev/api/navigate/wx.openOfficialAccountArticle.html
+     */
+    openOfficialAccountArticle(option: openOfficialAccountArticle.Option): Promise<openOfficialAccountArticle.SuccessCallbackResult>
+
     /** 打开半屏小程序。接入指引请参考 [半屏小程序能力](https://developers.weixin.qq.com/miniprogram/dev/framework/open-ability/openEmbeddedMiniProgram.html)。
      * @supported weapp
      * @see https://developers.weixin.qq.com/miniprogram/dev/api/navigate/wx.openEmbeddedMiniProgram.html

--- a/packages/taro/types/api/navigate/index.d.ts
+++ b/packages/taro/types/api/navigate/index.d.ts
@@ -10,7 +10,7 @@ declare module '../../index' {
       /** 接口调用失败的回调函数 */
       fail?: (res: FailCallbackResult) => void
       /** 接口调用结束的回调函数（调用成功、失败都会执行） */
-      complete?: (res: TaroGeneral.CallbackResult) => void
+      complete?: (res: CompleteCallbackResult) => void
     }
 
     interface SuccessCallbackResult extends TaroGeneral.CallbackResult {
@@ -21,10 +21,17 @@ declare module '../../index' {
     }
 
     interface FailCallbackResult extends TaroGeneral.CallbackResult {
-      /** 错误信息 */
-      errMsg: string
       /** 错误码 */
       errCode: number
+    }
+
+    interface CompleteCallbackResult extends TaroGeneral.CallbackResult {
+      /** 为 true 时，表示用户点击了取消（用于 Android 系统区分点击蒙层关闭还是点击取消按钮关闭） */
+      cancel: boolean
+      /** 为 true 时，表示用户点击了确定按钮 */
+      confirm: boolean
+      /** 用户点击了确定按钮后返回内容 */
+      content?: null
     }
   }
 
@@ -253,7 +260,7 @@ declare module '../../index' {
      * @supported weapp
      * @see https://developers.weixin.qq.com/miniprogram/dev/api/navigate/wx.openOfficialAccountArticle.html
      */
-    openOfficialAccountArticle(option: openOfficialAccountArticle.Option): Promise<openOfficialAccountArticle.SuccessCallbackResult | openOfficialAccountArticle.FailCallbackResult>
+    openOfficialAccountArticle(option: openOfficialAccountArticle.Option): Promise<openOfficialAccountArticle.SuccessCallbackResult>
 
     /** 打开半屏小程序。接入指引请参考 [半屏小程序能力](https://developers.weixin.qq.com/miniprogram/dev/framework/open-ability/openEmbeddedMiniProgram.html)。
      * @supported weapp

--- a/packages/taro/types/api/navigate/index.d.ts
+++ b/packages/taro/types/api/navigate/index.d.ts
@@ -1,6 +1,19 @@
 import Taro from '../../index'
 
 declare module '../../index' {
+  namespace openOfficialAccountArticle {
+    interface Option {
+      /** 需要打开的公众号地址 **/
+      url: string
+      /** 接口调用成功的回调函数 **/
+      success?: (res: TaroGeneral.CallbackResult) => void
+      /** 接口调用失败的回调函数 */
+      fail?: (res: TaroGeneral.CallbackResult) => void
+      /** 接口调用结束的回调函数（调用成功、失败都会执行） */
+      complete?: (res: TaroGeneral.CallbackResult) => void
+    }
+  }
+
   namespace openEmbeddedMiniProgram {
     interface Option {
       /** 要打开的小程序 appId */


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
添加微信小程序从基础库 3.4.8 开始支持的 wx.openOfficialAccountArticle 接口
功能描述：通过小程序打开任意公众号文章（不包括临时链接等异常状态下的公众号文章），必须有点击行为才能调用成功。
官方文档：https://developers.weixin.qq.com/miniprogram/dev/api/navigate/wx.openOfficialAccountArticle.html


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
