### PR TITLE
fix: 修复「店铺-h5」Android原生端沉浸式下拉 跟swiper的冲突问题

### DIFF
--- a/packages/taro-components-react/src/components/swiper/index.tsx
+++ b/packages/taro-components-react/src/components/swiper/index.tsx
@@ -189,6 +189,8 @@ class SwiperInner extends React.Component<SwiperProps, SwiperState> {
       nested: true,
       loopAdditionalSlides,
       centeredSlides,
+      touchReleaseOnEdges: true,
+      threshold: 0,
       ...effectsProps,
       on: {
         init (_swiper) {

--- a/packages/taro-components/src/components/swiper/swiper.tsx
+++ b/packages/taro-components/src/components/swiper/swiper.tsx
@@ -325,6 +325,8 @@ export class Swiper implements ComponentInterface {
       centeredSlides: centeredSlides,
       zoom: this.zoom,
       nested: true,
+      touchReleaseOnEdges: true,
+      threshold: 0,
       ...effectsProps,
       on: {
         transitionEnd(e) {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
Update "[ ]" to "[x]" to check a box
-->
**这个 PR 做了什么？** (简要描述所做更改)


**这个 PR 是什么类型？** (至少选择一个)

- [X] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 优化了轮播组件的滑动体验，新增边缘释放和滑动阈值配置选项。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->