### PR TITLE
fix(@tarojs/cli-convertor): 修复运行 npx @tarojs/cli-convertor 转换小程序时的报错：“taroize is not a function” (#18327)

### DIFF
--- a/packages/taro-cli-convertor/src/index.ts
+++ b/packages/taro-cli-convertor/src/index.ts
@@ -22,7 +22,7 @@ import {
   resolveScriptPath,
 } from '@tarojs/helper'
 import { isNull, isUndefined } from '@tarojs/shared'
-import * as taroize from '@tarojs/taroize'
+import taroize from '@tarojs/taroize'
 import wxTransformer from '@tarojs/transformer-wx'
 import Processors from 'postcss'
 import * as unitTransform from 'postcss-taro-unit-transform'


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)

将 `import * as taroize from '@tarojs/taroize'` 修改为 `import taroize from '@tarojs/taroize'`。

修复一次破坏性改动导致的bug：
[统一各包的构建产物目录为 dist，并调整主入口、类型声明等相关路径，简化包发布内容](https://github.com/NervJS/taro/pull/17910/files#diff-6eed60ac39958d7bb19f49d5670760827bcc1ee6202ee29d490629c17a11001e)

相关issue：
微信小程序转换报错 [#18327](https://github.com/NervJS/taro/issues/18327)


**这个 PR 是什么类型？** (至少选择一个)

- [x ] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [x ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序