### PR TITLE
fix: 🐛 taro-h5 处理IntersectionObserver初始调用不触发回调的问题

### DIFF
--- a/packages/taro-h5/src/api/wxml/IntersectionObserver.ts
+++ b/packages/taro-h5/src/api/wxml/IntersectionObserver.ts
@@ -61,7 +61,6 @@ export class TaroH5IntersectionObserver implements Taro.IntersectionObserver {
           // 使用时间戳而不是entry.time，跟微信小程序一致
           time: Date.now(),
         }
-
         // web端会默认首次触发
         if (!this._isInited) {
           // 初始的相交比例，如果调用时检测到的相交比例与这个值不相等且达到阈值，则会触发一次监听器的回调函数。

--- a/packages/taro-h5/src/api/wxml/IntersectionObserver.ts
+++ b/packages/taro-h5/src/api/wxml/IntersectionObserver.ts
@@ -61,10 +61,14 @@ export class TaroH5IntersectionObserver implements Taro.IntersectionObserver {
           // 使用时间戳而不是entry.time，跟微信小程序一致
           time: Date.now(),
         }
+        
         // web端会默认首次触发
-        if (!this._isInited && this._options.initialRatio <= Math.min.apply(Math, this._options.thresholds)) {
+        if (!this._isInited) {
           // 初始的相交比例，如果调用时检测到的相交比例与这个值不相等且达到阈值，则会触发一次监听器的回调函数。
-          return
+          const [min, max] = [Math.min(this._options.initialRatio, entry.intersectionRatio), Math.max(this._options.initialRatio, entry.intersectionRatio)];
+          if(this._options.initialRatio === entry.intersectionRatio || !this._options.thresholds.some(value => value >= min && value <= max)) {
+            return
+          }
         }
         _callback && _callback.call(this, result)
       })

--- a/packages/taro-h5/src/api/wxml/IntersectionObserver.ts
+++ b/packages/taro-h5/src/api/wxml/IntersectionObserver.ts
@@ -61,12 +61,12 @@ export class TaroH5IntersectionObserver implements Taro.IntersectionObserver {
           // 使用时间戳而不是entry.time，跟微信小程序一致
           time: Date.now(),
         }
-        
+
         // web端会默认首次触发
         if (!this._isInited) {
           // 初始的相交比例，如果调用时检测到的相交比例与这个值不相等且达到阈值，则会触发一次监听器的回调函数。
-          const [min, max] = [Math.min(this._options.initialRatio, entry.intersectionRatio), Math.max(this._options.initialRatio, entry.intersectionRatio)];
-          if(this._options.initialRatio === entry.intersectionRatio || !this._options.thresholds.some(value => value >= min && value <= max)) {
+          const [min, max] = [Math.min(this._options.initialRatio, entry.intersectionRatio), Math.max(this._options.initialRatio, entry.intersectionRatio)]
+          if (this._options.initialRatio === entry.intersectionRatio || !this._options.thresholds.some(value => value >= min && value <= max)) {
             return
           }
         }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
Taro.createIntersectionObserver， 在 **没有设定initialRatio和thresholds** 或者 **设定的initialRatio小于等于thresholds中的最小元素** 的情况下，不会在初始调用时触发回调，和微信小程序环境表现不一致


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
