### PR TITLE
chore(release): publish 4.0.9

### DIFF
--- a/crates/native_binding/package.json
+++ b/crates/native_binding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/binding",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Node binding for taro",
   "main": "binding.js",
   "typings": "binding.d.ts",

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tarojs/binding-darwin-arm64",
   "description": "Native binding for taro",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tarojs/binding-darwin-x64",
   "description": "Native binding for taro",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "os": [
     "darwin"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tarojs/binding-linux-x64-gnu",
   "description": "Native binding for taro",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "os": [
     "linux"
   ],

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/binding-linux-x64-musl",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "os": [
     "linux"
   ],

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tarojs/binding-win32-x64-msvc",
   "description": "Native binding for taro",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "os": [
     "win32"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taro",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "开放式跨端跨框架开发解决方案",
   "homepage": "https://github.com/NervJS/taro#readme",
   "author": "O2Team",

--- a/packages/babel-plugin-transform-react-jsx-to-rn-stylesheet/package.json
+++ b/packages/babel-plugin-transform-react-jsx-to-rn-stylesheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-transform-react-jsx-to-rn-stylesheet",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Transform stylesheet selector to style in JSX Elements.",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/babel-plugin-transform-solid-jsx/package.json
+++ b/packages/babel-plugin-transform-solid-jsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-transform-solid-jsx",
   "description": "A JSX to DOM plugin that wraps expressions for fine grained change detection",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/babel-plugin-transform-taroapi/package.json
+++ b/packages/babel-plugin-transform-taroapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-transform-taroapi",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "author": "O2Team",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/babel-preset-taro/package.json
+++ b/packages/babel-preset-taro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-taro",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro babel preset",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/create-app",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "create taro app with one command",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/css-to-react-native/package.json
+++ b/packages/css-to-react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "taro-css-to-react-native",
   "description": "Convert CSS text to a React Native stylesheet object",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "author": "O2Team",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/eslint-config-taro/package.json
+++ b/packages/eslint-config-taro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-taro",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro specific linting rules for ESLint",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/jest-helper/package.json
+++ b/packages/jest-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-taro-helper",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "jest helper for taro",
   "private": true,
   "author": "O2Team",

--- a/packages/postcss-html-transform/package.json
+++ b/packages/postcss-html-transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-html-transform",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "transform html tag name selector",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/postcss-plugin-constparse/package.json
+++ b/packages/postcss-plugin-constparse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-plugin-constparse",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "parse constants defined in config",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/postcss-pxtransform/package.json
+++ b/packages/postcss-pxtransform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-pxtransform",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "PostCSS plugin px 转小程序 rpx及h5 rem 单位",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/postcss-unit-transform/package.json
+++ b/packages/postcss-unit-transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-taro-unit-transform",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "小程序单位转换",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/rollup-plugin-copy/package.json
+++ b/packages/rollup-plugin-copy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-copy",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "rollup-plugin-copy for taro",
   "private": true,
   "author": "O2Team",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/shared",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro utils internal use.",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/stylelint-config-taro-rn/package.json
+++ b/packages/stylelint-config-taro-rn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-taro-rn",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Shareable stylelint config for React Native CSS modules",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/stylelint-taro-rn/package.json
+++ b/packages/stylelint-taro-rn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-taro-rn",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "A collection of React Native specific rules for stylelint",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/stylelint-taro/package.json
+++ b/packages/stylelint-taro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-taro",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro stylelint 规则集合",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-api/package.json
+++ b/packages/taro-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/api",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro common API",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-cli-convertor/package.json
+++ b/packages/taro-cli-convertor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/cli-convertor",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "cli tool for taro-convert",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-cli/package.json
+++ b/packages/taro-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/cli",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "cli tool for taro",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-components-advanced/package.json
+++ b/packages/taro-components-advanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/components-advanced",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-components-library-react/package.json
+++ b/packages/taro-components-library-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/components-library-react",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro 组件库 React 版本库",
   "private": true,
   "author": "O2Team",

--- a/packages/taro-components-library-solid/package.json
+++ b/packages/taro-components-library-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/components-library-solid",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro 组件库 Solid 版本库",
   "private": true,
   "main": "index.js",

--- a/packages/taro-components-library-vue3/package.json
+++ b/packages/taro-components-library-vue3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/components-library-vue3",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro 组件库 Vue3 版本库",
   "private": true,
   "author": "O2Team",

--- a/packages/taro-components-react/package.json
+++ b/packages/taro-components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/components-react",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "",
   "main:h5": "dist/index.js",
   "main": "dist/index.js",

--- a/packages/taro-components-rn/package.json
+++ b/packages/taro-components-rn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/components-rn",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "React Native 基础组件",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-components/package.json
+++ b/packages/taro-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/components",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro 组件库",
   "browser": "dist/index.js",
   "main:h5": "dist/index.js",

--- a/packages/taro-extend/package.json
+++ b/packages/taro-extend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/extend",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro extend functionality",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-framework-react/package.json
+++ b/packages/taro-framework-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-framework-react",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "React/Preact 框架插件",
   "author": "O2Team",
   "homepage": "https://github.com/nervjs/taro",

--- a/packages/taro-framework-solid/package.json
+++ b/packages/taro-framework-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-framework-solid",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Solid 框架插件",
   "author": "drchan",
   "homepage": "https://github.com/nervjs/taro",

--- a/packages/taro-framework-vue3/package.json
+++ b/packages/taro-framework-vue3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-framework-vue3",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Vue3 框架插件",
   "author": "O2Team",
   "homepage": "https://github.com/nervjs/taro",

--- a/packages/taro-h5/package.json
+++ b/packages/taro-h5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taro-h5",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro h5 framework",
   "browser": "dist/index.js",
   "main:h5": "dist/index.esm.js",

--- a/packages/taro-helper/package.json
+++ b/packages/taro-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/helper",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro Helper",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-loader/package.json
+++ b/packages/taro-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taro-loader",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro runner use webpack loader",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-platform-alipay/package.json
+++ b/packages/taro-platform-alipay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-alipay",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "支付宝小程序平台插件",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-platform-h5/package.json
+++ b/packages/taro-platform-h5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-h5",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Web 端平台插件",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-platform-harmony-hybrid/package.json
+++ b/packages/taro-platform-harmony-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-harmony-hybrid",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Harmony 端平台插件",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-platform-harmony/package.json
+++ b/packages/taro-platform-harmony/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-harmony-ets",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "OpenHarmony & 鸿蒙系统插件",
   "author": "O2Team",
   "homepage": "https://gitee.com/openharmony-sig/taro",

--- a/packages/taro-platform-jd/package.json
+++ b/packages/taro-platform-jd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-jd",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "京东小程序平台插件",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-platform-qq/package.json
+++ b/packages/taro-platform-qq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-qq",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "QQ 小程序平台插件",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-platform-swan/package.json
+++ b/packages/taro-platform-swan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-swan",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "百度小程序平台插件",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-platform-tt/package.json
+++ b/packages/taro-platform-tt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-tt",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "头条小程序平台插件",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-platform-weapp/package.json
+++ b/packages/taro-platform-weapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-platform-weapp",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "微信小程序平台插件",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-plugin-html/package.json
+++ b/packages/taro-plugin-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-html",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro 小程序端支持使用 HTML 标签的插件",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-plugin-http/package.json
+++ b/packages/taro-plugin-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-http",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro 小程序端支持使用 web 请求 的插件",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-plugin-inject/package.json
+++ b/packages/taro-plugin-inject/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-inject",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro 小程序端平台中间层插件",
   "author": "O2Team",
   "homepage": "https://github.com/nervjs/taro",

--- a/packages/taro-plugin-mini-ci/package.json
+++ b/packages/taro-plugin-mini-ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-mini-ci",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro 小程序端构建后支持CI（持续集成）的插件",
   "keywords": [
     "Taro",

--- a/packages/taro-plugin-react-devtools/package.json
+++ b/packages/taro-plugin-react-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-react-devtools",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro 小程序端支持使用 React DevTools 的插件",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-plugin-vue-devtools/package.json
+++ b/packages/taro-plugin-vue-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/plugin-vue-devtools",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro 小程序端支持使用 Vue DevTools 的插件",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-react/package.json
+++ b/packages/taro-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/react",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "like react-dom, but for mini apps.",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-rn-runner/package.json
+++ b/packages/taro-rn-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/rn-runner",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "ReactNative build tool for taro",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-rn-style-transformer/package.json
+++ b/packages/taro-rn-style-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/rn-style-transformer",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "提供 Taro RN 统一处理样式文件能力",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-rn-supporter/package.json
+++ b/packages/taro-rn-supporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/rn-supporter",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro rn supporter",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-rn-transformer/package.json
+++ b/packages/taro-rn-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/rn-transformer",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro RN 入口文件处理",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-rn/package.json
+++ b/packages/taro-rn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taro-rn",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro RN framework",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-router-rn/package.json
+++ b/packages/taro-router-rn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/router-rn",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro-router-rn",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-router/package.json
+++ b/packages/taro-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/router",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro-router",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-runner-utils/package.json
+++ b/packages/taro-runner-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/runner-utils",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro runner utilities.",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-runtime-rn/package.json
+++ b/packages/taro-runtime-rn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/runtime-rn",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "taro-runtime-rn",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-runtime/package.json
+++ b/packages/taro-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/runtime",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "taro runtime for mini apps.",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-service/package.json
+++ b/packages/taro-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/service",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro Service",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-transformer-wx/package.json
+++ b/packages/taro-transformer-wx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/transformer-wx",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Transfrom Nerv Component to Wechat mini program.",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-vite-runner/package.json
+++ b/packages/taro-vite-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/vite-runner",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "main": "index.js",
   "license": "MIT",
   "files": [

--- a/packages/taro-webpack5-prebundle/package.json
+++ b/packages/taro-webpack5-prebundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/webpack5-prebundle",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro app webpack5 prebundle",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-webpack5-runner/package.json
+++ b/packages/taro-webpack5-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/webpack5-runner",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro app runner",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro-with-weapp/package.json
+++ b/packages/taro-with-weapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/with-weapp",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "taroize 之后的运行时",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taro/package.json
+++ b/packages/taro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taro",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "Taro framework",
   "author": "O2Team",
   "license": "MIT",

--- a/packages/taroize/package.json
+++ b/packages/taroize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarojs/taroize",
-  "version": "4.0.9-beta.8",
+  "version": "4.0.9",
   "description": "转换原生微信小程序代码为 Taro 代码",
   "author": "O2Team",
   "license": "MIT",


### PR DESCRIPTION
# 特性
## H5
- 组件开发模式支持预览功能 @tutuxxx
  ```
  taro build native-components -- --watch --type h5 --components components/index/index
  ```
- 组件开发模式收敛产物chunk @tutuxxx

## 小程序
- 增加按需编译pages或components能力 @tutuxxx
  ```
  yarn dev:weapp --pages pages/index/index
  ```


# 修复
## h5
- 修复swiper初始1个元素且动态新增元素并切换current时动画失效问题 @tutuxxx
- 升级swiperjs,解决cube轮播闪烁问题 @tutuxxx
- 解决scrollview在ios下滚动不流畅问题 @tutuxxx

## 小程序
- 修复taro引用原生页面时误处理image等组件的src属性问题 @tutuxxx
- 修复clickview无法注入dataset问题 @tutuxxx
- 京东小程序下PickerView组件新增属性 @tutuxxx

## 鸿蒙
- 支持通过 importNativeComponent 定义原生组件 (#17041) @ZakaryCode


## 其他
- REAME 新增 duxui @ShaoGongBra
- 更新 taroify 链接 (#17082) @CodeMak1r-zy
- buildes5参数支持命令行和插件调用时传递 @tutuxxx
- 更新 WebAudioContext.decodeAudioData 类型声明 @BH4HPA
- 使用 wasm32-wasip1 代替 wasm32-wasi ,解决编译 rust 出错问题 @tutuxxx
