### PR TITLE
feat: 从 alipay apiDiff 移出 saveImageToPhotosAlbum

### DIFF
--- a/packages/taro-platform-alipay/src/apis.ts
+++ b/packages/taro-platform-alipay/src/apis.ts
@@ -18,7 +18,6 @@ const apiDiff: IApiDiff = {
       ]
     }
   },
-
   showActionSheet: {
     options: {
       change: [{
@@ -69,15 +68,6 @@ const apiDiff: IApiDiff = {
   },
   setNavigationBarColor: {
     alias: 'setNavigationBar'
-  },
-  saveImageToPhotosAlbum: {
-    alias: 'saveImage',
-    options: {
-      change: [{
-        old: 'filePath',
-        new: 'url'
-      }]
-    }
   },
   previewImage: {
     options: {

--- a/packages/taro-rn/src/lib/index.ts
+++ b/packages/taro-rn/src/lib/index.ts
@@ -1,4 +1,5 @@
 // 由 getLibList.js 脚本生成, 不要进行手动修改, 请不要手动修改
+export * from './ENV_TYPE'
 export * from './arrayBufferToBase64'
 export * from './authorize'
 export * from './base64ToArrayBuffer'
@@ -15,7 +16,6 @@ export * from './createInnerAudioContext'
 export * from './createSelectorQuery'
 export * from './createVideoContext'
 export * from './downloadFile'
-export * from './ENV_TYPE'
 export * from './getAppBaseInfo'
 export * from './getClipboardData'
 export * from './getEnv'

--- a/tests/__tests__/__snapshots__/mini-platform.spec.ts.snap
+++ b/tests/__tests__/__snapshots__/mini-platform.spec.ts.snap
@@ -104,15 +104,6 @@ require("./runtime");
             setNavigationBarColor: {
                 alias: "setNavigationBar"
             },
-            saveImageToPhotosAlbum: {
-                alias: "saveImage",
-                options: {
-                    change: [ {
-                        old: "filePath",
-                        new: "url"
-                    } ]
-                }
-            },
             previewImage: {
                 options: {
                     set: [ {

--- a/tests/__tests__/__snapshots__/tabbar.spec.ts.snap
+++ b/tests/__tests__/__snapshots__/tabbar.spec.ts.snap
@@ -2040,15 +2040,6 @@ require("./runtime");
             setNavigationBarColor: {
                 alias: "setNavigationBar"
             },
-            saveImageToPhotosAlbum: {
-                alias: "saveImage",
-                options: {
-                    change: [ {
-                        old: "filePath",
-                        new: "url"
-                    } ]
-                }
-            },
             previewImage: {
                 options: {
                     set: [ {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

支付宝小程序 saveImage 已经停止维护，取消对 saveImageToPhotosAlbum 的 alias 改为直接使用 saveImageToPhotosAlbum

**这个 PR 是什么类型?** (至少选择一个)

- [X] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):   

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [X] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
