### PR TITLE
fix(Form):Form 表单在 Web 下缺乏 type=“submit” 属性

### DIFF
--- a/packages/taro-plugin-html/src/constant.ts
+++ b/packages/taro-plugin-html/src/constant.ts
@@ -112,14 +112,5 @@ export const specialElements = new Map<string, string | SpecialMaps>([
       }
       return [key, value]
     }
-  }],
-  ['button', {
-    mapName: 'button',
-    mapAttr (key, value, props) {
-      if (key === 'type' && (value === 'submit' || value === 'reset')) {
-        props.formType = value
-      }
-      return [key, value]
-    }
   }]
 ])

--- a/packages/taro-plugin-html/src/constant.ts
+++ b/packages/taro-plugin-html/src/constant.ts
@@ -115,9 +115,9 @@ export const specialElements = new Map<string, string | SpecialMaps>([
   }],
   ['button', {
     mapName: 'button',
-    mapAttr (key, value) {
+    mapAttr (key, value, props) {
       if (key === 'type' && (value === 'submit' || value === 'reset')) {
-        key = 'formType'
+        props.formType = value
       }
       return [key, value]
     }

--- a/packages/taro-plugin-html/src/runtime.ts
+++ b/packages/taro-plugin-html/src/runtime.ts
@@ -36,6 +36,15 @@ hooks.tap('modifyHydrateData', (data, node) => {
     }
   }
 
+  // input[type=submit|reset] 时，额外添加 formType 属性
+  if (nodeName === 'input' && (data.type === 'submit' || data.type === 'reset')) {
+    data.formType = data.type
+  }
+  // button[type=submit|reset] 时，额外添加 formType 属性
+  if (nodeName === 'button' && (data.type === 'submit' || data.type === 'reset')) {
+    data.formType = data.type
+  }
+
   if (nodeName === 'br') {
     data[Shortcuts.Childnodes] = [{
       [Shortcuts.NodeName]: '#text',


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
Update "[ ]" to "[x]" to check a box
-->
**这个 PR 做了什么？** (简要描述所做更改)


**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix # https://github.com/NervJS/taro/issues/17855
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **优化**
  * 改进了按钮和输入元素的表单类型属性处理，增强了提交和重置按钮的兼容性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->