### PR TITLE
fix: 使用innerHTML赋值后转小程序时，a标签转view标签+img转image标签时，把width和height写入style属性

### DIFF
--- a/packages/taro-runtime/src/dom-external/inner-html/parser.ts
+++ b/packages/taro-runtime/src/dom-external/inner-html/parser.ts
@@ -127,6 +127,24 @@ function format (
         parent?.appendChild(text)
         return text
       }
+      // img标签,把width和height写入style,删除原有的width、height和style属性
+      if (child.tagName === 'img') {
+        let styleText = ''
+        const toBeRemovedIndexs: number[] = []
+        for (let i = 0; i < child.attributes.length; i++) {
+          const attr = child.attributes[i]
+          const [key, value] = splitEqual(attr)
+          if (key === 'width' || key === 'height') {
+            styleText += `${key}:${value};`
+            toBeRemovedIndexs.push(i)
+          } else if (key === 'style') {
+            styleText = `${styleText}${value};`
+            toBeRemovedIndexs.push(i)
+          }
+        }
+        child.attributes = child.attributes.filter((_, index) => !toBeRemovedIndexs.includes(index))
+        child.attributes.push(`style=${styleText.replace(/['"]/g, '')}`)
+      }
 
       const el: ParsedTaroElement = document.createElement(getTagName(child.tagName))
       el.h5tagName = child.tagName

--- a/packages/taro-runtime/src/dom-external/inner-html/parser.ts
+++ b/packages/taro-runtime/src/dom-external/inner-html/parser.ts
@@ -3,7 +3,7 @@ import { isFunction } from '@tarojs/shared'
 import { options } from '../../options'
 import { Scaner, Token } from './scaner'
 import StyleTagParser from './style'
-import { isBlockElements, isInlineElements, isMiniElements, specialMiniElements } from './tags'
+import { getSpecialElementMapping, isBlockElements, isInlineElements, isMiniElements, isSpecialElements, specialMiniElements } from './tags'
 import { unquote } from './utils'
 
 import type { TaroDocument } from '../../dom/document'
@@ -47,7 +47,7 @@ export interface Element extends Node {
   attributes: string[]
 }
 
-export interface ParsedTaroElement extends TaroElement{
+export interface ParsedTaroElement extends TaroElement {
   h5tagName?: string
 }
 
@@ -71,7 +71,23 @@ function hasTerminalParent (tagName: string, stack: Element[]) {
   return false
 }
 
-function getTagName (tag: string) {
+/**
+ * 将属性数组转换为属性对象
+ * @param attributes 字符串数组，包含属性信息
+ * @returns 属性对象，键为属性名，值为属性值或true
+ */
+function attributesArray2Props (attributes: string[]): Record<string, string | true> {
+  const props: Record<string, string | true> = {}
+  for (let i = 0; i < attributes.length; i++) {
+    const attr = attributes[i]
+    const [key, value] = splitEqual(attr)
+    props[key] = value == null ? true : unquote(value)
+  }
+
+  return props
+}
+
+function getTagName (tag: string, attributes: string[]) {
   if (options.html!.renderHTMLTag) {
     return tag
   }
@@ -84,6 +100,14 @@ function getTagName (tag: string) {
     return 'view'
   } else if (isInlineElements(tag)) {
     return 'text'
+  } else if (isSpecialElements(tag)) {
+    // if it's special tag, the real tag is determined by the config mapping
+    const mapping = getSpecialElementMapping(tag)
+    const props = attributesArray2Props(attributes)
+
+    if (mapping) {
+      return mapping.mapName(props)
+    }
   }
 
   return 'view'
@@ -146,7 +170,7 @@ function format (
         child.attributes.push(`style=${styleText.replace(/['"]/g, '')}`)
       }
 
-      const el: ParsedTaroElement = document.createElement(getTagName(child.tagName))
+      const el: ParsedTaroElement = document.createElement(getTagName(child.tagName, child.attributes))
       el.h5tagName = child.tagName
 
       parent?.appendChild(el)

--- a/packages/taro-runtime/src/dom-external/inner-html/tags.ts
+++ b/packages/taro-runtime/src/dom-external/inner-html/tags.ts
@@ -1,4 +1,4 @@
-import { internalComponents } from '@tarojs/shared'
+import { internalComponents, isString } from '@tarojs/shared'
 
 export function makeMap (
   str: string,
@@ -17,6 +17,25 @@ export const specialMiniElements = {
   iframe: 'web-view'
 }
 
+interface SpecialMap {
+  mapName: (props: Record<string, string | boolean>) => string
+}
+
+const specialElements = new Map<string, SpecialMap>([
+  ['a', {
+    mapName (props) {
+      if (props.as && isString(props.as)) return props.as.toLowerCase()
+      return !props.href || isString(props.href) && (/^javascript/.test(props.href)) ? 'view' : 'navigator'
+    }
+  }],
+])
+
+export const getSpecialElementMapping = (tag: string, expectsLowerCase:boolean = true) => {
+  tag = expectsLowerCase ? tag.toLowerCase() : tag
+  return specialElements.get(tag)
+}
+
+
 const internalCompsList = Object.keys(internalComponents)
   .map(i => i.toLowerCase())
   .join(',')
@@ -25,7 +44,10 @@ const internalCompsList = Object.keys(internalComponents)
 export const isMiniElements = makeMap(internalCompsList, true)
 
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements
-export const isInlineElements = makeMap('a,i,abbr,iframe,select,acronym,slot,small,span,bdi,kbd,strong,big,map,sub,sup,br,mark,mark,meter,template,canvas,textarea,cite,object,time,code,output,u,data,picture,tt,datalist,var,dfn,del,q,em,s,embed,samp,b', true)
+export const isInlineElements = makeMap('i,abbr,iframe,select,acronym,slot,small,span,bdi,kbd,strong,big,map,sub,sup,br,mark,mark,meter,template,canvas,textarea,cite,object,time,code,output,u,data,picture,tt,datalist,var,dfn,del,q,em,s,embed,samp,b', true)
 
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements
 export const isBlockElements = makeMap('address,fieldset,li,article,figcaption,main,aside,figure,nav,blockquote,footer,ol,details,form,p,dialog,h1,h2,h3,h4,h5,h6,pre,dd,header,section,div,hgroup,table,dl,hr,ul,dt', true)
+
+// specialElements
+export const isSpecialElements = makeMap('a', true)


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
1. 对于innerHTML生成的小程序, a标签（innerHTML）的转换逻辑保持跟直接a标签一致
2. 对于innerHTML生成的小程序, img=>image时，如果有width和height，把这2个值写入style属性内的最前部分

**这个 PR 是什么类型?** (至少选择一个)

- [X] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [X] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
