### PR TITLE
fix: babel plugin incorrect usage bug

### DIFF
--- a/packages/babel-preset-taro/index.js
+++ b/packages/babel-preset-taro/index.js
@@ -183,7 +183,7 @@ module.exports = (_, options = {}) => {
         legacy: decoratorsLegacy !== false,
       },
     ],
-    [require('@babel/plugin-proposal-class-properties'), { loose }]
+    [require('@babel/plugin-transform-class-properties'), { loose }]
   )
 
   plugins.push([


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

更新 babel 使用的插件名称

[@babel/plugin-proposal-class-properties](https://www.npmjs.com/package/@babel/plugin-proposal-class-properties) 插件已弃用，应采用 [@babel/plugin-transform-class-properties](https://www.npmjs.com/package/@babel/plugin-transform-class-properties)

注意到 package.json 中已更新使用新插件，但 index.js 中尚未更新使用新插件

查看提交记录注意到 [2ca1ce59c49d7900f6a098165299c2c52ea0548d](https://github.com/NervJS/taro/commit/2ca1ce59c49d7900f6a098165299c2c52ea0548d#diff-995e38033f29a5c3dd25bd338baf27b740b6cba2ca798181c9bd390e6b077729R29) 提交已更新，但在 [c7688632f566016465e257756707acafbac604a6 ](https://github.com/NervJS/taro/commit/c7688632f566016465e257756707acafbac604a6#diff-4b9fa15435482f1e950a9f332ee21ffc812b417191a7302bab115cf0fb3d610dR179) 中意外地恢复为弃用的原插件

在合并该 PR 后，就可以回退 [5400d1f4bd538bdb5e022e0a3abccb92f1483826](https://github.com/NervJS/taro/commit/5400d1f4bd538bdb5e022e0a3abccb92f1483826#diff-6eeac9f03bb102ede2f62be2e05878675d7b1491a3a288b33cf67a1622731ee3R66), 从项目模板中移除该弃用的插件

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
