### PR TITLE
排除 zustand/blob/main/src/react.ts

### DIFF
--- a/packages/taro-framework-react/src/vite.mini.ts
+++ b/packages/taro-framework-react/src/vite.mini.ts
@@ -49,7 +49,7 @@ function aliasPlugin (ctx: IPluginContext, framework: Frameworks): PluginOption 
         if (!isProd && ctx.initialConfig.mini?.debugReact !== true && !isHarmony) {
           // 不是生产环境，且没有设置 debugReact，则使用压缩版本的 react 依赖，减少体积
           alias.push({ find: /react-reconciler$/, replacement: 'react-reconciler/cjs/react-reconciler.production.min.js' })
-          alias.push({ find: /^(?!.*mobx-react$).*react$/, replacement: 'react/cjs/react.production.min.js' })
+          alias.push({ find: /^(?!.*(?:mobx-react$|zustand\/)).*react$/, replacement: 'react/cjs/react.production.min.js' })
           alias.push({ find: /scheduler$/, replacement: 'scheduler/cjs/scheduler.production.min.js' })
           alias.push({ find: /react\/jsx-runtime$/, replacement: 'react/cjs/react-jsx-runtime.production.min.js' })
 


### PR DESCRIPTION
**这个 PR 做了什么？** (简要描述所做更改)

修复 https://github.com/NervJS/taro/issues/17350

开发微信小程序时，react 会被默认替换成 react production mini 版本，但目前的匹配规则把  https://github.com/pmndrs/zustand/blob/main/src/react.ts 也包括进去了。

**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #

**这个 PR 涉及以下平台：**

- [x] 微信小程序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **优化改进**
  * 优化了React框架的生产构建配置，改进了模块别名处理逻辑，提升了构建性能和准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->