### PR TITLE
feat: 增加支付宝小程序 Page.events useKeyboardHeight

### DIFF
--- a/examples/mini-program-example/src/pages/api/taro/hooks/index.tsx
+++ b/examples/mini-program-example/src/pages/api/taro/hooks/index.tsx
@@ -97,6 +97,10 @@ export default class Index extends React.Component {
         func: null,
       },
       {
+        id: 'useKeyboardHeight',
+        func: null,
+      },
+      {
         id: 'usePullIntercept',
         func: null,
       },

--- a/packages/shared/src/runtime-hooks.ts
+++ b/packages/shared/src/runtime-hooks.ts
@@ -95,6 +95,7 @@ const defaultMiniLifecycle: MiniLifecycle = {
       'defer:onTabItemTap', // defer: 需要等页面组件挂载后再调用
       'onTitleClick',
       'onOptionMenuClick',
+      'events:onKeyboardHeight', // events: 支付宝平台需要挂载到 config.events 上
       'onPopMenuClick',
       'onPullIntercept',
       'onAddToFavorites'

--- a/packages/taro-framework-react/src/api-loader.ts
+++ b/packages/taro-framework-react/src/api-loader.ts
@@ -7,6 +7,7 @@ export default function (str: string) {
   useLaunch,
   useLoad,
   useOptionMenuClick,
+  useKeyboardHeight,
   usePageNotFound,
   usePageScroll,
   usePullDownRefresh,
@@ -33,6 +34,7 @@ taro.useError = useError
 taro.useLaunch = useLaunch
 taro.useLoad = useLoad
 taro.useOptionMenuClick = useOptionMenuClick
+taro.useKeyboardHeight = useKeyboardHeight
 taro.usePageNotFound = usePageNotFound
 taro.usePageScroll = usePageScroll
 taro.usePullDownRefresh = usePullDownRefresh
@@ -58,6 +60,7 @@ export {
   useLaunch,
   useLoad,
   useOptionMenuClick,
+  useKeyboardHeight,
   usePageNotFound,
   usePageScroll,
   usePullDownRefresh,

--- a/packages/taro-framework-react/src/runtime/hooks.ts
+++ b/packages/taro-framework-react/src/runtime/hooks.ts
@@ -78,6 +78,7 @@ export const useUnload = createTaroHook('onUnload')
 /** Mini-Program */
 export const useAddToFavorites = createTaroHook('onAddToFavorites')
 export const useOptionMenuClick = createTaroHook('onOptionMenuClick')
+export const useKeyboardHeight = createTaroHook('onKeyboardHeight')
 export const useSaveExitState = createTaroHook('onSaveExitState')
 export const useShareAppMessage = createTaroHook('onShareAppMessage')
 export const useShareTimeline = createTaroHook('onShareTimeline')

--- a/packages/taro-framework-solid/src/api-loader.ts
+++ b/packages/taro-framework-solid/src/api-loader.ts
@@ -7,6 +7,7 @@ export default function (str: string) {
   useLaunch,
   useLoad,
   useOptionMenuClick,
+  useKeyboardHeight,
   usePageNotFound,
   usePageScroll,
   usePullDownRefresh,
@@ -33,6 +34,7 @@ taro.useError = useError
 taro.useLaunch = useLaunch
 taro.useLoad = useLoad
 taro.useOptionMenuClick = useOptionMenuClick
+taro.useKeyboardHeight = useKeyboardHeight
 taro.usePageNotFound = usePageNotFound
 taro.usePageScroll = usePageScroll
 taro.usePullDownRefresh = usePullDownRefresh
@@ -58,6 +60,7 @@ export {
   useLaunch,
   useLoad,
   useOptionMenuClick,
+  useKeyboardHeight,
   usePageNotFound,
   usePageScroll,
   usePullDownRefresh,

--- a/packages/taro-framework-solid/src/runtime/hooks.ts
+++ b/packages/taro-framework-solid/src/runtime/hooks.ts
@@ -79,6 +79,7 @@ export const useUnload = createTaroHook('onUnload')
 /** Mini-Program */
 export const useAddToFavorites = createTaroHook('onAddToFavorites')
 export const useOptionMenuClick = createTaroHook('onOptionMenuClick')
+export const useKeyboardHeight = createTaroHook('onKeyboardHeight')
 export const useSaveExitState = createTaroHook('onSaveExitState')
 export const useShareAppMessage = createTaroHook('onShareAppMessage')
 export const useShareTimeline = createTaroHook('onShareTimeline')

--- a/packages/taro-framework-vue3/src/api-loader.ts
+++ b/packages/taro-framework-vue3/src/api-loader.ts
@@ -8,6 +8,7 @@ export default function (str: string) {
   useLaunch,
   useLoad,
   useOptionMenuClick,
+  useKeyboardHeight,
   usePageNotFound,
   usePageScroll,
   usePullDownRefresh,
@@ -35,6 +36,7 @@ taro.useLaunch = useLaunch
 taro.setGlobalDataPlugin = setGlobalDataPlugin
 taro.useLoad = useLoad
 taro.useOptionMenuClick = useOptionMenuClick
+taro.useKeyboardHeight = useKeyboardHeight
 taro.usePageNotFound = usePageNotFound
 taro.usePageScroll = usePageScroll
 taro.usePullDownRefresh = usePullDownRefresh
@@ -60,6 +62,7 @@ export {
   useLaunch,
   useLoad,
   useOptionMenuClick,
+  useKeyboardHeight,
   usePageNotFound,
   usePageScroll,
   usePullDownRefresh,

--- a/packages/taro-framework-vue3/src/runtime/composition-functions.ts
+++ b/packages/taro-framework-vue3/src/runtime/composition-functions.ts
@@ -81,6 +81,7 @@ export const useUnload = createTaroHook('onUnload')
 /** Mini-Program */
 export const useAddToFavorites = createTaroHook('onAddToFavorites')
 export const useOptionMenuClick = createTaroHook('onOptionMenuClick')
+export const useKeyboardHeight = createTaroHook('onKeyboardHeight')
 export const useSaveExitState = createTaroHook('onSaveExitState')
 export const useShareAppMessage = createTaroHook('onShareAppMessage')
 export const useShareTimeline = createTaroHook('onShareTimeline')

--- a/packages/taro-platform-harmony-cpp/src/runtime/framework/hooks.ts
+++ b/packages/taro-platform-harmony-cpp/src/runtime/framework/hooks.ts
@@ -83,6 +83,7 @@ export const useUnload = createTaroHook('onUnload')
 /** Mini-Program */
 export const useAddToFavorites = createTaroHook('onAddToFavorites')
 export const useOptionMenuClick = createTaroHook('onOptionMenuClick')
+export const useKeyboardHeight = createTaroHook('onKeyboardHeight')
 export const useSaveExitState = createTaroHook('onSaveExitState')
 export const useShareAppMessage = createTaroHook('onShareAppMessage')
 export const useShareTimeline = createTaroHook('onShareTimeline')

--- a/packages/taro-platform-harmony/src/runtime-framework/react/hooks.ts
+++ b/packages/taro-platform-harmony/src/runtime-framework/react/hooks.ts
@@ -84,6 +84,7 @@ export const useUnload = createTaroHook('onUnload')
 /** Mini-Program */
 export const useAddToFavorites = createTaroHook('onAddToFavorites')
 export const useOptionMenuClick = createTaroHook('onOptionMenuClick')
+export const useKeyboardHeight = createTaroHook('onKeyboardHeight')
 export const useSaveExitState = createTaroHook('onSaveExitState')
 export const useShareAppMessage = createTaroHook('onShareAppMessage')
 export const useShareTimeline = createTaroHook('onShareTimeline')

--- a/packages/taro-platform-harmony/src/runtime-framework/solid/hooks.ts
+++ b/packages/taro-platform-harmony/src/runtime-framework/solid/hooks.ts
@@ -78,6 +78,7 @@ export const useUnload = createTaroHook('onUnload')
 /** Mini-Program */
 export const useAddToFavorites = createTaroHook('onAddToFavorites')
 export const useOptionMenuClick = createTaroHook('onOptionMenuClick')
+export const useKeyboardHeight = createTaroHook('onKeyboardHeight')
 export const useSaveExitState = createTaroHook('onSaveExitState')
 export const useShareAppMessage = createTaroHook('onShareAppMessage')
 export const useShareTimeline = createTaroHook('onShareTimeline')

--- a/packages/taro-platform-harmony/src/utils/api-loader.ts
+++ b/packages/taro-platform-harmony/src/utils/api-loader.ts
@@ -7,6 +7,7 @@ export function apiLoader (str: string) {
   useLaunch,
   useLoad,
   useOptionMenuClick,
+  useKeyboardHeight,
   usePageNotFound,
   usePageScroll,
   usePullDownRefresh,
@@ -33,6 +34,7 @@ taro.useError = useError
 taro.useLaunch = useLaunch
 taro.useLoad = useLoad
 taro.useOptionMenuClick = useOptionMenuClick
+taro.useKeyboardHeight = useKeyboardHeight
 taro.usePageNotFound = usePageNotFound
 taro.usePageScroll = usePageScroll
 taro.usePullDownRefresh = usePullDownRefresh
@@ -58,6 +60,7 @@ export {
   useLaunch,
   useLoad,
   useOptionMenuClick,
+  useKeyboardHeight,
   usePageNotFound,
   usePageScroll,
   usePullDownRefresh,

--- a/packages/taro-runtime/src/dsl/common.ts
+++ b/packages/taro-runtime/src/dsl/common.ts
@@ -120,7 +120,7 @@ export function createPageConfig (component: any, pageName?: string, data?: Reco
   }
   let loadResolver: (...args: unknown[]) => void
   let hasLoaded: Promise<void>
-  const config: PageInstance & { events?: Record<string, any> } = {
+  const config: PageInstance = {
     [ONLOAD] (this: MpInstance, options: Readonly<Record<string, unknown>> = {}, cb?: TFunc) {
       hasLoaded = new Promise(resolve => { loadResolver = resolve })
 

--- a/packages/taro-runtime/src/dsl/common.ts
+++ b/packages/taro-runtime/src/dsl/common.ts
@@ -120,7 +120,7 @@ export function createPageConfig (component: any, pageName?: string, data?: Reco
   }
   let loadResolver: (...args: unknown[]) => void
   let hasLoaded: Promise<void>
-  const config: PageInstance = {
+  const config: PageInstance & { events?: Record<string, any> } = {
     [ONLOAD] (this: MpInstance, options: Readonly<Record<string, unknown>> = {}, cb?: TFunc) {
       hasLoaded = new Promise(resolve => { loadResolver = resolve })
 
@@ -239,16 +239,30 @@ export function createPageConfig (component: any, pageName?: string, data?: Reco
 
   LIFECYCLES.forEach((lifecycle) => {
     let isDefer = false
+    let isEvent = false
     lifecycle = lifecycle.replace(/^defer:/, () => {
       isDefer = true
       return ''
     })
-    config[lifecycle] = function () {
-      const exec = () => safeExecute(this.$taroPath, lifecycle, ...arguments)
-      if (isDefer) {
-        hasLoaded.then(exec)
-      } else {
-        return exec()
+    lifecycle = lifecycle.replace(/^events:/, () => {
+      isEvent = true
+      return ''
+    })
+
+    if (isEvent && process.env.TARO_ENV === 'alipay') {
+      // 初始化 config.events 对象
+      if (!config.events) config.events = {}
+      config.events[lifecycle] = function () {
+        return safeExecute(this.$taroPath, lifecycle, ...arguments)
+      }
+    } else {
+      config[lifecycle] = function () {
+        const exec = () => safeExecute(this.$taroPath, lifecycle, ...arguments)
+        if (isDefer) {
+          hasLoaded.then(exec)
+        } else {
+          return exec()
+        }
       }
     }
   })

--- a/packages/taro-runtime/src/dsl/instance.ts
+++ b/packages/taro-runtime/src/dsl/instance.ts
@@ -33,6 +33,7 @@ export interface PageLifeCycle extends Show {
   onAddToFavorites?(): void
   onLoad?(options: Record<string, unknown>, cb?: TFunc): void
   onOptionMenuClick?(): void
+  onKeyboardHeight?(obj: { height: number }): void
   onPageScroll?(obj: { scrollTop: number }): void
   onPullDownRefresh?(): void
   onPullIntercept?(): void

--- a/packages/taro-runtime/src/dsl/instance.ts
+++ b/packages/taro-runtime/src/dsl/instance.ts
@@ -58,6 +58,8 @@ export interface PageInstance extends PageLifeCycle {
   options?: Record<string, unknown>
   /** 页面渲染引擎类型 */
   renderer?: 'webview' | 'skyline'
+  /** 页面事件对象，支付宝小程序特有，详见[events](https://opendocs.alipay.com/mini/framework/page-detail#events) */
+  events?: Record<string, (...args: any[]) => any>
   /** 获得一个 EventChannel 对象，用于页面间通讯 */
   getOpenerEventChannel?(): Record<string, any>
   /** 执行关键帧动画，详见[动画](https://developers.weixin.qq.com/miniprogram/dev/framework/view/animation.html) */

--- a/packages/taro/types/api/taro.hooks.d.ts
+++ b/packages/taro/types/api/taro.hooks.d.ts
@@ -134,6 +134,12 @@ declare module '../index' {
     useOptionMenuClick(callback: () => void): void
 
     /**
+     * 键盘高度变化时的回调。
+     * @supported alipay
+     */
+    useKeyboardHeight(callback: (payload: { height: number }) => void): void
+
+    /**
      * 下拉中断时的回调。
      * @supported alipay, h5, harmony_hybrid
      */

--- a/packages/taro/types/taro.component.d.ts
+++ b/packages/taro/types/taro.component.d.ts
@@ -45,6 +45,8 @@ declare module './index' {
     eh?(event: MpEvent): void
     onLoad(options: Record<string, unknown>): void
     onOptionMenuClick?(): void
+    /** 键盘高度变化时触发 @supported alipay */
+    onKeyboardHeight?(opt: { height: number; }): void
     onPageScroll?(opt: PageScrollObject): void
     onPopMenuClick?(): void
     onPullDownRefresh?(): void

--- a/tests/__tests__/__snapshots__/babel.spec.ts.snap
+++ b/tests/__tests__/__snapshots__/babel.spec.ts.snap
@@ -626,6 +626,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}

--- a/tests/__tests__/__snapshots__/compiler-macros.spec.ts.snap
+++ b/tests/__tests__/__snapshots__/compiler-macros.spec.ts.snap
@@ -626,6 +626,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}

--- a/tests/__tests__/__snapshots__/config.spec.ts.snap
+++ b/tests/__tests__/__snapshots__/config.spec.ts.snap
@@ -626,6 +626,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}
@@ -2454,6 +2455,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}
@@ -4144,6 +4146,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}
@@ -5850,6 +5853,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}
@@ -7498,6 +7502,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}

--- a/tests/__tests__/__snapshots__/css-modules.spec.ts.snap
+++ b/tests/__tests__/__snapshots__/css-modules.spec.ts.snap
@@ -626,6 +626,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}
@@ -2329,6 +2330,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}

--- a/tests/__tests__/__snapshots__/framework.spec.ts.snap
+++ b/tests/__tests__/__snapshots__/framework.spec.ts.snap
@@ -626,6 +626,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}
@@ -2846,6 +2847,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}

--- a/tests/__tests__/__snapshots__/mini-platform.spec.ts.snap
+++ b/tests/__tests__/__snapshots__/mini-platform.spec.ts.snap
@@ -807,6 +807,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}
@@ -1923,6 +1924,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}
@@ -2900,6 +2902,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}

--- a/tests/__tests__/__snapshots__/parse-html.spec.ts.snap
+++ b/tests/__tests__/__snapshots__/parse-html.spec.ts.snap
@@ -626,6 +626,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}

--- a/tests/__tests__/__snapshots__/prerender.spec.ts.snap
+++ b/tests/__tests__/__snapshots__/prerender.spec.ts.snap
@@ -626,6 +626,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}
@@ -3688,6 +3689,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}
@@ -6750,6 +6752,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}

--- a/tests/__tests__/__snapshots__/sass.spec.ts.snap
+++ b/tests/__tests__/__snapshots__/sass.spec.ts.snap
@@ -626,6 +626,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}
@@ -2284,6 +2285,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}
@@ -3976,6 +3978,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}
@@ -5670,6 +5673,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}
@@ -7364,6 +7368,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}

