### PR TITLE
fix(taro-vite-runner): vite打包循环引用

### DIFF
--- a/packages/taro-vite-runner/src/mini/config.ts
+++ b/packages/taro-vite-runner/src/mini/config.ts
@@ -178,8 +178,8 @@ export default function (viteCompilerContext: ViteMiniCompilerContext): PluginOp
           // Note: vite-runner 里面涉及到一些js文件的注入，比如 comp.js， 为了避免这些文件被打包进 vendors，这里做了特殊处理
           if (testByReg2DExpList([taroViteRunnerDeps])(id)) return null
           // Note: react 中用到了 for of等新的语法，babel相关依赖会被打包到 vendors 中，但taro中会打包react相关依赖，从而会引入 vendors 中的 babel 相关依赖，导致循环引用
-          if (testByReg2DExpList([babelDeps])(id)) return 'babelHelpers'
-          if (testByReg2DExpList([taroDeps, reactRelatedDeps, tslibDeps, commonjsHelpersDeps])(id)) return 'taro'
+          if (testByReg2DExpList([babelDeps, commonjsHelpersDeps])(id)) return 'babelHelpers'
+          if (testByReg2DExpList([taroDeps, reactRelatedDeps, tslibDeps])(id)) return 'taro'
           if (testByReg2DExpList([nodeModulesDeps])(id)) return 'vendors'
           if (moduleInfo?.importers?.length && moduleInfo.importers.length > 1) return 'common'
         }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)
将commonjsHelpers相关代码移动到babelHelper.js产物中，防止出现例如getDefaultExportFromCjs函数被打入taro.js，而helper本身又依赖getDefaultExportFromCjs函数导致的循环引入问题。

本身是在使用vite构建小程序时，使用三方库@antmjs/vantui引发的问题。

与此相关的是此PR(https://github.com/NervJS/taro/pull/17891)

请@Single-Dancer 审查一下是否会有别的问题。

**这个 PR 是什么类型？** (至少选择一个)

- [ ] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [x] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [x] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **优化**
  * 改进了应用的构建模块分组策略，优化了包加载顺序和依赖处理。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->