### PR TITLE
fix: 修复Taro使用原生页面（微信小程序）时, .wxml中的src={{url}},来自data的url被异常解析的bug

### DIFF
--- a/packages/taro-webpack5-runner/src/loaders/miniTemplateLoader.ts
+++ b/packages/taro-webpack5-runner/src/loaders/miniTemplateLoader.ts
@@ -1,5 +1,6 @@
 import { isUrlRequest, urlToRequest } from 'loader-utils'
 import sax from 'sax'
+import { isSpecialFormat } from '../utils/index'
 
 export default function miniTemplateLoader (source) {
   this.cacheable && this.cacheable()
@@ -20,6 +21,8 @@ export default function miniTemplateLoader (source) {
 
   parser.onattribute = ({ name, value }) => {
     if (value && (name === 'src' || name === 'from') && isUrlRequest(value)) {
+      if (isSpecialFormat(name, value)) return
+
       const request = urlToRequest(value)
       requests.add(request)
     }

--- a/packages/taro-webpack5-runner/src/loaders/miniTemplateLoader.ts
+++ b/packages/taro-webpack5-runner/src/loaders/miniTemplateLoader.ts
@@ -1,5 +1,6 @@
 import { isUrlRequest, urlToRequest } from 'loader-utils'
 import sax from 'sax'
+
 import { isSpecialFormat } from '../utils/index'
 
 export default function miniTemplateLoader (source) {

--- a/packages/taro-webpack5-runner/src/utils/index.ts
+++ b/packages/taro-webpack5-runner/src/utils/index.ts
@@ -45,3 +45,12 @@ export const formatOpenHost = (host?: string) => {
 export function parsePublicPath (publicPath = '/') {
   return ['', 'auto'].includes(publicPath) ? publicPath : addTrailingSlash(publicPath)
 }
+
+export function isSpecialFormat(key: string, value: string) {
+  if (key === 'src' && /{{\s*\w+\s*}}/.test(value)) {
+    // in .wxml, the value url in <web-view src="{{url}}"/> should not be requested, it is a state value in page data
+    return true
+  }
+
+  return false
+}


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
Taro使用原生页面（小程序）时, 如果原生的小程序页面wxml有如下代码:（一个标签的src属性被赋值为一个data中的state值）
```
<web-view src="{{ url }}"></web-view>
```
来自data中的state值url会被异常解析


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
