### PR TITLE
fix(types/batchSetStorageSync): 修复类型，去掉外层包装对象

### DIFF
--- a/packages/taro/types/api/storage/index.d.ts
+++ b/packages/taro/types/api/storage/index.d.ts
@@ -106,19 +106,6 @@ declare module '../../index' {
     }
   }
 
-  namespace batchSetStorageSync {
-    interface Option {
-      /** [{ key, value }] */
-      kvList: kv[]
-    }
-    interface kv {
-      /** key 本地缓存中指定的 key */
-      key: string
-      /** data 需要存储的内容。只支持原生类型、Date、及能够通过JSON.stringify序列化的对象。*/
-      value: any
-    }
-  }
-
   namespace batchSetStorage {
     interface Option {
       /** [{ key, value }] */
@@ -348,7 +335,12 @@ declare module '../../index' {
      * ```
      * @see https://developers.weixin.qq.com/miniprogram/dev/api/storage/wx.batchGetStorageSync.html
      */
-    batchSetStorageSync(option: batchSetStorageSync.Option): void
+    batchSetStorageSync(option: {
+      /** key 本地缓存中指定的 key */
+      key: string
+      /** data 需要存储的内容。只支持原生类型、Date、及能够通过JSON.stringify序列化的对象。*/
+      value: any
+    }[]): void
 
     /** 将数据批量存储在本地缓存中指定的 key 中。会覆盖掉原来该 key 对应的内容。
      * 除非用户主动删除或因存储空间原因被系统清理，否则数据都一直可用。


### PR DESCRIPTION
Removed `batchSetStorageSync` interface and updated its usage in `batchSetStorage`.

close #18911 

<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)


**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [x] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [x] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [x] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 更新同步批量存储接口的类型定义：现可直接传入包含 `key` 和 `value` 的对象数组。
  * 移除不再需要的嵌套类型声明，简化开发者的使用方式。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->