### PR TITLE
fix: align WebAudioContext.decodeAudioData signature with weapp doc

### DIFF
--- a/packages/taro/types/api/media/audio.d.ts
+++ b/packages/taro/types/api/media/audio.d.ts
@@ -740,7 +740,11 @@ declare module '../../index' {
      * ```
      * @see https://developers.weixin.qq.com/miniprogram/dev/api/media/audio/WebAudioContext.decodeAudioData.html
      */
-    decodeAudioData(): AudioBuffer
+    decodeAudioData(
+      audioData: ArrayBuffer,
+      successCallback: (buffer: AudioBuffer) => void,
+      errorCallback: (error: any) => void
+    ): Promise<AudioBuffer>
   }
 
   namespace WebAudioContext {


### PR DESCRIPTION
…at docs

Updated the `decodeAudioData` method in `WebAudioContext` to match the official WeChat Mini Program documentation:
- Modified the return type to `Promise<AudioBuffer>` instead of `AudioBuffer`, because of this method' actual response.
- Adjusted method parameters to accept `audioData`, `successCallback`, and `errorCallback`.

This fixes the TypeScript error and aligns the implementation with the expected API behavior. Closes #17080

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复了 WebAudioContext.decodeAudioData 的签名


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #17080 
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [x] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
