### PR TITLE
fix(taro-platform-h5): 修复windows开发环境Taro对象上等方法不可用

### DIFF
--- a/packages/taro-platform-h5/src/program.ts
+++ b/packages/taro-platform-h5/src/program.ts
@@ -224,7 +224,16 @@ export default class H5 extends TaroPlatformWeb {
             const viteCompilerContext = await getViteH5CompilerContext(this)
             if (viteCompilerContext) {
               const exts = Array.from(new Set(viteCompilerContext.frameworkExts.concat(SCRIPT_EXT)))
-              if (id.startsWith(viteCompilerContext.sourceDir) && exts.some((ext) => id.includes(ext))) {
+              let cleanId = id
+
+              if (cleanId.startsWith('\u0000')) {
+                cleanId = cleanId.slice(1)
+              }
+
+              cleanId = cleanId.split('?')[0].replace(/\\/g, '/') // 👈 替换斜杠方向
+
+              const normalizedSourceDir = viteCompilerContext.sourceDir.replace(/\\/g, '/') // 👈 替换斜杠方向
+              if (cleanId.startsWith(normalizedSourceDir) && exts.some((ext) => id.includes(ext))) {
                 // @TODO 后续考虑使用 SWC 插件的方式实现
                 const result = await transformAsync(code, {
                   filename: id,

--- a/packages/taro-platform-h5/src/program.ts
+++ b/packages/taro-platform-h5/src/program.ts
@@ -224,7 +224,16 @@ export default class H5 extends TaroPlatformWeb {
             const viteCompilerContext = await getViteH5CompilerContext(this)
             if (viteCompilerContext) {
               const exts = Array.from(new Set(viteCompilerContext.frameworkExts.concat(SCRIPT_EXT)))
-              if (id.startsWith(viteCompilerContext.sourceDir) && exts.some((ext) => id.includes(ext))) {
+               let cleanId = id
+
+              if (cleanId.startsWith('\u0000')) {
+                cleanId = cleanId.slice(1)
+              }
+
+              cleanId = cleanId.split('?')[0].replace(/\\/g, '/') // 替换斜杠方向
+
+              const normalizedSourceDir = viteCompilerContext.sourceDir.replace(/\\/g, '/') //  替换斜杠方向
+              if (cleanId.startsWith(normalizedSourceDir) && exts.some((ext) => id.includes(ext))) {
                 // @TODO 后续考虑使用 SWC 插件的方式实现
                 const result = await transformAsync(code, {
                   filename: id,

--- a/packages/taro-platform-h5/src/program.ts
+++ b/packages/taro-platform-h5/src/program.ts
@@ -224,16 +224,7 @@ export default class H5 extends TaroPlatformWeb {
             const viteCompilerContext = await getViteH5CompilerContext(this)
             if (viteCompilerContext) {
               const exts = Array.from(new Set(viteCompilerContext.frameworkExts.concat(SCRIPT_EXT)))
-               let cleanId = id
-
-              if (cleanId.startsWith('\u0000')) {
-                cleanId = cleanId.slice(1)
-              }
-
-              cleanId = cleanId.split('?')[0].replace(/\\/g, '/') // 替换斜杠方向
-
-              const normalizedSourceDir = viteCompilerContext.sourceDir.replace(/\\/g, '/') //  替换斜杠方向
-              if (cleanId.startsWith(normalizedSourceDir) && exts.some((ext) => id.includes(ext))) {
+              if (id.startsWith(viteCompilerContext.sourceDir) && exts.some((ext) => id.includes(ext))) {
                 // @TODO 后续考虑使用 SWC 插件的方式实现
                 const result = await transformAsync(code, {
                   filename: id,


### PR DESCRIPTION
**这个 PR 做了什么？** (简要描述所做更改)
解决Windows开发环境中Taro.request、Taro.setStorageSync、Taro.getStorageSync、Taro.showToast等API方法不可用的问题。核心原因在于Windows系统路径使用反斜杠（\）而非正斜杠（/），同时路径中可能存在空格字符，导致相关模块无法被正确识别和导入。


**这个 PR 是什么类型？** (至少选择一个)

- [ ✅] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ✅] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **修复问题**
  * 统一并规范化构建/转换时的路径格式（处理前导字符、查询参数与分隔符等差异），提升跨平台兼容性，减少因路径格式不一致导致的转换或构建失败的潜在问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->