### PR TITLE
fix: 修复IOS端H5-选中视频-不触发成功/失败回调-latest

### DIFF
--- a/packages/taro-h5/src/api/media/video/chooseMedia.ts
+++ b/packages/taro-h5/src/api/media/video/chooseMedia.ts
@@ -1,6 +1,7 @@
 import Taro from '@tarojs/api'
 import { isMobile } from 'is-mobile'
 
+import { getDeviceInfo } from '../../../api/base/system'
 import { showActionSheet } from '../../../api/ui'
 import { getParameterError, shouldBeObject } from '../../../utils'
 import { MethodHandler } from '../../../utils/handler'
@@ -136,6 +137,7 @@ export const chooseMedia = async function (
 
     if (/^video\//.test(res.fileType)) {
       // Video
+      const isIOS = getDeviceInfo().system.toLowerCase().includes('ios')
       const video = document.createElement('video')
       const reader = new FileReader()
       video.crossOrigin = 'Anonymous'
@@ -160,6 +162,7 @@ export const chooseMedia = async function (
           resolve(res)
         }
         video.onerror = e => reject(e)
+        isIOS && video.load()
       })
     } else {
       // Image


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
IOS端浏览器环境，Taro.chooseMedia，选中视频时，无法触发成功/失败的回调

**这个 PR 是什么类型?** (至少选择一个)

- [X] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [X] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
