### PR TITLE
fix: 修复百度小程序 onLoad onTabItemTap执行时序问题

### DIFF
--- a/packages/taro-runtime/src/dsl/common.ts
+++ b/packages/taro-runtime/src/dsl/common.ts
@@ -237,6 +237,7 @@ export function createPageConfig (component: any, pageName?: string, data?: Reco
     }
   }
 
+  const isSWAN = process.env.TARO_ENV === 'swan'// 百度小程序
   LIFECYCLES.forEach((lifecycle) => {
     let isDefer = false
     lifecycle = lifecycle.replace(/^defer:/, () => {
@@ -245,6 +246,10 @@ export function createPageConfig (component: any, pageName?: string, data?: Reco
     })
     config[lifecycle] = function () {
       const exec = () => safeExecute(this.$taroPath, lifecycle, ...arguments)
+      if (isSWAN) {
+        return exec()
+      }
+
       if (isDefer) {
         hasLoaded.then(exec)
       } else {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)
百度小程序，真机上切换tab时，先触发onTabItemTap，后触发onLoad。当前的实现基于先onLoad后onTabItemTap的假设。

**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [x] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序