### PR TITLE
fix: 修复vite打包h5时tabBar图标路径转换平台不统一造成无法展示的问题

### DIFF
--- a/packages/taro-vite-runner/src/h5/entry.ts
+++ b/packages/taro-vite-runner/src/h5/entry.ts
@@ -57,13 +57,13 @@ export default function (viteCompilerContext: ViteH5CompilerContext): PluginOpti
 
         const getTabbarIconPath = (iconPath) => {
           return isProd
-            ? path.join('/', taroConfig.staticDirectory as string, 'images', path.basename(iconPath))
+            ? path.posix.join('/', taroConfig.staticDirectory as string, 'images', path.basename(iconPath))
             : iconPath.replace(/^./, '')
         }
 
         const emitTabbarIcon = async (sourceDir, iconPath) => {
           const filePath = path.resolve(sourceDir, iconPath)
-          const fileName = path.join(taroConfig.staticDirectory as string, 'images', path.basename(iconPath))
+          const fileName = path.posix.join(taroConfig.staticDirectory as string, 'images', path.basename(iconPath))
           if (!tabbarAssetsCache.get(fileName)) {
             tabbarAssetsCache.set(fileName, filePath)
             this.emitFile({


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
本次pr修复了在Win环境下vite打包build:h5时tabbar的iconPath时路径不兼容问题。

前提准备：使用官方脚手架`npx @tarojs/cli init myApp`创建项目，选择vue3+vite构建的项目，模板选择了gitee的(为了快速)。
node版本：v22.13.1
pnpm版本：v10.6.5
可直接复现仓库：[https://github.com/gk-shi/taro-vite-h5-tabbar-error](https://github.com/gk-shi/taro-vite-h5-tabbar-error)


- 问题详述：
由于`path.join`的返回结果在Win环境和Mac/Linux环境下返回存在`/`和`\`兼容性问题，造成tabBar的icon在打包后路径出现错误，因此使用`path.posix.join`来统一路径转换的过程。


- 修改前情况：
![vite-h5-tabbar-icon-error-code](https://github.com/user-attachments/assets/2ec0948a-7bd8-44f0-9703-fc384665e786)
红色箭头指的图片是在scss文件中设置的background-image能使用vite正常解析(查了vite内部用了`path.posix.join`)，用来对比

![vite-h5-tabbar-icon-error](https://github.com/user-attachments/assets/fb8dcba0-ad51-4732-bec5-26404f4c430a)


- 修改后情况：
![vite-h5-tabbar-icon-corret-code](https://github.com/user-attachments/assets/a92ee38b-d36d-4c1f-af22-d2f6c7751ece)
![vite-h5-tabbar-icon-corret](https://github.com/user-attachments/assets/f62c9761-2606-4c26-9c5f-a12ad8fabcaf)



- 另一个可能的问题：
-此处iconPath.replace(/^./, '')代码存疑：如果在tabBar配置iconPath: 'assets/images/tabbar-icon.svg'时，在vite下使用 dev:h5时会把路径第一个a字符替换掉，造成路径错误，只有配置iconPath: './assets/images/tabbar-icon.svg'才有效。
如果只是想匹配将第一个可能存在的`.`字符去掉，正则考虑改为：`/^\./`
![vite-h5-tabbar-icon-error-dev](https://github.com/user-attachments/assets/1a2d908e-fa7d-4cba-bf29-cf8c3bc25769)


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
