### PR TITLE
fix: windows 下开启CompileMode报错 (#15252)

### DIFF
--- a/packages/taro-webpack5-runner/src/plugins/MiniCompileModePlugin.ts
+++ b/packages/taro-webpack5-runner/src/plugins/MiniCompileModePlugin.ts
@@ -27,6 +27,7 @@
 
 import path from 'node:path'
 
+import { normalizePath } from '@tarojs/helper'
 import webpack, { type Compiler, Dependency, Module, } from 'webpack'
 
 import type { MiniCombination } from '../webpack/MiniCombination'
@@ -295,9 +296,9 @@ export default class MiniCompileModePlugin {
               .filter(key => (new RegExp(`-templates${fileType.templ}$`)).test(key))
               .map(key => {
                 const source = new ConcatSource()
-                source.add(`<import src="${path.relative(path.dirname(key), `./${baseTemplName}`)}"/>\n`)
+                source.add(`<import src="${normalizePath(path.relative(path.dirname(key), `./${baseTemplName}`))}"/>\n`)
                 if (fileType.xs) {
-                  const content = template.buildXsImportTemplate(path.relative(path.dirname(key), `./utils`))
+                  const content = template.buildXsImportTemplate(normalizePath(path.relative(path.dirname(key), `./utils`)))
                   source.add(content)
                 }
                 source.add(assets[key])


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
windows 系统下开启 CompileMode 编译代码后，` *-templates.wxml` 文件中引用文件的路径错误，开发者工具无法识别到文件，在此规范化文件路径


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #15252
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
