### PR TITLE
Fix: Make AXML import regex patterns compatible with various whitespa…

### DIFF
--- a/packages/taro-platform-alipay/src/index.ts
+++ b/packages/taro-platform-alipay/src/index.ts
@@ -81,11 +81,11 @@ function modifyPageTemplate (ctx: IPluginContext) {
       const assetsItem = assets[templateName]
       const src = assetsItem._value ? assetsItem._value.toString() : assetsItem.source()
       let relativePath
-      const templateCaller = src.replace(/<import src="(.*)base\.axml"\/>/, function (_, $1) {
+      const templateCaller = src.replace(/<import src="(.*)base\.axml"\s*\/>/, function (_, $1) {
         relativePath = $1
         return ''
       })
-      const main = baseXml.replace(/<import-sjs name="xs" from="(.*)utils.sjs" \/>/, function () {
+      const main = baseXml.replace(/<import-sjs name="xs" from="(.*)utils.sjs"\s*\/>/, function () {
         return src.includes('<import-sjs name="xs"')
           ? ''
           : `<import-sjs name="xs" from="${relativePath}utils.sjs" />`


### PR DESCRIPTION
…ce formats

<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)

## 改动描述
### 问题
在处理 Alipay 小程序 AXML 模板文件时，modifyPageTemplate 函数中的正则表达式在某些情况下无法正确匹配自闭合标签，导致生成错误的 SJS 导入路径。

### 错误表现：
error[CE1000.01]: cannot resolve module 'undefinedutils.sjs'

### 根本原因
两个正则表达式的写法过于严格，不能容纳 AXML 文件中可能出现的不同空格格式
当正则匹配失败时，relativePath 变量保持 undefined，导致第 576 行生成的路径变为 from="undefinedutils.sjs"。

### 修复方案
在两个正则表达式中加入 \s* 来兼容任意数量的空格：

### 受影响的场景
这个修复对以下场景特别重要：
• 使用 CSS 工具类框架（如 Tailwind CSS/Windi CSS）的项目
• 生成较复杂 AXML 模板的项目
• 自定义 webpack 插件修改 AXML 输出的项目

### 测试
已在实际项目中验证，修复后编译成功，生成正确的 SJS 导入路径：

**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [x] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了导入标签解析的兼容性，现在能够正确处理自闭标签前的空格，提高了模板处理的健壮性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->