### PR TITLE
fix(taro-platform-h5): 生成definition.json api为空

### DIFF
--- a/packages/taro-h5/package.json
+++ b/packages/taro-h5/package.json
@@ -71,7 +71,8 @@
     "rollup": "^3.29.4",
     "rollup-plugin-node-externals": "^5.0.0",
     "@rollup/plugin-typescript": "^12.1.2",
-    "@rollup/plugin-node-resolve": "^15.2.3"
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "rollup-plugin-dts": "^6.2.1"
   },
   "peerDependencies": {
     "@tarojs/components": "workspace:~"

--- a/packages/taro-h5/rollup.config.ts
+++ b/packages/taro-h5/rollup.config.ts
@@ -3,6 +3,7 @@ import { nodeResolve } from '@rollup/plugin-node-resolve'
 import ts from '@rollup/plugin-typescript'
 import { mergeWith } from 'lodash'
 import { defineConfig } from 'rollup'
+import { dts } from 'rollup-plugin-dts'
 import externals from 'rollup-plugin-node-externals'
 import postcss from 'rollup-plugin-postcss'
 
@@ -46,6 +47,20 @@ const variesConfig: RollupOptions[] = [
   },
 ]
 
+variesConfig.push({
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/index.esm.js',
+    inlineDynamicImports: true
+  }
+},
+{
+  // 需要该配置才能生成打包的 .d.ts 文件供 taro-platform-h5\build\definition-json\parser.ts 生成 apis 配置
+  input: 'src/index.ts',
+  output: { file: 'dist/index.esm.d.ts' },
+  plugins: [dts()]
+})
+
 if (process.env.NODE_ENV === 'production') {
   variesConfig.push(
     {
@@ -55,24 +70,9 @@ if (process.env.NODE_ENV === 'production') {
         file: 'dist/index.cjs.js',
         inlineDynamicImports: true,
       },
-    },
-    {
-      input: 'src/index.ts',
-      output: {
-        file: 'dist/index.esm.js',
-        inlineDynamicImports: true,
-      },
     }
   )
 }
