### PR TITLE
fix: TypeError: cannot read property 'then' of undefined

### DIFF
--- a/packages/taro-platform-harmony/src/runtime-framework/solid/page.ts
+++ b/packages/taro-platform-harmony/src/runtime-framework/solid/page.ts
@@ -88,6 +88,7 @@ export function createPageConfig (component: any, pageName?: string, pageConfig?
   let pageElement: any = null
   let unmounting = false
   let prepareMountList: (() => void)[] = []
+  let prepareLoadList: (() => void)[] = []
 
   function setCurrentRouter (page) {
     const router = page.route || page.__route__ || page.$taroPath
@@ -111,7 +112,12 @@ export function createPageConfig (component: any, pageName?: string, pageConfig?
   const page = {
     [ONLOAD] (options: Readonly<Record<string, unknown>> = {}, cb?: (...args: any[]) => any) {
       hasLoaded = new Promise(resolve => { loadResolver = resolve })
-
+      hasLoaded.then(() => {
+        if (prepareLoadList.length) {
+          prepareLoadList.forEach(fn => fn())
+          prepareLoadList = []
+        }
+      })
       Current.page = this as any
 
       // this.$taroPath 是页面唯一标识
@@ -217,7 +223,11 @@ export function createPageConfig (component: any, pageName?: string, pageConfig?
     page[lifecycle] = function () {
       const exec = () => safeExecute(this.$taroPath, lifecycle, ...arguments)
       if (isDefer) {
-        hasLoaded.then(exec)
+        if (hasLoaded) {
+          hasLoaded.then(exec)
+        } else {
+          prepareLoadList.push(exec)
+        }
       } else {
         return exec()
       }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

在我们线上项目发现sentry报错 `TypeError: cannot read property 'then' of undefined`
错误指向了压缩后的代码

<img width="604" alt="image" src="https://github.com/user-attachments/assets/c4aaf079-5aa4-489e-8d32-37898a3e9ca3" />

对应 taro 代码 在 https://github.com/NervJS/taro/blob/feat/4.0.6/packages/taro-runtime/src/dsl/common.ts#L240-L254


```ts
LIFECYCLES.forEach((lifecycle) => {
    let isDefer = false
    lifecycle = lifecycle.replace(/^defer:/, () => {
      isDefer = true
      return ''
    })
    config[lifecycle] = function () {
      const exec = () => safeExecute(this.$taroPath, lifecycle, ...arguments)
      if (isDefer) {
        hasLoaded.then(exec)
      } else {
        return exec()
      }
    }
  })
```

也就是代码 `hasLoaded.then(exec)` 报错，因为hasLoaded对象是undefined,经过分析发现 hasLoaded 对象默认是undefined，直到 `ONLOAD` 事件后才有值，因此更新了逻辑，在hasLoaded 为 undefined 时，将function放到队列中，等ONLOAD事件后再运行

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
