### PR TITLE
fix: 修复微信skyline标签和h5标签命名冲突时, taro默认使用小程序标签渲染. 但是项目可能没有开启skyline模式, 导致渲染html模版字符串异常

### DIFF
--- a/packages/taro-runtime/src/dom-external/inner-html/parser.ts
+++ b/packages/taro-runtime/src/dom-external/inner-html/parser.ts
@@ -71,7 +71,7 @@ function hasTerminalParent (tagName: string, stack: Element[]) {
   return false
 }
 
-function getTagName (tag: string) {
+function getTagName (tag: string, attributes: string[]) {
   if (options.html!.renderHTMLTag) {
     return tag
   }
@@ -79,6 +79,14 @@ function getTagName (tag: string) {
   if (specialMiniElements[tag]) {
     return specialMiniElements[tag]
   } else if (isMiniElements(tag)) {
+    if (isBlockElements(tag)) {
+      return attributes.includes('skyline-mode') ? tag : 'view'
+    }
+
+    if (isInlineElements(tag)) {
+      return attributes.includes('skyline-mode') ? tag : 'text'
+    }
+
     return tag
   } else if (isBlockElements(tag)) {
     return 'view'
@@ -128,7 +136,7 @@ function format (
         return text
       }
 
-      const el: ParsedTaroElement = document.createElement(getTagName(child.tagName))
+      const el: ParsedTaroElement = document.createElement(getTagName(child.tagName, child.attributes))
       el.h5tagName = child.tagName
 
       parent?.appendChild(el)


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)
微信小程序skyline模式下有span标签, 而h5也有span标签. 在用react的dangerouslySetInnerHTML解析html字符串模版时,不知道用哪一个去解析. 本次只要在有命名冲突的标签上增加attribute属性(skyline-mode), 则用skylin标签渲染,否则依旧转为view和text进行渲染.

**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #17747
- [] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [x] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **性能优化**
  * 优化了迷你元素的渲染逻辑，支持 skyline-mode 属性控制元素渲染方式。启用 skyline-mode 时，块级和行内迷你元素将按原始标签类型渲染，而非通用容器。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->