-
-variesConfig.push({
-  input: 'src/index.ts',
-  output: {
-    file: 'dist/index.esm.js',
-    inlineDynamicImports: true
-  }
-})
 
 export default defineConfig(
   variesConfig.map((v) => {

--- a/packages/taro-platform-h5/build/definition-json/parser.ts
+++ b/packages/taro-platform-h5/build/definition-json/parser.ts
@@ -94,7 +94,7 @@ export function parseAnyOrVoid (str = '', obj: unknown = str) {
 }
 
 export function parseDefinitionJSON ({
-  apisPath = require.resolve('@tarojs/taro-h5/dist/index.d.ts'),
+  apisPath = require.resolve('@tarojs/taro-h5/dist/index.esm.d.ts'),
   componentsPath = require.resolve('@tarojs/components/dist/types/components.d.ts'),
 } = {},
 config: ts.CompilerOptions = tsconfig,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1229,7 +1229,7 @@ importers:
         version: 15.2.3(rollup@3.29.4)
       '@rollup/plugin-typescript':
         specifier: ^12.1.2
-        version: 12.1.2(rollup@3.29.4)(tslib@2.6.2)(typescript@5.4.5)
+        version: 12.1.2(rollup@3.29.4)(tslib@2.6.2)
       '@tarojs/taro':
         specifier: workspace:*
         version: link:../taro
@@ -1250,10 +1250,10 @@ importers:
         version: 3.0.3
       jest-mock-console:
         specifier: ^1.0.0
-        version: 1.3.0(jest@29.7.0(@types/node@20.5.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.3.96)(@types/node@20.5.1)(typescript@5.4.5)))
+        version: 1.3.0
       jest-transform-css:
         specifier: ^6.0.1
-        version: 6.0.1(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.3.96)(@types/node@20.5.1)(typescript@5.4.5))
+        version: 6.0.1
       mock-socket:
         specifier: ^7.1.0
         version: 7.1.0
@@ -1266,6 +1266,9 @@ importers:
       rollup:
         specifier: ^3.29.4
         version: 3.29.4
+      rollup-plugin-dts:
+        specifier: ^6.2.1
+        version: 6.2.1(rollup@3.29.4)
       rollup-plugin-node-externals:
         specifier: ^5.0.0
         version: 5.1.3(rollup@3.29.4)
@@ -2275,7 +2278,7 @@ importers:
     devDependencies:
       '@rollup/plugin-typescript':
         specifier: ^12.1.2
-        version: 12.1.2(rollup@4.37.0)(tslib@2.6.2)
+        version: 12.1.2(rollup@4.37.0)(tslib@2.6.2)(typescript@5.4.5)
       '@types/react':
         specifier: ^18.2.79
         version: 18.3.3
@@ -2967,6 +2970,10 @@ packages:
     resolution: {integrity: sha512-ZJhac6FkEd1yhG2AHOmfcXG4ceoLltoCVJjN5XsWN9BifBQr+cHJbWi0h68HZuSORq+3WtJ2z0hwF2NG1b5kcA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.26.2':
+    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.24.6':
     resolution: {integrity: sha512-aC2DGhBq5eEdyXWqrDInSqQjO0k8xtPRf5YylULqx8MCd6jBtzqfta/3ETMRpuKIc5hyswfO80ObyA1MvkCcUQ==}
     engines: {node: '>=6.9.0'}
@@ -3087,6 +3094,10 @@ packages:
 
   '@babel/helper-validator-identifier@7.24.6':
     resolution: {integrity: sha512-4yA7s865JHaqUdRbnaxarZREuPTHrjpDT+pXoAZ1yhyo6uFnIEpS8VMu16siFOHDpZNKYv5BObhsB//ycbICyw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.25.9':
+    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.24.6':
@@ -4947,6 +4958,9 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.4.15':
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
+
+  '@jridgewell/sourcemap-codec@1.5.0':
+    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
@@ -11474,6 +11488,9 @@ packages:
   magic-string@0.30.10:
     resolution: {integrity: sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==}
 
+  magic-string@0.30.17:
+    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
   magicast@0.3.4:
     resolution: {integrity: sha512-TyDF/Pn36bBji9rWKHlZe+PZb6Mx5V8IHCSxk7X4aljM4e/vyDvZZYwHewdVaqiA0nb3ghfHU/6AUpDxWoER2Q==}
 
@@ -13697,6 +13714,13 @@ packages:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
 
+  rollup-plugin-dts@6.2.1:
+    resolution: {integrity: sha512-sR3CxYUl7i2CHa0O7bA45mCrgADyAQ0tVtGSqi3yvH28M+eg1+g5d7kQ9hLvEz5dorK3XVsH5L2jwHLQf72DzA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      rollup: ^3.29.4 || ^4
+      typescript: ^4.5 || ^5.0
+
   rollup-plugin-image-file@1.0.2:
     resolution: {integrity: sha512-o3Ss9iZb4cF1R2jQYbIprk7GRE9/L17l674Azq/9zykTgnEpGM+lpXj43q4O71LwqVnzH0XV9POwDJqJMwWLcQ==}
 
@@ -15827,7 +15851,34 @@ snapshots:
       '@babel/highlight': 7.24.6
       picocolors: 1.0.1
 
+  '@babel/code-frame@7.26.2':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.25.9
+      js-tokens: 4.0.0
+      picocolors: 1.0.1
+    optional: true
+
   '@babel/compat-data@7.24.6': {}
+
+  '@babel/core@7.24.4':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.24.6
+      '@babel/generator': 7.24.6
+      '@babel/helper-compilation-targets': 7.24.6
+      '@babel/helper-module-transforms': 7.24.6(@babel/core@7.24.4)
+      '@babel/helpers': 7.24.6
+      '@babel/parser': 7.24.6
+      '@babel/template': 7.24.6
+      '@babel/traverse': 7.24.6
+      '@babel/types': 7.24.0
+      convert-source-map: 2.0.0
+      debug: 4.3.4
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/core@7.24.4(supports-color@9.4.0)':
     dependencies:
@@ -15940,7 +15991,7 @@ snapshots:
 
   '@babel/helper-module-transforms@7.24.6(@babel/core@7.24.4)':
     dependencies:
-      '@babel/core': 7.24.4(supports-color@9.4.0)
+      '@babel/core': 7.24.4
       '@babel/helper-environment-visitor': 7.24.6
       '@babel/helper-module-imports': 7.24.6
       '@babel/helper-simple-access': 7.24.6
@@ -15982,6 +16033,9 @@ snapshots:
   '@babel/helper-string-parser@7.24.6': {}
 
   '@babel/helper-validator-identifier@7.24.6': {}
+
+  '@babel/helper-validator-identifier@7.25.9':
+    optional: true
 
   '@babel/helper-validator-option@7.24.6': {}
 
@@ -16110,17 +16164,17 @@ snapshots:
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.24.4)':
     dependencies:
-      '@babel/core': 7.24.4(supports-color@9.4.0)
+      '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.24.6
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.24.4)':
     dependencies:
-      '@babel/core': 7.24.4(supports-color@9.4.0)
+      '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.24.6
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.24.4)':
     dependencies:
-      '@babel/core': 7.24.4(supports-color@9.4.0)
+      '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.24.6
 
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.24.4)':
@@ -16170,12 +16224,12 @@ snapshots:
 
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.24.4)':
     dependencies:
