### PR TITLE
feat: 支持 onError 获取 error 对象

### DIFF
--- a/packages/taro-framework-react/src/runtime/connect.ts
+++ b/packages/taro-framework-react/src/runtime/connect.ts
@@ -117,7 +117,7 @@ export function connectReactPage (
       }
 
       static getDerivedStateFromError (error: Error) {
-        Current.app?.onError?.(error.message + error.stack)
+        Current.app?.onError?.(error.message + error.stack, error)
         return { hasError: true }
       }
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
onError 添加参数，返回原始 error 对象

我们做错误监控的时候捕获了 onError 的对象，但是由于返回的是一个字符串无法解析，里面包含了 statck 的信息，会导致错误聚合问题


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [ x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
