### PR TITLE
fix(taro-plugin-generator): vite runner 配置

### DIFF
--- a/packages/taro-cli/templates/default/package.json.tmpl
+++ b/packages/taro-cli/templates/default/package.json.tmpl
@@ -112,6 +112,7 @@
     "@types/node": "^20"
   }{{/if}}{{#if (eq compiler "Vite") }}
   "devDependencies": {
+    "@tarojs/plugin-generator": "{{ version }}",
     "@babel/core": "^7.24.4",
     "@babel/plugin-transform-class-properties": "7.25.9",
     "@tarojs/cli": "{{ version }}",

--- a/packages/taro-plugin-generator/src/generators/es5/index.ts
+++ b/packages/taro-plugin-generator/src/generators/es5/index.ts
@@ -1,13 +1,17 @@
 /* eslint-disable no-console */
-import { readPkgJson } from '../../utils'
+import { getCompilerType, readPkgJson } from '../../utils'
 import { updateBabelConfig } from './babel'
 import { updateConfig } from './config'
 
 import type { IPluginContext } from '@tarojs/service'
 
 export async function es5Generator(ctx: IPluginContext) {
+  const compilerType = getCompilerType(ctx.initialConfig.compiler)
+  if (!compilerType) {
+    throw new Error('未找到编译器类型')
+  }
   await updateBrowserList(ctx)
-  await updateConfig(ctx)
+  await updateConfig({ ctx, compilerType })
   await updateBabelConfig(ctx)
   console.log('✅ 启用「编译为 ES5」成功')
 }
@@ -20,10 +24,7 @@ async function updateBrowserList(ctx: IPluginContext) {
     return
   }
   const pkgJson = readPkgJson(ctx)
-  pkgJson.browserslist = {
-    development: ['defaults and fully supports es6-module', 'maintained node versions'],
-    production: ['last 3 versions', 'Android >= 4.1', 'ios >= 8'],
-  }
+  pkgJson.browserslist = ['last 3 versions', 'Android >= 4.1', 'ios >= 8']
   await fs.outputJson(`${ctx.paths.appPath}/package.json`, pkgJson, {
     encoding: 'utf-8',
     spaces: 2,


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
Update "[ ]" to "[x]" to check a box
-->
**这个 PR 做了什么？** (简要描述所做更改)
编译为es5 vite runner 配置错误

**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 当编译器为 Vite 时，模板项目会在开发依赖中自动添加 @tarojs/plugin-generator 插件。

* **重构**
  * 优化了配置文件的修改逻辑，根据不同编译器类型（Vite 或 Webpack5）分别处理配置和错误提示。
  * 简化了 package.json 中 browserslist 字段的结构，统一为生产环境目标数组。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->