--- a/tests/__tests__/__snapshots__/skyline.spec.ts.snap
+++ b/tests/__tests__/__snapshots__/skyline.spec.ts.snap
@@ -626,6 +626,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}

--- a/tests/__tests__/__snapshots__/subpackages.spec.ts.snap
+++ b/tests/__tests__/__snapshots__/subpackages.spec.ts.snap
@@ -1396,6 +1396,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}

--- a/tests/__tests__/__snapshots__/tabbar.spec.ts.snap
+++ b/tests/__tests__/__snapshots__/tabbar.spec.ts.snap
@@ -1546,6 +1546,7 @@ D�RN��/y�   X}_�A��T�    IEND�B\`�
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}
@@ -2743,6 +2744,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}
@@ -3886,6 +3888,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}

--- a/tests/__tests__/__snapshots__/ts.spec.ts.snap
+++ b/tests/__tests__/__snapshots__/ts.spec.ts.snap
@@ -626,6 +626,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}

--- a/tests/__tests__/__snapshots__/wx-hybrid.spec.ts.snap
+++ b/tests/__tests__/__snapshots__/wx-hybrid.spec.ts.snap
@@ -1469,6 +1469,7 @@ require("./runtime");
         function useUnload() {}
         function useAddToFavorites() {}
         function useOptionMenuClick() {}
+        function useKeyboardHeight() {}
         function useSaveExitState() {}
         function useShareAppMessage() {}
         function useShareTimeline() {}

--- a/tests/__tests__/mocks/taro.ts
+++ b/tests/__tests__/mocks/taro.ts
@@ -19,6 +19,7 @@ export function useResize () {}
 export function useUnload () {}
 export function useAddToFavorites () {}
 export function useOptionMenuClick () {}
+export function useKeyboardHeight () {}
 export function useSaveExitState () {}
 export function useShareAppMessage () {}
 export function useShareTimeline () {}


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)

这个 PR 为 Taro 框架添加了支付宝小程序的 [onKeyboardHeight](https://opendocs.alipay.com/mini/framework/page-detail#events) 支持，用于监听键盘高度变化事件。

主要更改：

  - 新增 useKeyboardHeight Hook - 支持在支付宝小程序中监听键盘高度变化
  - 添加生命周期支持 - 在 runtime-hooks.ts 中添加 events:onKeyboardHeight
  生命周期，支持支付宝平台的 events 配置
  - 完整的框架集成 - 为所有框架（React、Vue3、Solid、Harmony）添加了完整的 Hook 实现和导出
  - 类型定义完善 - 更新了相关的 TypeScript 类型定义
  - runtime 增强 - 支持 events: 前缀的生命周期处理，专门针对支付宝小程序的事件配置需求

**这个 PR 是什么类型？** (至少选择一个)

- [ ] 错误修复 (Bugfix) issue: fix #
- [x] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [x] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 新增 useKeyboardHeight 钩子，用于监听键盘高度变化，并在 React/Vue3/Solid/Harmony 等运行时作为公共 API 暴露。
  - 支持支付宝平台的事件型页面生命周期，新增 onKeyboardHeight 页面回调并通过页面事件注册机制触发。
  - 示例小程序的 API 列表中添加了 useKeyboardHeight 项目。
- 测试
  - 增加 useKeyboardHeight 的测试 mock 导出用于单元测试。
- 杂务
  - 更新类型声明，公开 useKeyboardHeight 与 onKeyboardHeight。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->