### PR TITLE
feat: 鸿蒙配置添加是否支持css变量解析开关

### DIFF
--- a/packages/taro-vite-runner/src/harmony/postcss/compile.ts
+++ b/packages/taro-vite-runner/src/harmony/postcss/compile.ts
@@ -31,7 +31,8 @@ export async function compileCSS(
   code: string,
   config: ResolvedConfig,
   urlReplacer?: CssUrlReplacer,
-  isGlobalModule ?: boolean
+  isGlobalModule ?: boolean,
+  cssVariable?: boolean
 ): Promise<{
     code: string
     map?: SourceMapInput
@@ -208,7 +209,9 @@ export async function compileCSS(
     )
   }
 
-  postcssPlugins.push((await import('postcss-css-variables')).default({}))
+  if (cssVariable !== true) {
+    postcssPlugins.push((await import('postcss-css-variables')).default({}))
+  }
 
   if (!postcssPlugins.length) {
     return {

--- a/packages/taro-vite-runner/src/harmony/style.ts
+++ b/packages/taro-vite-runner/src/harmony/style.ts
@@ -254,7 +254,7 @@ export async function stylePlugin(viteCompilerContext: ViteHarmonyCompilerContex
         modules,
         deps,
         map,
-      } = await compileCSS(id, raw, viteConfig, urlReplacer, isGlobalModule)
+      } = await compileCSS(id, raw, viteConfig, urlReplacer, isGlobalModule, taroConfig.cssVariables)
 
       // if (!cssCache.has(id)) {
 

--- a/packages/taro/types/compile/viteCompilerContext.d.ts
+++ b/packages/taro/types/compile/viteCompilerContext.d.ts
@@ -59,6 +59,7 @@ export interface ViteHarmonyBuildConfig extends CommonBuildConfig, IHarmonyConfi
   runtimePath?: string | string[]
   isPure?: boolean
   taroComponentsPath: string
+  cssVariables?: boolean  // 是否动态解析css变量
 }
 
 export interface CommonBuildConfig extends IProjectConfig<'vite'> {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

为harmony下添加cssVariables选项配置，用于控制是否自动载入变量解析插件

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [x] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [x] 鸿蒙（harmony）
