### PR TITLE
fix: include port in URL origin property

### DIFF
--- a/packages/taro-runtime/src/__tests__/location.spec.js
+++ b/packages/taro-runtime/src/__tests__/location.spec.js
@@ -10,7 +10,7 @@ describe('location', () => {
         'https://taro.com:8080/hello/world?name=hongxin&age=18#a=1&b=2'
       )
       expect(href).toBe('https://taro.com:8080/hello/world?name=hongxin&age=18#a=1&b=2')
-      expect(origin).toBe('https://taro.com')
+      expect(origin).toBe('https://taro.com:8080')
       expect(protocol).toBe('https:')
       expect(hostname).toBe('taro.com')
       expect(host).toBe('taro.com:8080')
@@ -152,6 +152,18 @@ describe('location', () => {
       const url = new URL('http://taro.com/')
       expect(url.toString()).toBe('http://taro.com/')
       expect(url.pathname).toBe('/')
+    }
+
+    {
+      const url = new URL('/path', 'http://taro.com:8080/')
+      expect(url.toString()).toBe('http://taro.com:8080/path')
+      expect(url.href).toBe('http://taro.com:8080/path')
+      expect(url.protocol).toBe('http:')
+      expect(url.hostname).toBe('taro.com')
+      expect(url.host).toBe('taro.com:8080')
+      expect(url.port).toBe('8080')
+      expect(url.origin).toBe('http://taro.com:8080')
+      expect(url.pathname).toBe('/path')
     }
 
     {

--- a/packages/taro-runtime/src/bom/URL.ts
+++ b/packages/taro-runtime/src/bom/URL.ts
@@ -206,7 +206,7 @@ export function parseUrl (url = '') {
   result.search = matches[10] || ''
   result.hash = matches[12] || ''
   result.href = url
-  result.origin = result.protocol + '//' + result.hostname
+  result.origin = result.protocol + '//' + result.hostname + (result.port ? `:${result.port}` : '')
   result.host = result.hostname + (result.port ? `:${result.port}` : '')
 
   return result


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->

fix: #17986

**这个 PR 做了什么？** (简要描述所做更改)

修复了 Taro Runtime 中 URL 对象的 `origin` 属性缺失端口号的问题，更符合 Web 标准 API 的行为规范。[MDN](https://developer.mozilla.org/zh-CN/docs/Web/API/URL/origin)

### Before
<img width="235" height="197" alt="image" src="https://github.com/user-attachments/assets/61c7c329-5a17-4837-97b6-f151268d77af" />

### After
<img width="262" height="193" alt="image" src="https://github.com/user-attachments/assets/41d648f8-b5c7-4dc7-a74c-590ac045fb44" />


**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #

**这个 PR 涉及以下平台：**

- [x] 所有平台


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了解析带端口号的 URL 时，origin 属性未包含端口号的问题，现已正确显示端口。
  * 新增了相关测试用例，确保 URL 解析在包含端口号的场景下各属性均正确。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->