### PR TITLE
fix(runner): recalc `fontSize` 0.5s after window resize, fix #18653

### DIFF
--- a/packages/taro-vite-runner/src/utils/html.ts
+++ b/packages/taro-vite-runner/src/utils/html.ts
@@ -11,7 +11,7 @@ export function getHtmlScript (entryScript: string, pxtransformOption): string {
   const rootValue = (baseFontSize / options.deviceRatio[designWidth]) * 2
 
   if ((options?.targetUnit ?? 'rem') === 'rem') {
-    htmlScript = `<script>!function(n){function f(){var e=n.document.documentElement,r=e.getBoundingClientRect(),width=r.width,height=r.height,arr=[width,height].filter(function(value){return Boolean(value)}),w=Math.min.apply(Math,arr),x=${rootValue}*w/${designWidth};e.style.fontSize=x>=${max}?"${max}px":x<=${min}?"${min}px":x+"px"}; n.addEventListener("resize",(function(){f()})),f()}(window);</script>\n`
+    htmlScript = `<script>!function(n){function f(){var e=n.document.documentElement,r=e.getBoundingClientRect(),width=r.width,height=r.height,arr=[width,height].filter(function(value){return Boolean(value)}),w=Math.min.apply(Math,arr),x=${rootValue}*w/${designWidth};e.style.fontSize=x>=${max}?"${max}px":x<=${min}?"${min}px":x+"px"}; n.addEventListener("resize",(function(){f();setTimeout(f,500)})),f()}(window);</script>\n`
   }
   htmlScript += `  <script type="module" src="${normalizePath(entryScript)}"></script>`
   return htmlScript

--- a/packages/taro-webpack5-runner/src/webpack/H5WebpackPlugin.ts
+++ b/packages/taro-webpack5-runner/src/webpack/H5WebpackPlugin.ts
@@ -106,7 +106,7 @@ export class H5WebpackPlugin {
     const rootValue = baseFontSize / options.deviceRatio![designWidth!] * 2
     let htmlScript = ''
     if ((options?.targetUnit ?? 'rem') === 'rem') {
-      htmlScript = `!function(n){function f(){var e=n.document.documentElement,r=e.getBoundingClientRect(),width=r.width,height=r.height,arr=[width,height].filter(function(value){return Boolean(value)}),w=Math.min.apply(Math,arr),x=${rootValue}*w/${designWidth};e.style.fontSize=x>=${max}?"${max}px":x<=${min}?"${min}px":x+"px"}; n.addEventListener("resize",(function(){f()})),f()}(window);`
+      htmlScript = `!function(n){function f(){var e=n.document.documentElement,r=e.getBoundingClientRect(),width=r.width,height=r.height,arr=[width,height].filter(function(value){return Boolean(value)}),w=Math.min.apply(Math,arr),x=${rootValue}*w/${designWidth};e.style.fontSize=x>=${max}?"${max}px":x<=${min}?"${min}px":x+"px"}; n.addEventListener("resize",(function(){f();setTimeout(f,500)})),f()}(window);`
     }
     const args: Record<string, string | string []> = {
       filename: `${entry || 'index'}.html`,


### PR DESCRIPTION
**这个 PR 做了什么？** (简要描述所做更改)

部分移动端浏览器（如微信 WebView）加载或刷新时有概率将 window resize 为一个 height 很小的大小，之后又恢复。经过测试在 window resize event 0.5s 之后再次尝试计算 fontSize 可解决。

影响范围：v3.7.0-alpha.27 以来的所有版本

详情看 #18653 中评论

**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #18653
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [x] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **改进**
  * 优化了响应式设计中字体大小的动态调整机制。当窗口大小改变时，系统现在会立即重新计算根节点的字体大小，并在短延迟后再进行一次调整，使界面布局能更快更稳定地适应屏幕尺寸的变化。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NervJS/taro/pull/19218)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->