### PR TITLE
fix: 使用innerHTML赋值后转小程序时，a标签转view标签+img转image标签时，把width和height写入style属性【latest】

### DIFF
--- a/packages/taro-runtime/src/dom-external/inner-html/parser.ts
+++ b/packages/taro-runtime/src/dom-external/inner-html/parser.ts
@@ -47,7 +47,7 @@ export interface Element extends Node {
   attributes: string[]
 }
 
-export interface ParsedTaroElement extends TaroElement{
+export interface ParsedTaroElement extends TaroElement {
   h5tagName?: string
 }
 
@@ -126,6 +126,20 @@ function format (
         }
         parent?.appendChild(text)
         return text
+      }
+      // img标签,把width和height写入style
+      if (child.tagName === 'img') {
+        let styleText = ''
+        for (let i = 0; i < child.attributes.length; i++) {
+          const attr = child.attributes[i]
+          const [key, value] = splitEqual(attr)
+          if (key === 'width' || key === 'height') {
+            styleText += `${key}:${value};`
+          } else if (key === 'style') {
+            styleText = `${styleText}${value};`
+          }
+        }
+        child.attributes.push(`style=${styleText.replace(/['"]/g, '')}`)
       }
 
       const el: ParsedTaroElement = document.createElement(getTagName(child.tagName))

--- a/packages/taro-runtime/src/dom-external/inner-html/tags.ts
+++ b/packages/taro-runtime/src/dom-external/inner-html/tags.ts
@@ -25,7 +25,7 @@ const internalCompsList = Object.keys(internalComponents)
 export const isMiniElements = makeMap(internalCompsList, true)
 
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements
-export const isInlineElements = makeMap('a,i,abbr,iframe,select,acronym,slot,small,span,bdi,kbd,strong,big,map,sub,sup,br,mark,mark,meter,template,canvas,textarea,cite,object,time,code,output,u,data,picture,tt,datalist,var,dfn,del,q,em,s,embed,samp,b', true)
+export const isInlineElements = makeMap('i,abbr,iframe,select,acronym,slot,small,span,bdi,kbd,strong,big,map,sub,sup,br,mark,mark,meter,template,canvas,textarea,cite,object,time,code,output,u,data,picture,tt,datalist,var,dfn,del,q,em,s,embed,samp,b', true)
 
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements
-export const isBlockElements = makeMap('address,fieldset,li,article,figcaption,main,aside,figure,nav,blockquote,footer,ol,details,form,p,dialog,h1,h2,h3,h4,h5,h6,pre,dd,header,section,div,hgroup,table,dl,hr,ul,dt', true)
+export const isBlockElements = makeMap('a,address,fieldset,li,article,figcaption,main,aside,figure,nav,blockquote,footer,ol,details,form,p,dialog,h1,h2,h3,h4,h5,h6,pre,dd,header,section,div,hgroup,table,dl,hr,ul,dt', true)


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
1. 对于innerHTML生成的小程序, a=>text 变成 a=>view
2. 对于innerHTML生成的小程序, img=>image时，如果有width和height，把这2个值写入style属性内


**这个 PR 是什么类型?** (至少选择一个)

- [X] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [X] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
