### PR TITLE
fix(vite): 深色模式的tabbar无法引用theme.json变量

### DIFF
--- a/packages/taro-vite-runner/src/mini/entry.ts
+++ b/packages/taro-vite-runner/src/mini/entry.ts
@@ -106,7 +106,7 @@ export default function (viteCompilerContext: ViteMiniCompilerContext): PluginOp
           const { sourceDir } = viteCompilerContext
           list.forEach(async item => {
             const { iconPath, selectedIconPath } = item
-            if (iconPath) {
+            if (iconPath && !iconPath.startsWith('@')) {
               const filePath = path.resolve(sourceDir, iconPath)
               this.emitFile({
                 type: 'asset',
@@ -116,7 +116,7 @@ export default function (viteCompilerContext: ViteMiniCompilerContext): PluginOp
               this.addWatchFile(filePath)
             }
 
-            if (selectedIconPath) {
+            if (selectedIconPath && !selectedIconPath.startsWith('@')) {
               const filePath = path.resolve(sourceDir, selectedIconPath)
               this.emitFile({
                 type: 'asset',


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)

解决了微信小程序平台，深色模式适配下，tabbar中的icon无法引用theme.json变量的问题

**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [x] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了标签栏图标路径的处理逻辑：当图标路径为空或为内部别名（以 @ 开头）时，跳过资源读取、发出和文件监视，避免对无效或内部引用执行不必要操作，降低构建开销并提高构建稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->