### PR TITLE
fix: 修复4.0.5版本下ScrollView内嵌Swiper时，Swiper滑动无响应的问题

### DIFF
--- a/packages/taro-components-react/src/components/swiper/index.tsx
+++ b/packages/taro-components-react/src/components/swiper/index.tsx
@@ -186,6 +186,7 @@ class SwiperInner extends React.Component<SwiperProps, SwiperState> {
       speed: parseInt(String(duration), 10),
       observer: true,
       observeParents: true,
+      nested: true,
       loopAdditionalSlides,
       centeredSlides,
       ...effectsProps,

--- a/packages/taro-components/src/components/swiper/swiper.tsx
+++ b/packages/taro-components/src/components/swiper/swiper.tsx
@@ -324,6 +324,7 @@ export class Swiper implements ComponentInterface {
       observer: true,
       centeredSlides: centeredSlides,
       zoom: this.zoom,
+      nested: true,
       ...effectsProps,
       on: {
         changeTransitionEnd(e) {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

问题表象：@tarojs/components 4.0.5版本下，使用ScrollView内嵌Swiper时，滑动Swiper失效。

问题原因：
@tarojs/components 4.0.5版本里，引用的swiper版本是11.1.0。这个版本的swiper的滑动监听touchmove默认绑定在document上（冒泡阶段）。
但使用ScrollView时，在touchmove中会调用event.stopPropagation()拦截掉事件的冒泡，导致其内嵌的Swiper滑动无响应。

问题处理思路：
修改默认参数nested，将其默认设置为true。这样的话，swiper的touchmove还是document上监听，但是是捕获阶段监听，就不会被ScrollView拦截掉。


**这个 PR 是什么类型?** (至少选择一个)

- [X] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [X] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
