### PR TITLE
fix: postCss 支持绝对路径插件

### DIFF
--- a/packages/taro-webpack5-runner/src/postcss/postcss.h5.ts
+++ b/packages/taro-webpack5-runner/src/postcss/postcss.h5.ts
@@ -89,7 +89,7 @@ export const getPostcssPlugins = function (appPath: string, option: [string, Tog
 
     if (!isNpmPkg(pluginName)) {
       // local plugin
-      pluginName = path.join(appPath, pluginName)
+      pluginName = path.isAbsolute(pluginName) ? pluginName : path.join(appPath, pluginName)
     }
 
     try {

--- a/packages/taro-webpack5-runner/src/postcss/postcss.harmony.ts
+++ b/packages/taro-webpack5-runner/src/postcss/postcss.harmony.ts
@@ -83,7 +83,7 @@ export const getPostcssPlugins = function (appPath: string, option: [string, Tog
 
     if (!isNpmPkg(pluginName)) {
       // local plugin
-      pluginName = path.join(appPath, pluginName)
+      pluginName = path.isAbsolute(pluginName) ? pluginName : path.join(appPath, pluginName)
     }
 
     try {

--- a/packages/taro-webpack5-runner/src/postcss/postcss.mini.ts
+++ b/packages/taro-webpack5-runner/src/postcss/postcss.mini.ts
@@ -82,7 +82,7 @@ export const getPostcssPlugins = function (appPath: string, option: [string, Tog
 
     if (!isNpmPkg(pluginName)) {
       // local plugin
-      pluginName = path.join(appPath, pluginName)
+      pluginName = path.isAbsolute(pluginName) ? pluginName : path.join(appPath, pluginName)
     }
 
     try {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)


**这个 PR 是什么类型？** (至少选择一个)

- [ ] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [x] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [x] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 改进本地 PostCSS 插件的路径解析：现在支持绝对路径和相对路径并存。绝对路径将保持不变，只有非绝对（相对）路径会基于应用根路径解析，从而减少插件加载路径错误并提升配置灵活性与稳定性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->