### PR TITLE
fix: getBoundingClientRect在alipay小程序上的兼容

### DIFF
--- a/packages/taro-runtime/src/dom-external/element.ts
+++ b/packages/taro-runtime/src/dom-external/element.ts
@@ -7,6 +7,14 @@ export function getBoundingClientRectImpl (this: TaroElement): Promise<null> {
   if (!options.miniGlobal) return Promise.resolve(null)
   return new Promise(resolve => {
     const query = options.miniGlobal.createSelectorQuery()
+    // ref: https://opendocs.alipay.com/mini/api/na4yun
+    if (process.env.TARO_ENV === 'alipay') {
+      query.select(`#${this.uid}`).boundingClientRect().exec(res => {
+        resolve(res)
+      })
+      return
+    }
+
     query.select(`#${this.uid}`).boundingClientRect(res => {
       resolve(res)
     }).exec()


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->
ref: https://github.com/NervJS/taro/issues/17351
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
解决无法在alipay小程序上正常使用`getBoundingClientRect`的问题


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [x] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
