### PR TITLE
修复@taro/extend 4.1.1 版本，在微信小程序下，window is undefined 的问题

### DIFF
--- a/packages/taro-extend/src/jquery/event.js
+++ b/packages/taro-extend/src/jquery/event.js
@@ -7,6 +7,8 @@
 //     (c) 2010-2016 Thomas Fuchs
 //     Zepto.js may be freely distributed under the MIT license.
 
+import { window } from '@tarojs/runtime'
+
 export function initEvent ($) {
   let _zid = 1; let undefined
   const slice = Array.prototype.slice


### PR DESCRIPTION
fix: window is undefind bug.

<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
Update "[ ]" to "[x]" to check a box
-->
**这个 PR 做了什么？** (简要描述所做更改)
修复在小程序下使用 @taro/extend的时候 window 不存在的情况
`TypeError: Cannot use 'in' operator to search for 'onfocusin' in undefined`

**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix # [https://github.com/NervJS/taro/issues/17837](https://github.com/NervJS/taro/issues/17837)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **杂项**
  - 优化了对 window 对象的引用方式，以提升在 Taro 运行环境中的兼容性。用户无需进行任何操作，功能保持不变。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->