### PR TITLE
fix(taro-framework-solid): 修复Solid框架的类名空格分隔问题

### DIFF
--- a/packages/taro-framework-solid/src/reconciler/props.ts
+++ b/packages/taro-framework-solid/src/reconciler/props.ts
@@ -70,9 +70,9 @@ function updateClassList (dom: TaroElement, newValue: ClassList) {
   for (const key in newValue) {
     if (newValue[key]) {
       // 处理classList中包含空格分隔的类名
-      key.split(' ').forEach(className => className && addList.push(key))
+      key.split(' ').forEach(className => className && addList.push(className))
     } else {
-      key.split(' ').forEach(className => className && removeList.push(key))
+      key.split(' ').forEach(className => className && removeList.push(className))
     }
   }
   (dom.classList as any).add(...addList);

--- a/packages/taro-framework-solid/src/reconciler/props.ts
+++ b/packages/taro-framework-solid/src/reconciler/props.ts
@@ -67,12 +67,13 @@ export function setProperty (
 
 function updateClassList (dom: TaroElement, newValue: ClassList) {
   const [addList, removeList]: [string[], string[]] = [[], []]
+  const regexp = /\s+/
   for (const key in newValue) {
     if (newValue[key]) {
       // 处理classList中包含空格分隔的类名
-      key.split(' ').forEach(className => className && addList.push(className))
+      key.trim().split(regexp).forEach(className => addList.push(className))
     } else {
-      key.split(' ').forEach(className => className && removeList.push(className))
+      key.trim().split(regexp).forEach(className => removeList.push(className))
     }
   }
   (dom.classList as any).add(...addList);

--- a/packages/taro-framework-solid/src/reconciler/props.ts
+++ b/packages/taro-framework-solid/src/reconciler/props.ts
@@ -69,9 +69,10 @@ function updateClassList (dom: TaroElement, newValue: ClassList) {
   const [addList, removeList]: [string[], string[]] = [[], []]
   for (const key in newValue) {
     if (newValue[key]) {
-      addList.push(key)
+      // 处理classList中包含空格分隔的类名
+      key.split(' ').forEach(className => className && addList.push(key))
     } else {
-      removeList.push(key)
+      key.split(' ').forEach(className => className && removeList.push(key))
     }
   }
   (dom.classList as any).add(...addList);


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

- 在 updateClassList 函数中，对类名进行空格分隔处理
- 确保类名中的每个部分都能正确添加或移除

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #17501 
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 修复了处理包含多个以空格分隔的 class 名称时的异常，提升了 class 列表更新的准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->