### PR TITLE
fix(runtime): align URL query serialization with browser behavior

### DIFF
--- a/packages/taro-runtime/src/bom/URL.ts
+++ b/packages/taro-runtime/src/bom/URL.ts
@@ -1,7 +1,7 @@
 import { isString, isUndefined } from '@tarojs/shared'
 
 import env from '../env'
-import { URLSearchParams } from './URLSearchParams'
+import { TaroURLSearchParams, URLSearchParams } from './URLSearchParams'
 
 class TaroURL {
   static createObjectURL () {
@@ -19,6 +19,8 @@ class TaroURL {
   #port = ''
   #protocol = ''
   #search: URLSearchParams
+  #searchModified = false
+  #searchRaw = ''
 
   constructor (url: string, base?: string) {
     if (!isString(url)) url = String(url)
@@ -31,7 +33,7 @@ class TaroURL {
     this.#pathname = pathname || '/'
     this.#port = port
     this.#protocol = protocol
-    this.#search = new URLSearchParams(search)
+    this.#setSearch(search)
   }
 
   /* public property */
@@ -90,6 +92,8 @@ class TaroURL {
   }
 
   get search () {
+    if (!this.#searchModified) return this.#searchRaw
+
     const val = this.#search.toString()
     return (val.length === 0 || val.startsWith('?')) ? val : `?${val}`
   }
@@ -97,7 +101,7 @@ class TaroURL {
   set search (val: string) {
     if (isString(val)) {
       val = val.trim()
-      this.#search = new URLSearchParams(val)
+      this.#setSearch(val)
     }
   }
 
@@ -155,6 +159,19 @@ class TaroURL {
 
   toJSON () {
     return this.toString()
+  }
+
+  #setSearch (val: string) {
+    const search = val ? (val.startsWith('?') ? val : `?${val}`) : ''
+
+    this.#searchRaw = search
+    this.#searchModified = false
+    this.#search = new URLSearchParams(search)
+    if (this.#search instanceof TaroURLSearchParams) {
+      this.#search._setOnChange(() => {
+        this.#searchModified = true
+      })
+    }
   }
 
   // convenient for deconstructor

--- a/packages/taro-runtime/src/bom/URLSearchParams.ts
+++ b/packages/taro-runtime/src/bom/URLSearchParams.ts
@@ -36,8 +36,9 @@ function encode (str: string) {
   return encodeURIComponent(str).replace(findReg, replacer)
 }
 
-export const URLSearchParams = process.env.TARO_PLATFORM === 'web' ? env.window.URLSearchParams : class {
+export class TaroURLSearchParams {
   #dict = Object.create(null)
+  #onChange?: () => void
 
   constructor (query) {
     query ??= ''
@@ -81,12 +82,18 @@ export const URLSearchParams = process.env.TARO_PLATFORM === 'web' ? env.window.
     }
   }
 
+  _setOnChange (onChange?: () => void) {
+    this.#onChange = onChange
+  }
+
   append (name: string, value: string) {
     appendTo(this.#dict, name, value)
+    this.#onChange?.()
   }
 
   delete (name: string) {
     delete this.#dict[name]
+    this.#onChange?.()
   }
 
   get (name: string) {
@@ -109,6 +116,7 @@ export const URLSearchParams = process.env.TARO_PLATFORM === 'web' ? env.window.
 
   set (name: string, value: string) {
     this.#dict[name] = ['' + value]
+    this.#onChange?.()
   }
 
   forEach (callback, thisArg) {
@@ -136,3 +144,5 @@ export const URLSearchParams = process.env.TARO_PLATFORM === 'web' ? env.window.
     return query.join('&')
   }
 }
+
+export const URLSearchParams = process.env.TARO_PLATFORM === 'web' ? env.window.URLSearchParams : TaroURLSearchParams

--- a/packages/taro-runtime/tests/location.spec.ts
+++ b/packages/taro-runtime/tests/location.spec.ts
@@ -197,6 +197,17 @@ describe('location', () => {
       expect(url.toString()).toBe('http://taro.com/?a=1&b=2&c=3&d=4')
     }
 
+    {
+      const url = new URL('https://example.test/?name=|aaa')
+      expect(url.search).toBe('?name=|aaa')
+      expect(url.toString()).toBe('https://example.test/?name=|aaa')
+      expect(url.searchParams.get('name')).toBe('|aaa')
+      expect(url.searchParams.toString()).toBe('name=%7Caaa')
+
+      url.searchParams.append('age', '18')
+      expect(url.toString()).toBe('https://example.test/?name=%7Caaa&age=18')
+    }
+
     // setters
     {
       const url = new URL('http://taro.com')


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)

修复小程序端 `URL` 在构造后过早使用 `URLSearchParams.toString()` 重写 query 的问题。

此前 `new URL('https://example.test/?name=|aaa')` 后，`url.search` / `url.href` 会被序列化为 `?name=%7Caaa`，与浏览器 WHATWG URL 行为不一致。按 Web 平台 URL 标准，URL query 序列化不应在构造阶段使用 `application/x-www-form-urlencoded` 规则；只有在修改 `searchParams` 后，才应将参数列表重新序列化并写回 URL。

标准依据：

- WHATWG URL Standard: https://url.spec.whatwg.org/#query-percent-encode-set
  - URL query percent-encode set 包含 C0 控制字符、空格、`"`、`#`、`<`、`>`；special-query percent-encode set 额外包含 `'`。
  - `|` 不在 URL query percent-encode set 中，因此 `new URL('https://example.test/?name=|aaa').search` 应保留为 `?name=|aaa`。
- WHATWG URL Standard: https://url.spec.whatwg.org/#application-x-www-form-urlencoded-percent-encode-set
  - `URLSearchParams` 的 stringification 使用 `application/x-www-form-urlencoded` 序列化规则。
  - 该规则会将 `|` 序列化为 `%7C`，因此 `url.searchParams.toString()` 应返回 `name=%7Caaa`。
- WHATWG URL Standard: https://url.spec.whatwg.org/#concept-urlsearchparams-update
  - `URLSearchParams.append/set/delete` 会触发 update，将参数列表重新序列化并写回关联的 URL query。
  - 因此只有在修改 `searchParams` 后，`url.href` 才应变为 `https://example.test/?name=%7Caaa&age=18`。

本 PR 调整了 `TaroURL` 与 `URLSearchParams` 的联动逻辑：

- `new URL()` 后保留原始 `search` 表达，避免提前 encode query 参数。
- `searchParams.append/set/delete` 后再触发 URL query 更新。
- 补充 `name=|aaa` 场景测试，确保 `url.search` / `url.href` 与 `url.searchParams.toString()` 分别符合对应序列化规则。

**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [x] 所有小程序
- [x] 微信小程序
- [x] 企业微信小程序
- [x] 京东小程序
- [x] 百度小程序
- [x] 支付宝小程序
- [x] 支付宝 IOT 小程序
- [x] 钉钉小程序
- [x] QQ 小程序
- [x] 飞书小程序
- [x] 快手小程序
- [x] 头条小程序


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 优化 URL 查询参数处理，保留未修改查询字符串的原始格式。
  * 改进特殊字符（包括 `|`、`#`）的编码与解码行为。
  * 修复带尾部 `?` 的 URL 在查询字符串和完整地址显示上的处理。

* **测试**
  * 新增 URL、查询参数及特殊字符处理的测试覆盖，验证参数修改后的正确编码结果。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->