### PR TITLE
fix(h5): getBackgroundAudioManager should return singleton instance

### DIFF
--- a/packages/taro-h5/src/api/media/background-audio/index.ts
+++ b/packages/taro-h5/src/api/media/background-audio/index.ts
@@ -11,7 +11,12 @@ export const onBackgroundAudioPlay = /* @__PURE__ */ temporarilyNotSupport('onBa
 export const onBackgroundAudioPause = /* @__PURE__ */ temporarilyNotSupport('onBackgroundAudioPause')
 export const getBackgroundAudioPlayerState = /* @__PURE__ */ temporarilyNotSupport('getBackgroundAudioPlayerState')
 
+let _instance: BackgroundAudioManager | null = null
+
 /**
  * 获取全局唯一的背景音频管理器
  */
-export const getBackgroundAudioManager = () => new BackgroundAudioManager()
+export const getBackgroundAudioManager = () => {
+  if (!_instance) _instance = new BackgroundAudioManager()
+  return _instance
+}


### PR DESCRIPTION
## Description

This PR fixes a critical bug where `getBackgroundAudioManager()` creates a new instance on every call, causing multiple audio players to run simultaneously on H5.

## Problem

Current implementation:
```typescript
export const getBackgroundAudioManager = () => new BackgroundAudioManager()
```

Issues:
- Creates new `HTMLAudioElement` per call
- Multiple audio instances play concurrently
- Inconsistent with WeChat Mini Program behavior (which returns singleton)
- Comment says "获取全局唯一的背景音频管理器" but implementation doesn't enforce uniqueness

## Solution

```typescript
let _instance: BackgroundAudioManager | null = null

export const getBackgroundAudioManager = () => {
  return _instance
}
```

## Impact

- ✅ Fixes concurrent audio playback on H5
- ✅ Aligns H5 behavior with WeChat Mini Program
- ✅ No breaking changes (existing code works as expected)
- ✅ Minimal code change (3 lines)

## Testing

Tested in production app with multiple pages calling `getBackgroundAudioManager()`:
- Before: Two audio tracks playing simultaneously
- After: Single audio instance, proper playback control

---

**Related Issues:** None found (first report of this bug)
**Documentation:** Comment already states "全局唯一" - implementation now matches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 优化了后台音频管理器的资源管理机制，提升了性能效率，减少了不必要的开销。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->