### PR TITLE
修复Windows下MultiPlatformPlugin无法识别斜杠的问题

### DIFF
--- a/packages/taro-runner-utils/src/resolve/MultiPlatformPlugin.ts
+++ b/packages/taro-runner-utils/src/resolve/MultiPlatformPlugin.ts
@@ -79,7 +79,7 @@ export class MultiPlatformPlugin {
   private includes (filePath: string): boolean {
     if (!this.options.include || !this.options.include.length) return false
 
-    filePath = filePath.replace(path.sep, '/')
+    filePath = filePath.replace(/[\\/]/g, '/');
 
     const res = this.options.include.find(item => filePath.includes(item))
     return Boolean(res)

--- a/packages/taro-runner-utils/src/resolve/MultiPlatformPlugin.ts
+++ b/packages/taro-runner-utils/src/resolve/MultiPlatformPlugin.ts
@@ -79,7 +79,7 @@ export class MultiPlatformPlugin {
   private includes (filePath: string): boolean {
     if (!this.options.include || !this.options.include.length) return false
 
-    filePath = filePath.replace(/[\\/]/g, '/');
+    filePath = filePath.replace(/[\\/]/g, '/')
 
     const res = this.options.include.find(item => filePath.includes(item))
     return Boolean(res)


### PR DESCRIPTION
在Windows平台，reslove的路径为：D:\\projects\\example\\node_modules\\@test\\test... 执行filePath = filePath.replace(path.sep, '/');后的路径为： D:/projects\\example\\node_modules\\@test\\test...

原来的replace只能替换第一个斜杠，导致外部配置带斜杠的不会生效。如：include=['@test/test']

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复Windows下MultiPlatformPlugin无法识别斜杠的问题


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
