### PR TITLE
fix: react中Checkbox组件设置className不起作用，页面刷新之后类样式才有效果

### DIFF
--- a/packages/taro-components/__tests__/__snapshots__/form.e2e.ts.snap
+++ b/packages/taro-components/__tests__/__snapshots__/form.e2e.ts.snap
@@ -25,13 +25,13 @@ CDPPage {
     <taro-textarea-core class="hydrated" name="my-textarea" value=""><textarea class="taro-textarea" maxlength="140" name="my-textarea"></textarea>
     </taro-textarea-core>
     <taro-radio-group-core class="hydrated weui-cells_radiogroup" name="my-radio-group">
-      <taro-radio-core checked="" class="hydrated weui-cells_checkbox" classname="weui-cells_checkbox" key="radio1" name="my-radio-group" value="radio1">
+      <taro-radio-core checked="" class="hydrated weui-cells_checkbox" key="radio1" name="my-radio-group" value="radio1">
         <!---->
         <input class="weui-check" name="my-radio-group" type="radio" value="radio1">
         <i class="weui-icon-checked"></i>
         radio1
       </taro-radio-core>
-      <taro-radio-core checked="false" class="hydrated weui-cells_checkbox" classname="weui-cells_checkbox" key="radio2" name="my-radio-group" value="radio2">
+      <taro-radio-core checked="false" class="hydrated weui-cells_checkbox" key="radio2" name="my-radio-group" value="radio2">
         <!---->
         <input class="weui-check" name="my-radio-group" type="radio" value="radio2">
         <i class="weui-icon-checked"></i>
@@ -39,12 +39,12 @@ CDPPage {
       </taro-radio-core>
     </taro-radio-group-core>
     <taro-checkbox-group-core class="hydrated" name="my-checkbox-group">
-      <taro-checkbox-core checked="false" class="hydrated weui-cells_checkbox" classname="weui-cells_checkbox" key="checkbox1" name="my-checkbox-group" value="checkbox1">
+      <taro-checkbox-core checked="false" class="hydrated weui-cells_checkbox" key="checkbox1" name="my-checkbox-group" value="checkbox1">
         <!---->
         <input class="taro-checkbox_checked" name="my-checkbox-group" type="checkbox" value="checkbox1">
         checkbox1
       </taro-checkbox-core>
-      <taro-checkbox-core checked="false" class="hydrated weui-cells_checkbox" classname="weui-cells_checkbox" key="checkbox2" name="my-checkbox-group" value="checkbox2">
+      <taro-checkbox-core checked="false" class="hydrated weui-cells_checkbox" key="checkbox2" name="my-checkbox-group" value="checkbox2">
         <!---->
         <input class="taro-checkbox_checked" name="my-checkbox-group" type="checkbox" value="checkbox2">
         checkbox2
@@ -92,13 +92,13 @@ CDPPage {
     <taro-textarea-core class="hydrated" name="my-textarea" value=""><textarea class="taro-textarea" maxlength="140" name="my-textarea"></textarea>
 </taro-textarea-core>,
     <taro-radio-group-core class="hydrated weui-cells_radiogroup" name="my-radio-group">
-  <taro-radio-core checked="" class="hydrated weui-cells_checkbox" classname="weui-cells_checkbox" key="radio1" name="my-radio-group" value="radio1">
+  <taro-radio-core checked="" class="hydrated weui-cells_checkbox" key="radio1" name="my-radio-group" value="radio1">
     <!---->
     <input class="weui-check" name="my-radio-group" type="radio" value="radio1">
     <i class="weui-icon-checked"></i>
     radio1
   </taro-radio-core>
-  <taro-radio-core checked="false" class="hydrated weui-cells_checkbox" classname="weui-cells_checkbox" key="radio2" name="my-radio-group" value="radio2">
+  <taro-radio-core checked="false" class="hydrated weui-cells_checkbox" key="radio2" name="my-radio-group" value="radio2">
     <!---->
     <input class="weui-check" name="my-radio-group" type="radio" value="radio2">
     <i class="weui-icon-checked"></i>
@@ -106,12 +106,12 @@ CDPPage {
   </taro-radio-core>
 </taro-radio-group-core>,
     <taro-checkbox-group-core class="hydrated" name="my-checkbox-group">
-  <taro-checkbox-core checked="false" class="hydrated weui-cells_checkbox" classname="weui-cells_checkbox" key="checkbox1" name="my-checkbox-group" value="checkbox1">
+  <taro-checkbox-core checked="false" class="hydrated weui-cells_checkbox" key="checkbox1" name="my-checkbox-group" value="checkbox1">
     <!---->
     <input class="taro-checkbox_checked" name="my-checkbox-group" type="checkbox" value="checkbox1">
     checkbox1
   </taro-checkbox-core>
-  <taro-checkbox-core checked="false" class="hydrated weui-cells_checkbox" classname="weui-cells_checkbox" key="checkbox2" name="my-checkbox-group" value="checkbox2">
+  <taro-checkbox-core checked="false" class="hydrated weui-cells_checkbox" key="checkbox2" name="my-checkbox-group" value="checkbox2">
     <!---->
     <input class="taro-checkbox_checked" name="my-checkbox-group" type="checkbox" value="checkbox2">
     checkbox2
@@ -123,17 +123,17 @@ CDPPage {
     <input name="my-picker" type="hidden" value="1">
   </div>
 </taro-picker-core>,
-    <taro-checkbox-core checked="false" class="hydrated weui-cells_checkbox" classname="weui-cells_checkbox" key="checkbox1" name="my-checkbox-group" value="checkbox1">
+    <taro-checkbox-core checked="false" class="hydrated weui-cells_checkbox" key="checkbox1" name="my-checkbox-group" value="checkbox1">
   <!---->
   <input class="taro-checkbox_checked" name="my-checkbox-group" type="checkbox" value="checkbox1">
   checkbox1
 </taro-checkbox-core>,
-    <taro-checkbox-core checked="false" class="hydrated weui-cells_checkbox" classname="weui-cells_checkbox" key="checkbox2" name="my-checkbox-group" value="checkbox2">
+    <taro-checkbox-core checked="false" class="hydrated weui-cells_checkbox" key="checkbox2" name="my-checkbox-group" value="checkbox2">
   <!---->
   <input class="taro-checkbox_checked" name="my-checkbox-group" type="checkbox" value="checkbox2">
   checkbox2
 </taro-checkbox-core>,
-    <taro-radio-core checked="" class="hydrated weui-cells_checkbox" classname="weui-cells_checkbox" key="radio1" name="my-radio-group" value="radio1">
+    <taro-radio-core checked="" class="hydrated weui-cells_checkbox" key="radio1" name="my-radio-group" value="radio1">
   <!---->
   <input class="weui-check" name="my-radio-group" type="radio" value="radio1">
   <i class="weui-icon-checked"></i>

--- a/packages/taro-components/src/components/checkbox/checkbox.tsx
+++ b/packages/taro-components/src/components/checkbox/checkbox.tsx
@@ -49,7 +49,7 @@ export class Checkbox implements ComponentInterface {
 
     return (
       <Host
-        className='weui-cells_checkbox'
+        class='weui-cells_checkbox'
       >
         <input
           ref={dom => {

--- a/packages/taro-components/src/components/radio/radio.tsx
+++ b/packages/taro-components/src/components/radio/radio.tsx
@@ -52,7 +52,7 @@ export class Radio implements ComponentInterface {
 
     return (
       <Host
-        className='weui-cells_checkbox'
+        class='weui-cells_checkbox'
         onClick={this.handleClick}
       >
         <input


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复h5开发中Checkbox组件设置class样式不起作用


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
