### PR TITLE
fix(taro-loader): handle cache miss in entry-cache loader when webpack persistent cache hits

### DIFF
--- a/packages/taro-loader/src/entry-cache.ts
+++ b/packages/taro-loader/src/entry-cache.ts
@@ -8,5 +8,8 @@ export default function () {
     // just in case, delete cache in next tick
     setImmediate(() => entryCache.delete(name))
     callback(null, content!.source, content!.map)
+  } else {
+    // 当 webpack 持久化缓存命中时，entryCache 为空，需要兜底返回空字符串
+    callback(null, '')
   }
 }


### PR DESCRIPTION
**这个 PR 做了什么？**

修复开启 webpack 持久化缓存（`cache: { enable: true }`）后，当文件没有改动进行二次编译时，`entry-cache.js` loader 不返回内容导致编译报错的问题。

**这个 PR 是什么类型？**

- [x] 错误修复 (Bugfix) issue: fix #15001
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [x] 所有小程序
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

---

## 问题描述

开启 webpack 持久化缓存（`cache: { enable: true }`）后，当文件没有改动进行二次编译时，
报错：`ModuleBuildError: Module build failed: Error: Final loader (entry-cache.js) didn't return a Buffer or String`

相关 Issue: #15001

## 根因分析

`entry-cache.js` 作为 inline loader 被 app/page/component loader 使用。流程如下：

1. `app.js` loader 将源码存入内存 `entryCache` Map
2. 生成的代码通过 `import component from '!entry-cache.js?name=app!src/app.ts'` 引入
3. `entry-cache.js` loader 从 Map 中读取并返回源码

当 webpack 持久化缓存命中时：

- `app.js` loader 被跳过（不执行），不会写入 `entryCache`
- 但 `entry-cache.js` loader 仍被执行，此时 `entryCache` 为空
- `if (name && entryCache.has(name))` 为 false，`callback` 永远不会被调用
- webpack 报错

## 修复方案

添加 `else` 分支，在缓存未命中时调用 `callback(null, '')` 兜底。

## 影响范围

此 bug 在 3.6.x ~ 4.1.11 版本中均存在。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 优化了加载器的缓存处理：缓存未命中时现在会保证调用回调返回空内容，避免挂起或不响应，提升稳定性与可靠性。
  * 缓存命中行为保持不变，兼容现有流程。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->