### PR TITLE
fix(types): `adjustKeyboardTo` 类型修正

### DIFF
--- a/packages/taro-components/types/Textarea.d.ts
+++ b/packages/taro-components/types/Textarea.d.ts
@@ -125,9 +125,9 @@ interface TextareaProps extends StandardProps, FormItemProps {
   ariaLabel?: string
   /** 键盘对齐位置
    * @supported weapp
-   * @default false
+   * @default 'cursor'
    */
-  adjustKeyboardTo?: boolean
+  adjustKeyboardTo?: 'cursor' | 'bottom'
   /** 输入框聚焦时触发
    * @supported weapp, alipay, swan, tt, qq, jd, h5, rn, harmony, harmony_hybrid
    */


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

https://developers.weixin.qq.com/miniprogram/dev/component/textarea.html

`adjustKeyboardTo` 类型修正

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [x] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 优化了多行输入框的键盘对齐方式选择，`adjustKeyboardTo` 属性现支持 `'cursor'` 或 `'bottom'` 两种模式，默认值为 `'cursor'`，提升了输入体验的灵活性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->