### PR TITLE
fix: vite构建vue3项目循环引用报错

### DIFF
--- a/packages/taro-vite-runner/src/mini/config.ts
+++ b/packages/taro-vite-runner/src/mini/config.ts
@@ -166,6 +166,7 @@ export default function (viteCompilerContext: ViteMiniCompilerContext): PluginOp
     const taroDeps: RegExp[] = [REG_TARO_SCOPED_PACKAGE]
     const taroViteRunnerDeps: RegExp[] = [/node_modules[\\/]@tarojs[\\/]vite-runner/]
     const nodeModulesDeps: RegExp[] = [REG_NODE_MODULES_DIR]
+    const babelDeps: RegExp[] = [/node_modules[\\/]@babel[\\/]/]
     const commonjsHelpersDeps: RegExp[] = [/commonjsHelpers\.js$/]
     const tslibDeps: RegExp [] = [/node_modules[\\/]tslib[\\/]/]
     const testByReg2DExpList = (reg2DExpList: RegExp[][]) => (id: string) => reg2DExpList.some(regExpList => regExpList.some(regExp => regExp.test(id)))
@@ -186,6 +187,8 @@ export default function (viteCompilerContext: ViteMiniCompilerContext): PluginOp
           const moduleInfo = getModuleInfo(id)
           // Note: vite-runner 里面涉及到一些js文件的注入，比如 comp.js， 为了避免这些文件被打包进 vendors，这里做了特殊处理
           if (testByReg2DExpList([taroViteRunnerDeps])(id)) return null
+          // Note: vue3 中用到了 for of等新的语法，babel相关依赖会被打包到 vendors 中，但taro中会打包vue3相关依赖，从而会引入 vendors 中的 babel 相关依赖，导致循环引用
+          if (testByReg2DExpList([babelDeps])(id)) return 'babelHelpers'
           if (testByReg2DExpList([taroDeps, vueRelatedDeps, tslibDeps, commonjsHelpersDeps])(id)) return 'taro'
           if (testByReg2DExpList([nodeModulesDeps])(id)) return 'vendors'
           if (moduleInfo?.importers?.length && moduleInfo.importers.length > 1) return 'common'


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
vite构建vue3项目，打包内容 taro.js 和 vendors.js 会出现循环引用，导致报错。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 解决了打包过程中可能因依赖分组不当而导致的循环依赖问题，提升了 Vue 3 项目构建时的稳定性。

- **Refactor**
  - 优化了依赖分块逻辑，对库的识别和分组进行了改进，从而提高了整体构建流程的效率与可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->