### PR TITLE
Fix/style max 

### DIFF
--- a/packages/taro-platform-harmony/src/runtime-framework/solid/reconciler/props.ts
+++ b/packages/taro-platform-harmony/src/runtime-framework/solid/reconciler/props.ts
@@ -5,7 +5,7 @@ import type { Style, TaroElement } from '@tarojs/runtime'
 
 export type Props = Record<string, unknown>
 
-const IS_NON_DIMENSIONAL = /max|aspect|acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i
+const IS_NON_DIMENSIONAL = /aspect|acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i
 
 function isEventName (s: string) {
   return s[0] === 'o' && s[1] === 'n'

--- a/packages/taro-react/src/props.ts
+++ b/packages/taro-react/src/props.ts
@@ -8,6 +8,7 @@ import type { Style, TaroElement } from '@tarojs/runtime'
 export type Props = Record<string, unknown>
 
 const IS_NON_DIMENSIONAL = /aspect|acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i
+
 function isEventName (s: string) {
   return s[0] === 'o' && s[1] === 'n'
 }

--- a/packages/taro-react/src/props.ts
+++ b/packages/taro-react/src/props.ts
@@ -7,8 +7,7 @@ import type { Style, TaroElement } from '@tarojs/runtime'
 
 export type Props = Record<string, unknown>
 
-const IS_NON_DIMENSIONAL = /max|aspect|acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i
-
+const IS_NON_DIMENSIONAL = /aspect|acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i
 function isEventName (s: string) {
   return s[0] === 'o' && s[1] === 'n'
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
taro-react 的 IS_NON_DIMENSIONAL 正则表达式中，添加了 max 字符串的判断，导致内联样式 style 中的 max 开头的属性值（如：maxHeight, maxWidth），无法正确添加 px 单位后缀，样式展示不正确。

![image](https://github.com/user-attachments/assets/0fbb5016-3c3d-440a-870b-48015d63aa2e)

![image](https://github.com/user-attachments/assets/25c4143f-907a-4ca5-99a1-be2d040469d0)



**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [x] 鸿蒙（harmony）
