### PR TITLE
feat(types): Add optional env config for cloud container call

### DIFF
--- a/packages/taro/types/api/cloud/index.d.ts
+++ b/packages/taro/types/api/cloud/index.d.ts
@@ -1,4 +1,4 @@
-import Taro, { DownloadTask, UploadTask } from "../../index"
+import Taro from "../../index"
 
 declare module '../../index' {
   namespace cloud {
@@ -212,6 +212,10 @@ declare module '../../index' {
 
     /** 调用云托管参数 */
     interface CallContainerParam < P extends string | TaroGeneral.IAnyObject | ArrayBuffer = any | any > {
+      config?:{
+        /** 微信云托管的环境ID, 如果在 Taro.cloud.init 中配置了env, 则可以不配置。 */
+        env: string, 
+      }
       /** 服务路径 */
       path: string
       /** HTTP请求方法，默认 GET */


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

为微信小程序云托管服务的 `Taro.cloud.callContainer` 方法补充 TypeScript 类型定义，具体添加 `config` 属性，包含 `env` 字段用于指定云环境ID。根据微信官方文档规范，确保类型定义与实际API使用方式一致。

参考文档：https://developers.weixin.qq.com/miniprogram/dev/wxcloudservice/wxcloudrun/src/development/call/mini.html

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [x] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）