### PR TITLE
FIX: requestSubscribeMessage ts类型错误

### DIFF
--- a/packages/taro/types/api/open-api/subscribe-message.d.ts
+++ b/packages/taro/types/api/open-api/subscribe-message.d.ts
@@ -2,7 +2,7 @@ import Taro from '../../index'
 
 declare module '../../index' {
   namespace requestSubscribeMessage {
-    interface Option {
+    interface BaseOption {
       /**
        * 需要订阅的消息模板的id的集合（注意：iOS客户端7.0.6版本、Android客户端7.0.7版本之后的一次性订阅/长期订阅才支持多个模板消息，iOS客户端7.0.5版本、Android客户端7.0.6版本之前的一次订阅只支持一个模板消息）消息模板id在[微信公众平台(mp.weixin.qq.com)-功能-订阅消息]中配置
        * @supported weapp, tt
@@ -23,6 +23,11 @@ declare module '../../index' {
       /** 接口调用成功的回调函数 */
       success?: (result: SuccessCallbackResult) => void
     }
+
+    type AtLeastOne<T, Keys extends keyof T = keyof T> =
+      Keys extends keyof T ? T & Required<Pick<T, Keys>> : never;
+
+    type Option = AtLeastOne<BaseOption, 'tmplIds' | 'entityIds'>;
 
     interface FailCallbackResult extends TaroGeneral.CallbackResult {
       /** 接口调用失败错误码 */


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)


**这个 PR 是什么类型？** (至少选择一个)

- [ ] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [x] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [x] 所有小程序
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 重构订阅消息 API 的参数类型，抽离 BaseOption，并以类型工具强制 tmplIds 与 entityIds 成对提供；保持原有使用体验，提升类型一致性与可读性。
- Bug Fixes
  - 加强类型校验，在编译期提示缺失必要字段，减少因参数不完整导致的调用错误，提升开发体验与稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->