-      '@babel/core': 7.24.4(supports-color@9.4.0)
+      '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.24.6
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.24.4)':
     dependencies:
-      '@babel/core': 7.24.4(supports-color@9.4.0)
+      '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.24.6
 
   '@babel/plugin-syntax-jsx@7.24.6(@babel/core@7.24.4)':
@@ -16185,32 +16239,32 @@ snapshots:
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.24.4)':
     dependencies:
-      '@babel/core': 7.24.4(supports-color@9.4.0)
+      '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.24.6
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.24.4)':
     dependencies:
-      '@babel/core': 7.24.4(supports-color@9.4.0)
+      '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.24.6
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.24.4)':
     dependencies:
-      '@babel/core': 7.24.4(supports-color@9.4.0)
+      '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.24.6
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.24.4)':
     dependencies:
-      '@babel/core': 7.24.4(supports-color@9.4.0)
+      '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.24.6
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.24.4)':
     dependencies:
-      '@babel/core': 7.24.4(supports-color@9.4.0)
+      '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.24.6
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.24.4)':
     dependencies:
-      '@babel/core': 7.24.4(supports-color@9.4.0)
+      '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.24.6
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.24.4)':
@@ -16220,7 +16274,7 @@ snapshots:
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.24.4)':
     dependencies:
-      '@babel/core': 7.24.4(supports-color@9.4.0)
+      '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.24.6
 
   '@babel/plugin-syntax-typescript@7.24.6(@babel/core@7.24.4)':
@@ -16731,6 +16785,21 @@ snapshots:
       '@babel/code-frame': 7.24.6
       '@babel/parser': 7.24.6
       '@babel/types': 7.24.6
+
+  '@babel/traverse@7.24.6':
+    dependencies:
+      '@babel/code-frame': 7.24.6
+      '@babel/generator': 7.24.6
+      '@babel/helper-environment-visitor': 7.24.6
+      '@babel/helper-function-name': 7.24.6
+      '@babel/helper-hoist-variables': 7.24.6
+      '@babel/helper-split-export-declaration': 7.24.6
+      '@babel/parser': 7.24.6
+      '@babel/types': 7.24.6
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/traverse@7.24.6(supports-color@9.4.0)':
     dependencies:
@@ -17832,41 +17901,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.3.96)(@types/node@20.5.1)(typescript@5.4.5))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 18.19.33
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.3.96)(@types/node@20.5.1)(typescript@5.4.5))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.7
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   '@jest/create-cache-key-function@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
@@ -18121,10 +18155,10 @@ snapshots:
 
   '@jest/transform@29.7.0':
     dependencies:
-      '@babel/core': 7.24.4(supports-color@9.4.0)
+      '@babel/core': 7.24.4
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      babel-plugin-istanbul: 6.1.1(supports-color@9.4.0)
+      babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
@@ -18422,6 +18456,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
 
   '@jridgewell/sourcemap-codec@1.4.15': {}
+
+  '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
@@ -19203,6 +19239,14 @@ snapshots:
       rollup: 4.18.0
       tslib: 2.6.2
 
+  '@rollup/plugin-typescript@12.1.2(rollup@3.29.4)(tslib@2.6.2)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      resolve: 1.22.8
+    optionalDependencies:
+      rollup: 3.29.4
+      tslib: 2.6.2
+
   '@rollup/plugin-typescript@12.1.2(rollup@3.29.4)(tslib@2.6.2)(typescript@5.4.5)':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
@@ -19212,10 +19256,11 @@ snapshots:
       rollup: 3.29.4
       tslib: 2.6.2
 
-  '@rollup/plugin-typescript@12.1.2(rollup@4.37.0)(tslib@2.6.2)':
+  '@rollup/plugin-typescript@12.1.2(rollup@4.37.0)(tslib@2.6.2)(typescript@5.4.5)':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.37.0)
       resolve: 1.22.8
+      typescript: 5.4.5
     optionalDependencies:
       rollup: 4.37.0
       tslib: 2.6.2
@@ -21002,10 +21047,10 @@ snapshots:
 
   babel-jest@29.7.0(@babel/core@7.24.4):
     dependencies:
