### PR TITLE
fix(ascf): 修复open-type类型声明&增加事件回调

### DIFF
--- a/packages/taro-components/types/Button.d.ts
+++ b/packages/taro-components/types/Button.d.ts
@@ -200,6 +200,12 @@ interface ButtonProps extends StandardProps {
    * @supported weapp, alipay, swan, tt, jd
    */
   onGetPhoneNumber?: CommonEventFunction<ButtonProps.onGetPhoneNumberEventDetail>
+  /** 获取手机号和风险等级的回调
+   *
+   * 生效时机：`open-type="getPhoneNumberAndRiskLevel"`
+   * @supported ascf
+   */
+  onGetPhoneNumberAndRiskLevel?: CommonEventFunction<ButtonProps.onGetPhoneNumberAndRiskLevelEventDetail>
   /**
    * 手机号实时验证回调，`open-type="getRealtimePhoneNumber"` 时有效
    * @supported weapp
@@ -314,8 +320,23 @@ declare namespace ButtonProps {
     | keyof openTypeKeys['alipay']
     | keyof openTypeKeys['qq']
     | keyof openTypeKeys['tt']
+    | keyof openTypeKeys['ascf']
   /** open-type 的合法值 */
   interface openTypeKeys {
+    ascf: {
+      /** 获取用户手机号码，当open-type等于该值时，为保障用户隐私，button组件采用同层渲染ArkUI原生functionalButton组件的方式实现。 */
+      getPhoneNumber,
+      /** 打开授权设置页面。 */
+      openSetting,
+      /** 打开应用，可以通过app-bundle-name，app-module-name，app-ability-name，app-parameters属性打开指定应用。当前只支持打开系统应用，或者在元服务跳转三方应用的场景下只能打开同系列开发者的应用，否则会遭到系统生态管控拦截，提示应用无法打开 */
+      launchApp,
+      /** 触发用户分享，用户点击按钮后触发Page.onShareAppMessage事件，只支持分享首页。 */
+      share,
+      /** 获取服务动态授权码，用于推送服务动态。当open-type等于该值时，必须同时指定activity-type属性。 */
+      liveActivity,
+      /** 获取手机号和风险等级。 */
+      getPhoneNumberAndRiskLevel
+    }
     weapp: {
       /** 打开客服会话，如果用户在会话中点击消息卡片后返回小程序，可以从回调中获得具体信息
        * @see https://developers.weixin.qq.com/miniprogram/dev/framework/open-ability/customer-message/customer-message.html
@@ -514,6 +535,9 @@ declare namespace ButtonProps {
      * @supported alipay
      */
     sign: string
+  }
+  interface onGetPhoneNumberAndRiskLevelEventDetail {
+    code: string
   }
   interface onGetRealTimePhoneNumberEventDetail {
     code: string

--- a/packages/taro-platform-ascf/src/apis-list.ts
+++ b/packages/taro-platform-ascf/src/apis-list.ts
@@ -30,4 +30,5 @@ export const needPromiseApis = new Set([
   'setWindowSize',
   'sendBizRedPacket',
   'startFacialRecognitionVerify',
+  'getUserRiskLevel'
 ])

--- a/packages/taro-platform-ascf/src/components.ts
+++ b/packages/taro-platform-ascf/src/components.ts
@@ -70,7 +70,8 @@ export const components = {
     bindError: _empty,
     bindOpenSetting: _empty,
     bindLaunchApp: _empty,
-    bindAgreePrivacyAuthorization: _empty
+    bindAgreePrivacyAuthorization: _empty,
+    bindGetPhoneNumberAndRiskLevel: _empty,
   },
   Form: {
     'report-submit-timeout': _zero


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)
修复open-type类型声明&增加事件回调

**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [x] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 新功能
* Button 组件在 ASCF 平台新增获取用户手机号与风险等级的开放能力，支持对应的 openType 和回调事件。
* 新增对 getUserRiskLevel 接口的 Promise 风格支持，便于异步处理返回的风险等级信息。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->