### PR TITLE
fix: black screen when using routeType with navigateTo in Skyline mode

### DIFF
--- a/packages/taro-platform-weapp/src/apis.ts
+++ b/packages/taro-platform-weapp/src/apis.ts
@@ -22,6 +22,42 @@ export function initNativeApi (taro) {
       }
     }
   })
+
+  // 保存原始的 navigateTo 方法
+  const originalNavigateTo = taro.navigateTo
+
+  // 重写 navigateTo 以支持 Skyline 渲染模式
+  taro.navigateTo = function (options: Record<string, any>) {
+    // 检查是否在 Skyline 模式下使用了特殊的 routeType
+    if (options?.routeType && typeof wx !== 'undefined') {
+      // 获取当前渲染器类型
+      const renderer = taro.getRenderer?.() || 'webview'
+
+      // Skyline 模式下，routeType 参数需要通过原生 API 直接调用
+      // 避免 Taro 运行时的动画处理导致节点查找失败
+      if (renderer === 'skyline') {
+        return new Promise((resolve, reject) => {
+          const { success, fail, complete, ...restOptions } = options
+          wx.navigateTo({
+            ...restOptions,
+            success: (res) => {
+              success?.(res)
+              resolve(res)
+            },
+            fail: (err) => {
+              fail?.(err)
+              reject(err)
+            },
+            complete
+          })
+        })
+      }
+    }
+
+    // 非 Skyline 模式或无 routeType 参数时使用标准流程
+    return originalNavigateTo.call(taro, options)
+  }
+
   taro.cloud = wx.cloud
   taro.getTabBar = function (pageCtx) {
     if (typeof pageCtx?.getTabBar === 'function') {

--- a/packages/taro-platform-weapp/src/apis.ts
+++ b/packages/taro-platform-weapp/src/apis.ts
@@ -26,7 +26,12 @@ export function initNativeApi (taro) {
   // 保存原始的 navigateTo 方法
   const originalNavigateTo = taro.navigateTo
 
-  // 重写 navigateTo 以支持 Skyline 渲染模式
+  /**
+   * 重写 navigateTo 以支持 Skyline 渲染模式
+   * 在 Skyline 模式下使用 routeType 参数时，直接调用微信原生 API，避免 Taro 运行时的动画处理导致节点查找失败
+   * @param options - 导航参数对象
+   * @returns Promise<any>
+   */
   taro.navigateTo = function (options: Record<string, any>) {
     // 检查是否在 Skyline 模式下使用了特殊的 routeType
     if (options?.routeType && typeof wx !== 'undefined') {
@@ -42,13 +47,18 @@ export function initNativeApi (taro) {
             ...restOptions,
             success: (res) => {
               success?.(res)
+              complete?.(res)
               resolve(res)
             },
             fail: (err) => {
-              fail?.(err)
+              try {
+                fail?.(err)
+              } catch (e) {
+                // ignore
+              }
+              complete?.(err)
               reject(err)
-            },
-            complete
+            }
           })
         })
       }


### PR DESCRIPTION
<!--请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md并使用 "[x]" 进行勾选-->

**这个 PR 做了什么？** (简要描述所做更改)

修复 Skyline 渲染模式下使用 `navigateTo` 配置 `routeType` 参数导致页面黑屏的问题。

在 Skyline 模式下，当调用 `Taro.navigateTo({ url, routeType: 'wx://upwards' })` 时，Taro 运行时会尝试在 JavaScript 层应用动画样式，但 Skyline 的节点存在于原生渲染层，导致 `[ui] applyAnimatedStyle can not find corresponding nodes` 错误，页面黑屏崩溃。

本次修复通过检测 Skyline 模式并直接调用微信原生 `wx.navigateTo` API，绕过 Taro 运行时的动画处理层，彻底解决该问题。

**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #18879
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe)

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [x] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

---

## 问题描述

**Closes** #18879

**现象**：在微信小程序 Skyline 渲染模式下，使用 `navigateTo` 配置 `routeType` 参数进行页面跳转时，触发以下错误并导致页面黑屏：


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 在 Skyline 渲染模式下改进页面跳转兼容性：检测到 Skyline 路由类型时使用原生跳转以提升导航可靠性和体验。
  * 在非 Skyline 场景自动回退到既有跳转行为，同时保留现有云能力、底部栏与渲染器接口行为不变。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->