### PR TITLE
fix: 当设置babel 的targets为ios10以后，class不转换后导致onShareAppMessage和onShareTi…

### DIFF
--- a/packages/taro-framework-react/src/loader-meta.ts
+++ b/packages/taro-framework-react/src/loader-meta.ts
@@ -46,19 +46,19 @@ function addConfig (source) {
           check(callee.property.value)
         }
       }
-      node.arguments.forEach((item) => {
+      node.arguments.forEach((item: any) => {
         if (item.type === 'Literal' && item.value) {
           check(item.value)
         }
       })
     },
-    ClassDeclaration(node) {
+    ClassDeclaration(node: any) {
       // 类声明: class Foo {}
       if (node.id && node.id.name) {
         check(node.id.name)
       }
       // 类体方法: class Foo { bar() {} }
-      node.body.body.forEach((method) => {
+      node.body.body.forEach((method: any) => {
         if (method.type === 'MethodDefinition') {
           if (method.key.type === 'Identifier') {
             check(method.key.name)
@@ -68,12 +68,12 @@ function addConfig (source) {
         }
       })
     },
-    ClassExpression(node) {
+    ClassExpression(node: any) {
       // 类表达式: const A = class B {}
       if (node.id && node.id.name) {
         check(node.id.name)
       }
-      node.body.body.forEach((method) => {
+      node.body.body.forEach((method: any) => {
         if (method.type === 'MethodDefinition') {
           if (method.key.type === 'Identifier') {
             check(method.key.name)

--- a/packages/taro-framework-react/src/loader-meta.ts
+++ b/packages/taro-framework-react/src/loader-meta.ts
@@ -27,15 +27,15 @@ function addConfig (source) {
   }
 
   walk.simple(ast, {
-    FunctionExpression (node: any) {
+    FunctionExpression(node: any) {
       if (!node.id || !node.id.name) return
       check(node.id.name)
     },
-    FunctionDeclaration (node: any) {
+    FunctionDeclaration(node: any) {
       if (!node.id || !node.id.name) return
       check(node.id.name)
     },
-    CallExpression (node: any) {
+    CallExpression(node: any) {
       const { callee } = node
       if (callee.type === 'Identifier') {
         check(callee.name)
@@ -46,12 +46,43 @@ function addConfig (source) {
           check(callee.property.value)
         }
       }
-      node.arguments.forEach(item => {
+      node.arguments.forEach((item) => {
         if (item.type === 'Literal' && item.value) {
           check(item.value)
         }
       })
-    }
+    },
+    ClassDeclaration(node) {
+      // 类声明: class Foo {}
+      if (node.id && node.id.name) {
+        check(node.id.name)
+      }
+      // 类体方法: class Foo { bar() {} }
+      node.body.body.forEach((method) => {
+        if (method.type === 'MethodDefinition') {
+          if (method.key.type === 'Identifier') {
+            check(method.key.name)
+          } else if (method.key.type === 'Literal') {
+            check(method.key.value as string)
+          }
+        }
+      })
+    },
+    ClassExpression(node) {
+      // 类表达式: const A = class B {}
+      if (node.id && node.id.name) {
+        check(node.id.name)
+      }
+      node.body.body.forEach((method) => {
+        if (method.type === 'MethodDefinition') {
+          if (method.key.type === 'Identifier') {
+            check(method.key.name)
+          } else if (method.key.type === 'Literal') {
+            check(method.key.value as string)
+          }
+        }
+      })
+    },
   })
 
   return additionConfig

--- a/packages/taro-rn/src/lib/index.ts
+++ b/packages/taro-rn/src/lib/index.ts
@@ -1,5 +1,4 @@
 // 由 getLibList.js 脚本生成, 不要进行手动修改, 请不要手动修改
-export * from './ENV_TYPE'
 export * from './arrayBufferToBase64'
 export * from './authorize'
 export * from './base64ToArrayBuffer'
@@ -16,6 +15,7 @@ export * from './createInnerAudioContext'
 export * from './createSelectorQuery'
 export * from './createVideoContext'
 export * from './downloadFile'
+export * from './ENV_TYPE'
 export * from './getAppBaseInfo'
 export * from './getClipboardData'
 export * from './getEnv'

--- a/packages/taro-rn/src/lib/index.ts
+++ b/packages/taro-rn/src/lib/index.ts
@@ -1,4 +1,5 @@
 // 由 getLibList.js 脚本生成, 不要进行手动修改, 请不要手动修改
+export * from './ENV_TYPE'
 export * from './arrayBufferToBase64'
 export * from './authorize'
 export * from './base64ToArrayBuffer'
@@ -15,7 +16,6 @@ export * from './createInnerAudioContext'
 export * from './createSelectorQuery'
 export * from './createVideoContext'
 export * from './downloadFile'
-export * from './ENV_TYPE'
 export * from './getAppBaseInfo'
 export * from './getClipboardData'
 export * from './getEnv'


### PR DESCRIPTION


<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)
当babel config设置
 targets: {
          ios: '10'
        }
        
 以后 class就不会转换为function，从而导致检测onShareAppMessage和onShareTimeline 检测失效


**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [x] 所有小程序
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - 改进对类声明/类表达式及其成员方法名的识别，同时增强对链式/成员调用的处理，提升基于 class 的组件与链式调用场景的兼容性与稳定性，减少因命名形式差异导致的异常或失效。
- Refactor
  - 进行轻量语法与遍历逻辑调整，统一处理方式，不影响现有功能表现。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->