### PR TITLE
fix(vite-runner): 修复Windows环境下使用vite构建时路径错误

### DIFF
--- a/packages/taro-vite-runner/src/utils/html.ts
+++ b/packages/taro-vite-runner/src/utils/html.ts
@@ -1,3 +1,5 @@
+import { normalizePath } from '@tarojs/helper'
+
 export function getHtmlScript (entryScript: string, pxtransformOption): string {
   let htmlScript = ''
   const options = pxtransformOption?.config || {}
@@ -11,6 +13,6 @@ export function getHtmlScript (entryScript: string, pxtransformOption): string {
   if ((options?.targetUnit ?? 'rem') === 'rem') {
     htmlScript = `<script>!function(n){function f(){var e=n.document.documentElement,r=e.getBoundingClientRect(),width=r.width,height=r.height,arr=[width,height].filter(function(value){return Boolean(value)}),w=Math.min.apply(Math,arr),x=${rootValue}*w/${designWidth};e.style.fontSize=x>=${max}?"${max}px":x<=${min}?"${min}px":x+"px"}; n.addEventListener("resize",(function(){f()})),f()}(window);</script>\n`
   }
-  htmlScript += `  <script type="module" src="${entryScript}"></script>`
+  htmlScript += `  <script type="module" src="${normalizePath(entryScript)}"></script>`
   return htmlScript
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

该PR在`getHtmlScript`中使用`normalizePath`处理了路径.

此Bug应在上游处理以期彻底解决此类问题, 但我对该框架不熟悉不敢轻易修改上游代码.
类似PR: https://github.com/NervJS/taro/pull/16124

**bug简述**

Windows 下使用 vite 构建时, 由于html代码注入了有误的路径"\\app.config.ts", 导致不能被解析.
https://github.com/NervJS/taro/blob/0828d8d26a6012a88f6da7753d119218c729af6d/packages/taro-vite-runner/src/h5/config.ts#L202-L203

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: [#16314](https://github.com/NervJS/taro/issues/16314)
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