-      '@babel/core': 7.24.4(supports-color@9.4.0)
+      '@babel/core': 7.24.4
       '@jest/transform': 29.7.0
       '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 6.1.1(supports-color@9.4.0)
+      babel-plugin-istanbul: 6.1.1
       babel-preset-jest: 29.6.3(@babel/core@7.24.4)
       chalk: 4.1.2
       graceful-fs: 4.2.11
@@ -21061,6 +21106,16 @@ snapshots:
       estraverse: 4.3.0
 
   babel-plugin-global-define@1.0.3: {}
+
+  babel-plugin-istanbul@6.1.1:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.24.6
+      '@istanbuljs/load-nyc-config': 1.1.0
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-instrument: 5.2.1
+      test-exclude: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   babel-plugin-istanbul@6.1.1(supports-color@9.4.0):
     dependencies:
@@ -21170,7 +21225,7 @@ snapshots:
 
   babel-preset-current-node-syntax@1.0.1(@babel/core@7.24.4):
     dependencies:
-      '@babel/core': 7.24.4(supports-color@9.4.0)
+      '@babel/core': 7.24.4
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.4)
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.24.4)
       '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.4)
@@ -21254,7 +21309,7 @@ snapshots:
 
   babel-preset-jest@29.6.3(@babel/core@7.24.4):
     dependencies:
-      '@babel/core': 7.24.4(supports-color@9.4.0)
+      '@babel/core': 7.24.4
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.24.4)
 
@@ -22241,21 +22296,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@20.5.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.3.96)(@types/node@20.5.1)(typescript@5.4.5)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.5.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.3.96)(@types/node@20.5.1)(typescript@5.4.5))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   create-require@1.1.1: {}
 
   cross-env@7.0.3:
@@ -22578,6 +22618,10 @@ snapshots:
   debug@4.1.1:
     dependencies:
       ms: 2.1.3
+
+  debug@4.3.4:
+    dependencies:
+      ms: 2.1.2
 
   debug@4.3.4(supports-color@9.4.0):
     dependencies:
@@ -24956,6 +25000,8 @@ snapshots:
 
   icss-replace-symbols@1.1.0: {}
 
+  icss-utils@5.1.0: {}
+
   icss-utils@5.1.0(postcss@8.4.38):
     dependencies:
       postcss: 8.4.38
@@ -25370,6 +25416,16 @@ snapshots:
 
   istanbul-lib-coverage@3.2.2: {}
 
+  istanbul-lib-instrument@5.2.1:
+    dependencies:
+      '@babel/core': 7.24.4
+      '@babel/parser': 7.24.6
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-coverage: 3.2.2
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   istanbul-lib-instrument@5.2.1(supports-color@9.4.0):
     dependencies:
       '@babel/core': 7.24.4(supports-color@9.4.0)
@@ -25578,25 +25634,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@20.5.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.3.96)(@types/node@20.5.1)(typescript@5.4.5)):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.3.96)(@types/node@20.5.1)(typescript@5.4.5))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.5.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.3.96)(@types/node@20.5.1)(typescript@5.4.5))
-      exit: 0.1.2
-      import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.5.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.3.96)(@types/node@20.5.1)(typescript@5.4.5))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-config@27.5.1(ts-node@10.9.2(@swc/core@1.3.96)(@types/node@20.5.1)(typescript@5.4.5)):
     dependencies:
       '@babel/core': 7.24.4(supports-color@9.4.0)
@@ -25658,68 +25695,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 18.19.33
       ts-node: 10.9.2(@swc/core@1.3.96)(@types/node@18.19.33)(typescript@5.4.5)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.3.96)(@types/node@20.5.1)(typescript@5.4.5)):
-    dependencies:
-      '@babel/core': 7.24.4(supports-color@9.4.0)
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.24.4)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.7
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 18.19.33
-      ts-node: 10.9.2(@swc/core@1.3.96)(@types/node@20.5.1)(typescript@5.4.5)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@20.5.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.3.96)(@types/node@20.5.1)(typescript@5.4.5)):
-    dependencies:
-      '@babel/core': 7.24.4(supports-color@9.4.0)
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.24.4)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.7
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.5.1
-      ts-node: 10.9.2(@swc/core@1.3.96)(@types/node@20.5.1)(typescript@5.4.5)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -26035,9 +26010,7 @@ snapshots:
       slash: 3.0.0
       stack-utils: 2.0.6
 
-  jest-mock-console@1.3.0(jest@29.7.0(@types/node@20.5.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.3.96)(@types/node@20.5.1)(typescript@5.4.5))):
-    dependencies:
-      jest: 29.7.0(@types/node@20.5.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.3.96)(@types/node@20.5.1)(typescript@5.4.5))
+  jest-mock-console@1.3.0: {}
 
   jest-mock@27.5.1:
     dependencies:
