### PR TITLE
fix(taro-platform-weapp): 修复 NativeSlot 编译模板在skyline下报错

### DIFF
--- a/packages/taro-platform-weapp/src/program.ts
+++ b/packages/taro-platform-weapp/src/program.ts
@@ -48,6 +48,7 @@ export default class Weapp extends TaroPlatformBase {
     const template = this.template
     template.mergeComponents(this.ctx, components)
     template.voidElements.add('voip-room')
+    template.voidElements.add('native-slot')
     template.focusComponents.add('editor')
     if (pluginOptions?.enablekeyboardAccessory) {
       template.voidElements.delete('input')


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
Update "[ ]" to "[x]" to check a box
-->
**这个 PR 做了什么？** (简要描述所做更改)
将 NativeSlot 添加到 voidElements，使编译模板里的 slot 不生成子节点

**这个 PR 是什么类型？** (至少选择一个)

- [ ] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复问题**
  - 解决了模板处理时对 'native-slot' 元素的识别问题，提升了组件兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->