### PR TITLE
fix: 修复vue3框架选中vite编译工具时依赖冲突

### DIFF
--- a/packages/eslint-config-taro/package.json
+++ b/packages/eslint-config-taro/package.json
@@ -35,7 +35,7 @@
     "eslint": "^8",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.4.0",
-    "eslint-plugin-vue": "^9.17.0"
+    "eslint-plugin-vue": "^8.0.0"
   },
   "peerDependenciesMeta": {
     "eslint-plugin-react": {

--- a/packages/taro-framework-vue3/package.json
+++ b/packages/taro-framework-vue3/package.json
@@ -41,7 +41,7 @@
     "@tarojs/taro": "workspace:*",
     "vue-loader": "^17.0.0",
     "@vue/compiler-core": "^3.4.25",
-    "vite": "^4.2.0",
+    "vite": "^5.2.0",
     "webpack": "5.91.0",
     "vue": "^3.4.25"
   },
@@ -53,7 +53,7 @@
     "@vitejs/plugin-vue": "^5",
     "@vitejs/plugin-vue-jsx": "^3",
     "vue-loader": "^17.0.0",
-    "vite": "^4",
+    "vite": "^5",
     "vue": "^3",
     "webpack": "^5"
   },

--- a/packages/taro-framework-vue3/package.json
+++ b/packages/taro-framework-vue3/package.json
@@ -41,7 +41,7 @@
     "@tarojs/taro": "workspace:*",
     "vue-loader": "^17.0.0",
     "@vue/compiler-core": "^3.4.25",
-    "vite": "^5.2.0",
+    "vite": "^4.2.0",
     "webpack": "5.91.0",
     "vue": "^3.4.25"
   },
@@ -50,10 +50,10 @@
     "@tarojs/runtime": "workspace:*",
     "@tarojs/runner-utils": "workspace:*",
     "@tarojs/shared": "workspace:*",
-    "@vitejs/plugin-vue": "^5",
+    "@vitejs/plugin-vue": "^4",
     "@vitejs/plugin-vue-jsx": "^3",
     "vue-loader": "^17.0.0",
-    "vite": "^5",
+    "vite": "^4",
     "vue": "^3",
     "webpack": "^5"
   },


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

解决官方cli 4.0初始化时，选择vue3+vite时，存在依赖冲突 `packages/taro-framework-vue3/package.json`：
``` json
{
"devDependencies": {
    "vite": "^4.2.0",
  },
  "peerDependencies": {
    "@vitejs/plugin-vue": "^5",
    "vite": "^4",
  },
}
```

`@vitejs/plugin-vue` 应该和`vite`统一大版本号，否则会冲突，最小的改动就是将`@vitejs/plugin-vue` 改为：

``` sh
"@vitejs/plugin-vue": "^4",
```

这样`vite`的最低版本就是v4，如果后续需要统一将`vite`设置高一点的版本，需要将这3个同时升级。

**另外**
初始化时，和官方模板还存在一个`eslint-plugin-vue`的版本冲突：
`eslint-config-taro@4.0.9`中，`packages/eslint-config-taro/package.json`:

``` json
  "peerDependencies": {
    "eslint-plugin-vue": "^9.17.0"
  }
```
 模板 `https://github.com/NervJS/taro-project-templates/blob/v4.0/vue3-NutUI/package.json.tmpl`：
``` json
"eslint-plugin-vue": "^8.0.0",
```

这个`pr`也一并调整了，模板项目那边需要改动2处，也是考虑到最小改动，仅将`packages/eslint-config-taro`中的依赖调整了一下。

**这个 PR 是什么类型?** (至少选择一个)

- [✔ ] 错误修复(Bugfix) issue:
  - fix #17201 
  - fix #16994
  - fix #16779 
  - fix #16711
  - fix #16670 
  - fix #16589

**这个 PR 涉及以下平台:**

- [✔ ] 所有小程序

