### PR TITLE
fix: 修复首页白屏问题

### DIFF
--- a/packages/taro-router/src/router/page.ts
+++ b/packages/taro-router/src/router/page.ts
@@ -90,8 +90,8 @@ export default class PageHandler {
         return false
       }
     )?.[0] || routePath
-
-    return !!pagePath && this.tabBarList.some(t => stripTrailing(t.pagePath) === pagePath)
+    // Fix: 这里仍然需要使用 addLeadingSlash 来处理 pagePath，因为 pagePath 可能在未被增加统一前缀 / 的时候就进行比对
+    return !!pagePath && this.tabBarList.some(t => addLeadingSlash(stripTrailing(t.pagePath)) === pagePath)
   }
 
   isDefaultNavigationStyle () {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)
修复 H5 快速切换页面后 TabBar 页未加 taro_tabbar_page 的问题。
根因是 isTabBar 对比时配置里的 pagePath 无前导斜杠，修正为比较前统一 addLeadingSlash/stripTrailing 格式化。
至于为何会让下面这行代码
https://github.com/NervJS/taro/blob/4e186a349f95b7ec7a192727a74b9d3f5efd1924/packages/taro-components/src/components/tabbar/tabbar.tsx#L110
的执行顺序在下面这行代码之后
https://github.com/NervJS/taro/blob/4e186a349f95b7ec7a192727a74b9d3f5efd1924/packages/taro-router/src/router/page.ts#L94
猜测是在慢设备/弱网/主线程阻塞导致组件生命周期延后且快速触发 tab 切换时导致的竞态问题。
即 tabBarList 补斜杠只在 <taro-tabbar> 的 componentWillLoad 里完成，而在StencilJS中componentWillLoad是异步执行的，若出现竞态问题则会导致先获取tabbar.pagePath进行匹配。

该项 fix 已在个人项目中完成测试，修复成功。

**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [x] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
  * 修复了选项卡路由路径匹配的逻辑，提升了路径对比的准确性和一致性，使选项卡导航功能更加稳定可靠。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->