### PR TITLE
fix: 修复jd下CustomWrapper内的组件className失效问题

### DIFF
--- a/packages/taro-runtime/src/dsl/common.ts
+++ b/packages/taro-runtime/src/dsl/common.ts
@@ -363,6 +363,12 @@ export function createRecursiveComponentConfig (componentName?: string) {
     }
     : EMPTY_OBJ
 
+  // 不同平台的个性化配置
+  const extraOptions: { [key: string]: any } = {}
+  if (process.env.TARO_ENV === 'jd') {
+    extraOptions.addGlobalClass = true
+  }
+
   return hooks.call('modifyRecursiveComponentConfig',
     {
       properties: {
@@ -378,6 +384,7 @@ export function createRecursiveComponentConfig (componentName?: string) {
         }
       },
       options: {
+        ...extraOptions,
         virtualHost: !isCustomWrapper
       },
       methods: {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
jd下CustomWrapper内的组件className, 添加不带wrapper-- 的原样式名


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [x] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 引入了按平台定制的配置选项，可在特定环境（例如“jd”平台）下自动启用额外全局样式支持，进一步提升了组件配置的灵活性，同时确保现有功能保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->