### PR TITLE
fix: postcss-pxtransform 未使用 opts.mediaQuery 来控制是否需要转换 @media 后的单位, 导…

### DIFF
--- a/packages/postcss-pxtransform/index.js
+++ b/packages/postcss-pxtransform/index.js
@@ -235,11 +235,13 @@ module.exports = (options = {}) => {
         },
         AtRule: {
           media: (rule) => {
-            if (skip) return
-            if (!opts.methods.includes('size')) return
+            if (opts.mediaQuery) {
+              if (skip) return
+              if (!opts.methods.includes('size')) return
 
-            if (!/px/i.test(rule.params)) return
-            rule.params = rule.params.replace(pxRgx, pxReplace)
+              if (!/px/i.test(rule.params)) return
+              rule.params = rule.params.replace(pxRgx, pxReplace)
+            }
           },
         },
       }


### PR DESCRIPTION
…致: 1. 如果设置为 px 单位，一定会被转换成 rpx (与 Taro3.x 的默认表现不一致); 2. 开发者无法通过构建配置来控制是否需要转换 @media 后的单位

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

Taro4.0.9 的这块代码，会把
@media screen and (max-width: 640px) {
转换成
@media screen and (max-width: 640rpx) {

Taro3.5.12 则不会默认进入到 media 替换单位的处理逻辑，而是会根据 opts.mediaQuery 的值来判断是否需要做转换：
https://github.com/NervJS/taro/blob/v3.5.12/packages/postcss-pxtransform/index.js#L174
https://github.com/NervJS/taro/blob/v3.5.12/packages/postcss-pxtransform/index.js#L13

因此，未来解决上述问题，我这边把 opts.mediaQuery 的判断逻辑加上了，达到效果如下：
1. 默认不对 media 进行单位转换，即默认表现 和 Taro3.x 保持一致；
2. 如果需要开启转换，开发者可以自己通过设置 mediaQuery 为 true 来实现，这个也与 Taro3.x 保持一致


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [x] QQ 轻应用
- [x] 京东小程序
- [x] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [x] 移动端（React-Native）
- [x] 鸿蒙（harmony）
