### PR TITLE
Update BaseCi.ts

### DIFF
--- a/packages/taro-plugin-mini-ci/src/BaseCi.ts
+++ b/packages/taro-plugin-mini-ci/src/BaseCi.ts
@@ -74,9 +74,9 @@ export interface AlipayConfig {
   /** 工具id */
   toolId: string
   /** 私钥文件路径，在获取项目属性和上传时用于鉴权使用(privateKeyPath和privateKey之间必须要填写其中一个) */
-  privateKeyPath: string
+  privateKeyPath?: string
   /** 私钥文本内容，在获取项目属性和上传时用于鉴权使用(privateKeyPath和privateKey之间必须要填写其中一个) */
-  privateKey: string
+  privateKey?: string
   /** 小程序开发者工具安装路径 */
   devToolsInstallPath?: string
   /** 上传的终端, 默认alipay */


### PR DESCRIPTION
 支付宝私钥文件路径，在获取项目属性和上传时用于鉴权privateKeyPath和privateKey之间只需要填写一个，不是必填

<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)


**这个 PR 是什么类型？** (至少选择一个)

- [ ] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [x] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [x] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新功能
  * 支持在支付宝相关配置中将私钥路径与私钥设为可选，减少必填项，提升配置灵活性与兼容性；未提供时可采用替代的凭证来源（如环境变量或外部管理），简化不同环境下的集成与部署。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->