### PR TITLE
fix(debugger): 解决jsvm debugger能力sourcemap映射问题

### DIFF
--- a/packages/taro-vite-runner/src/harmony/babel.ts
+++ b/packages/taro-vite-runner/src/harmony/babel.ts
@@ -14,6 +14,7 @@ export default (viteCompilerContext: ViteHarmonyCompilerContext): PluginOption =
       if (/(\.(et|j|t)sx?|\.vue)$/.test(id.split('?')[0])) {
         const result = transformSync(code, {
           filename: id,
+          sourceMaps: true,
           plugins: [
             [
               function renameImportPlugin (babel: typeof BabelCore): BabelCore.PluginObj<BabelCore.PluginPass> {
@@ -75,6 +76,7 @@ export default (viteCompilerContext: ViteHarmonyCompilerContext): PluginOption =
         // TODO 后续考虑使用 SWC 插件的方式实现
         const result = await transformAsync(code, {
           filename: id,
+          sourceMaps: true,
           plugins: [
             [
               require('babel-plugin-transform-taroapi'),


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)

解决jsvm debugger能力sourcemap映射问题

**这个 PR 是什么类型？** (至少选择一个)

- [✅ ] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [✅ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 在构建过程中启用 Babel 转换的 sourceMap 生成功能：构建产物包含更精确的映射信息，断点、错误堆栈与控制台行号更准确地映射回原始源码，提升调试与定位问题的效率。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->