### PR TITLE
fix: fix CoverView some types lose problem

### DIFF
--- a/packages/taro-components/types/CoverView.d.ts
+++ b/packages/taro-components/types/CoverView.d.ts
@@ -114,6 +114,22 @@ interface CoverViewProps extends ViewProps {
    * @supported alipay
    */
   onTouchCancel?: CommonEventFunction
+  /**
+   * 标记点 ID
+   * @description 用于地图组件的标记点识别
+   * @supported weapp
+   * @example
+   * <CoverView markerId={123} />
+   */
+  markerId?: number
+  /**
+   * 插槽名称
+   * @description 用于组件间的内容分发
+   * @supported weapp
+   * @example
+   * <CoverView slot="header" />
+   */
+  slot?: string
 }
 /** 覆盖在原生组件之上的文本视图。可覆盖的原生组件包括 map、video、canvas、camera、live-player、live-pusher 只支持嵌套 cover-view、cover-image，可在 cover-view 中使用 button。
  * @classification viewContainer


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)
fix CoverView some types lose problem

```tsx
<Map>
   <CoverView slot="customCallout">
       <CoverView markerId={1}><View>hello world</View></CoverView>
   </CoverView>
</Map>

```

**这个 PR 是什么类型？** (至少选择一个)

- [ ] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [x] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [x] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 为组件属性新增了 `markerId` 和 `slot` 两个可选项，提升了在微信小程序平台下的功能扩展性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->