### PR TITLE
fix(vite-runner mini): app.css 为空的情况下 自定义组件复用后样式丢失

### DIFF
--- a/packages/taro-components/__tests__/__snapshots__/picker-view.spec.tsx.snap
+++ b/packages/taro-components/__tests__/__snapshots__/picker-view.spec.tsx.snap
@@ -111,6 +111,9 @@ exports[`PickerView props valid 1`] = `
     <taro-view-core style="0: h; 1: e; 2: i; 3: g; 4: h; 5: t; 6: :; 7:  ; 8: 6; 9: 0; 10: p; 11: x; 12: ;; 13:  ; 14: l; 15: i; 16: n; 17: e; 18: -; 19: h; 20: e; 21: i; 22: g; 23: h; 24: t; 25: :; 26:  ; 27: 6; 28: 0; 29: p; 30: x; 31: ;; 32:  ; 33: t; 34: e; 35: x; 36: t; 37: -; 38: a; 39: l; 40: i; 41: g; 42: n; 43: :; 44:  ; 45: c; 46: e; 47: n; 48: t; 49: e; 50: r; 51: ;;">
       2025年
     </taro-view-core>
+    <taro-view-core style="0: h; 1: e; 2: i; 3: g; 4: h; 5: t; 6: :; 7:  ; 8: 6; 9: 0; 10: p; 11: x; 12: ;; 13:  ; 14: l; 15: i; 16: n; 17: e; 18: -; 19: h; 20: e; 21: i; 22: g; 23: h; 24: t; 25: :; 26:  ; 27: 6; 28: 0; 29: p; 30: x; 31: ;; 32:  ; 33: t; 34: e; 35: x; 36: t; 37: -; 38: a; 39: l; 40: i; 41: g; 42: n; 43: :; 44:  ; 45: c; 46: e; 47: n; 48: t; 49: e; 50: r; 51: ;;">
+      2026年
+    </taro-view-core>
   </taro-picker-view-column-core>
   <div class="taro-picker-view-mask-container">
     <div class="taro-picker-view-mask-top test_maskClass" style="background-color: rgba(33, 33, 33, 0.5);"></div>

--- a/packages/taro-vite-runner/src/mini/style.ts
+++ b/packages/taro-vite-runner/src/mini/style.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 
-import type{ ViteMiniCompilerContext } from '@tarojs/taro/types/compile/viteCompilerContext'
+import type { ViteMiniCompilerContext } from '@tarojs/taro/types/compile/viteCompilerContext'
 import type { OutputAsset } from 'rollup'
 import type { PluginOption } from 'vite'
 
@@ -46,6 +46,16 @@ export default function (viteCompilerContext: ViteMiniCompilerContext): PluginOp
           appStyleChunk.source = commonStyleFileNames.reduce((prev, current) => {
             return prev + `@import "${path.relative(sourceDir, path.join(sourceDir, current))}";\n`
           }, `@import "${APP_STYLE_NAME}";\n`)
+        }
+        if (!appStyleChunk && commonStyleFileNames.length > 0) {
+          const sourceDir = viteCompilerContext.sourceDir
+          this.emitFile({
+            type: 'asset',
+            fileName: appStyleFileName,
+            source: commonStyleFileNames
+              .map((i) => `@import "${path.relative(sourceDir, path.join(sourceDir, i))}";`)
+              .join('\n')
+          })
         }
       }
     }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)
原因：app.css 没有内容会被过滤掉，导致不引入生成的 common.wxss。

修复方式：增加了边界条件判断，emit 一个 app${nativeStyleExt}

**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #17587
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [x] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复了在特定情况下应用样式资源无法正确生成的问题，确保样式文件始终被正确加载和处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->