@@ -26349,6 +26322,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  jest-transform-css@6.0.1:
+    dependencies:
+      common-tags: 1.8.2
+      cross-spawn: 7.0.3
+      postcss-load-config: 4.0.1
+      postcss-modules: 4.3.1
+      style-inject: 0.3.0
+    transitivePeerDependencies:
+      - ts-node
+
   jest-transform-css@6.0.1(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.3.96)(@types/node@20.5.1)(typescript@5.4.5)):
     dependencies:
       common-tags: 1.8.2
@@ -26490,18 +26473,6 @@ snapshots:
       '@jest/types': 29.6.3
       import-local: 3.1.0
       jest-cli: 29.7.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.3.96)(@types/node@18.19.33)(typescript@5.4.5))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest@29.7.0(@types/node@20.5.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.3.96)(@types/node@20.5.1)(typescript@5.4.5)):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.3.96)(@types/node@20.5.1)(typescript@5.4.5))
-      '@jest/types': 29.6.3
-      import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.5.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.3.96)(@types/node@20.5.1)(typescript@5.4.5))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -27128,6 +27099,10 @@ snapshots:
   magic-string@0.30.10:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
+
+  magic-string@0.30.17:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   magicast@0.3.4:
     dependencies:
@@ -28346,6 +28321,11 @@ snapshots:
       postcss: 8.4.38
       ts-node: 10.9.2(@swc/core@1.3.96)(@types/node@18.19.33)(typescript@5.4.5)
 
+  postcss-load-config@4.0.1:
+    dependencies:
+      lilconfig: 2.1.0
+      yaml: 2.4.2
+
   postcss-load-config@4.0.1(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.3.96)(@types/node@20.5.1)(typescript@5.4.5)):
     dependencies:
       lilconfig: 2.1.0
@@ -28451,9 +28431,17 @@ snapshots:
       postcss: 8.4.38
       postcss-selector-parser: 6.1.0
 
+  postcss-modules-extract-imports@3.1.0: {}
+
   postcss-modules-extract-imports@3.1.0(postcss@8.4.38):
     dependencies:
       postcss: 8.4.38
+
+  postcss-modules-local-by-default@4.0.5:
+    dependencies:
+      icss-utils: 5.1.0
+      postcss-selector-parser: 6.1.0
+      postcss-value-parser: 4.2.0
 
   postcss-modules-local-by-default@4.0.5(postcss@8.4.38):
     dependencies:
@@ -28462,15 +28450,34 @@ snapshots:
       postcss-selector-parser: 6.1.0
       postcss-value-parser: 4.2.0
 
+  postcss-modules-scope@3.2.0:
+    dependencies:
+      postcss-selector-parser: 6.1.0
+
   postcss-modules-scope@3.2.0(postcss@8.4.38):
     dependencies:
       postcss: 8.4.38
       postcss-selector-parser: 6.1.0
 
+  postcss-modules-values@4.0.0:
+    dependencies:
+      icss-utils: 5.1.0
+
   postcss-modules-values@4.0.0(postcss@8.4.38):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.38)
       postcss: 8.4.38
+
+  postcss-modules@4.3.1:
+    dependencies:
+      generic-names: 4.0.0
+      icss-replace-symbols: 1.1.0
+      lodash.camelcase: 4.3.0
+      postcss-modules-extract-imports: 3.1.0
+      postcss-modules-local-by-default: 4.0.5
+      postcss-modules-scope: 3.2.0
+      postcss-modules-values: 4.0.0
+      string-hash: 1.1.3
 
   postcss-modules@4.3.1(postcss@8.4.38):
     dependencies:
@@ -29487,6 +29494,13 @@ snapshots:
       semver-compare: 1.0.0
       sprintf-js: 1.1.3
     optional: true
+
+  rollup-plugin-dts@6.2.1(rollup@3.29.4):
+    dependencies:
+      magic-string: 0.30.17
+      rollup: 3.29.4
+    optionalDependencies:
+      '@babel/code-frame': 7.26.2
 
   rollup-plugin-image-file@1.0.2:
     dependencies:


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
在`taro-h5`的构建中生成打包后的`index.esm.d.ts`



**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix https://github.com/NervJS/taro/pull/17543
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 优化了构建配置，现在支持生成ES模块和对应的TypeScript声明文件，提升了模块兼容性与开发体验。
	- 更新了API定义的引用路径，确保与最新构建输出保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->