### PR TITLE
fix(tabbar):使用非官方tabbar自定义后，h5 页面没有高度样式导致空白

### DIFF
--- a/packages/taro-router/src/style.ts
+++ b/packages/taro-router/src/style.ts
@@ -55,6 +55,12 @@ ${
   }
 ${
   enableTabBar ? `
+  .taro-tabbar__container {
+      height:100%;
+  }
+  .taro-tabbar__panel {
+      height: 100%;
+  }
   .taro-tabbar__container > .taro-tabbar__panel {
     overflow: hidden;
   }
@@ -75,7 +81,7 @@ ${
   .taro_router > .taro_page.taro_page_show.taro_page_stationed:not(.taro_page_shade):not(.taro_tabbar_page):not(:last-child) {
     display: none;
   }`
-} 
+}
 `
   addStyle(css)
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
Update "[ ]" to "[x]" to check a box
-->
**这个 PR 做了什么？** (简要描述所做更改)


**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **样式优化**
  - 优化了底部 TabBar 容器和面板的样式，确保其高度始终占满 100%。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->