### PR TITLE
fix(taro-platform-alipay): 支付宝小程序编译button缺少appParameter

### DIFF
--- a/packages/taro-platform-alipay/src/components.ts
+++ b/packages/taro-platform-alipay/src/components.ts
@@ -40,6 +40,7 @@ export const components = {
   Button: {
     scope: '',
     'public-id': '',
+    'app-parameter': '',
     bindGetAuthorize: '',
     bindError: '',
     bindGetUserInfo: '',

--- a/tests/__tests__/__snapshots__/mini-platform.spec.ts.snap
+++ b/tests/__tests__/__snapshots__/mini-platform.spec.ts.snap
@@ -553,6 +553,7 @@ require("./runtime");
             Button: {
                 scope: "",
                 "public-id": "",
+                "app-parameter": "",
                 bindGetAuthorize: "",
                 bindError: "",
                 bindGetUserInfo: "",

--- a/tests/__tests__/__snapshots__/tabbar.spec.ts.snap
+++ b/tests/__tests__/__snapshots__/tabbar.spec.ts.snap
@@ -2489,6 +2489,7 @@ require("./runtime");
             Button: {
                 scope: "",
                 "public-id": "",
+                "app-parameter": "",
                 bindGetAuthorize: "",
                 bindError: "",
                 bindGetUserInfo: "",


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
支付宝小程序button组件编译出来的模板缺少app-parameter，导致open-type为launchApp时无法跳转


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [x] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 为 Button 组件新增支持 'app-parameter' 属性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->