### PR TITLE
feat(weapp): button openType add "liveActivity" for 3.x version

### DIFF
--- a/packages/shared/src/components.ts
+++ b/packages/shared/src/components.ts
@@ -93,6 +93,7 @@ const Button = {
   'hover-stay-time': '70',
   name: NO_DEFAULT_VALUE,
   bindagreeprivacyauthorization: NO_DEFAULT_VALUE,
+  bindcreateliveactivity: NO_DEFAULT_VALUE,
   ...touchEvents
 }
 

--- a/packages/shared/src/components.ts
+++ b/packages/shared/src/components.ts
@@ -93,7 +93,6 @@ const Button = {
   'hover-stay-time': '70',
   name: NO_DEFAULT_VALUE,
   bindagreeprivacyauthorization: NO_DEFAULT_VALUE,
-  bindcreateliveactivity: NO_DEFAULT_VALUE,
   ...touchEvents
 }
 

--- a/packages/taro-components/types/Button.d.ts
+++ b/packages/taro-components/types/Button.d.ts
@@ -73,6 +73,12 @@ interface ButtonProps extends StandardProps {
    * @supported weapp, swan
    */
   sessionFrom?: string
+  /** 一次性订阅消息的模板 notify_type
+   *  可参考: https://developers.weixin.qq.com/miniprogram/dev/framework/open-ability/subscribe-message-2.html
+   * 生效时机：`open-type="liveActivity"`
+   * @supported weapp
+   */
+  activityType?: string
   /** 会话内消息卡片标题
    *
    * 生效时机：`open-type="contact"`
@@ -283,6 +289,13 @@ interface ButtonProps extends StandardProps {
    * @supported tt
    */
   onJoinGroup?: CommonEventFunction<{ errMsg: string; errNo: number }>
+  /**
+   * 监听用户一次性订阅消息事件
+   *
+   * 生效时机：`open-type="liveActivity"`
+   * @supported weapp
+   */
+  onCreateLiveActivity?: CommonEventFunction
 }
 declare namespace ButtonProps {
   /** size 的合法值 */
@@ -350,6 +363,10 @@ declare namespace ButtonProps {
        * 用户同意隐私协议按钮。可通过 bindagreeprivacyauthorization 监听用户同意隐私协议事件
        */
       agreePrivacyAuthorization
+      /**
+       * 新版一次性订阅消息按钮。可通过 bindcreateliveactivity 监听用户一次性订阅消息事件
+       */
+      liveActivity
       /**
        * 从基础库 2.32.3 版本起，隐私同意按钮支持与手机号快速验证组件耦合使用，调用方式为：
        * <button open-type="getPhoneNumber|agreePrivacyAuthorization">

--- a/packages/taro-components/types/Button.d.ts
+++ b/packages/taro-components/types/Button.d.ts
@@ -74,7 +74,7 @@ interface ButtonProps extends StandardProps {
    */
   sessionFrom?: string
   /** 一次性订阅消息的模板 notify_type
-   *  可参考: https://developers.weixin.qq.com/miniprogram/dev/framework/open-ability/subscribe-message-2.html
+   *  @see https://developers.weixin.qq.com/miniprogram/dev/framework/open-ability/subscribe-message-2.html
    * 生效时机：`open-type="liveActivity"`
    * @supported weapp
    */
@@ -295,7 +295,7 @@ interface ButtonProps extends StandardProps {
    * 生效时机：`open-type="liveActivity"`
    * @supported weapp
    */
-  onCreateLiveActivity?: CommonEventFunction
+  onCreateLiveActivity?: CommonEventFunction<ButtonProps.onCreateLiveActivityEventDetail>
 }
 declare namespace ButtonProps {
   /** size 的合法值 */
@@ -540,6 +540,10 @@ declare namespace ButtonProps {
     errMsg: string
     /* 用户授权结果 */
     authSetting: Record<string, boolean>
+  }
+
+  interface onCreateLiveActivityEventDetail {
+    code: string
   }
 }
 /** 按钮

--- a/packages/taro-weapp/src/components.ts
+++ b/packages/taro-weapp/src/components.ts
@@ -60,6 +60,7 @@ export const components = {
     'app-parameter': _empty,
     'show-message-card': _false,
     'business-id': _empty,
+    'activity-type': _empty,
     bindGetUserInfo: _empty,
     bindContact: _empty,
     bindGetPhoneNumber: _empty,
@@ -68,7 +69,8 @@ export const components = {
     bindError: _empty,
     bindOpenSetting: _empty,
     bindLaunchApp: _empty,
-    bindAgreePrivacyAuthorization: _empty
+    bindAgreePrivacyAuthorization: _empty,
+    bindCreateLiveActivity: _empty,
   },
   Form: {
     'report-submit-timeout': _zero


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

支持"新版一次性订阅消息"

微信小程序 button 组件 openType 属性新增 liveActivity

可参考: https://developers.weixin.qq.com/miniprogram/dev/framework/open-ability/subscribe-message-2.html

close: https://github.com/NervJS/taro/issues/16992

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
