### PR TITLE
fix(ascf): 增加Taro -> ascf的方法映射

### DIFF
--- a/packages/taro-platform-ascf/src/apis.ts
+++ b/packages/taro-platform-ascf/src/apis.ts
@@ -1,6 +1,7 @@
 import { processApis } from '@tarojs/shared'
 
 import { needPromiseApis } from './apis-list'
+import { reflectApis } from './reflect-apis'
 
 declare const has: any
 
@@ -28,4 +29,5 @@ export function initNativeApi (taro) {
       return pageCtx.getTabBar()?.$taroInstances
     }
   }
+  reflectApis(taro, has)
 }

--- a/packages/taro-platform-ascf/src/reflect-apis.ts
+++ b/packages/taro-platform-ascf/src/reflect-apis.ts
@@ -1,0 +1,25 @@
+import { processApis } from '@tarojs/shared'
+
+/**
+ * 在调用Taro.xxx(key)时，映射到has.xxxx(value)
+ * 如：Taro.navigateToMiniProgram()，实际执行的是has.navigateToAtomicService()
+ */
+const reflectApisMap: Map<string, string> = new Map([
+  ['navigateToMiniProgram', 'navigateToAtomicService'],
+  ['navigateBackMiniProgram', 'navigateBackAtomicService']
+])
+
+const needPromiseApis = new Set(reflectApisMap.keys())
+
+export function reflectApis (taro, has) {
+  processApis(taro, has, {
+    needPromiseApis,
+    isOnlyPromisify: true,
+    transformMeta (api: string, options: Record<string, any>) {
+      return {
+        options,
+        key: reflectApisMap.get(api) || api,
+      }
+    }
+  })
+}


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)
增加Taro -> ascf的方法映射，如：Taro.navigateToMiniProgram()，实际执行的是has.navigateToAtomicService()


**这个 PR 是什么类型？** (至少选择一个)

- [ x ] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ x ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序