### PR TITLE
fix(taro-components): textarea autoHeight 回显不生效

### DIFF
--- a/packages/taro-components/src/components/textarea/textarea.tsx
+++ b/packages/taro-components/src/components/textarea/textarea.tsx
@@ -83,6 +83,7 @@ export class Textarea implements ComponentInterface {
       const isActive = typeof document !== 'undefined' && document.activeElement === this.textareaRef
       const selection = isActive ? (this.lastSelectionRange || this.getSelectionSnapshot(this.textareaRef)) : null
       this.textareaRef.value = value
+      this.handleLineChange()
       if (selection) {
         this.restoreSelection(this.textareaRef, selection)
       }
@@ -97,6 +98,7 @@ export class Textarea implements ComponentInterface {
   componentDidLoad () {
     this.textareaRef?.addEventListener('compositionstart', this.handleComposition)
     this.textareaRef?.addEventListener('compositionend', this.handleComposition)
+    this.handleLineChange()
   }
 
   disconnectedCallback () {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)
修复 textarea h5 props.value 有值的情况下 autoHeight 不生效，对齐微信小程序表现

**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [x] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复受控文本区域在 value 更新后未触发行数/高度变化事件的问题，现会在同步写入后触发 linechange 上报。
  * 优化组件首次加载时的行数检测，组件初始化后会立即计算并上报当前行数变化，提升初始显示准确性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NervJS/taro/pull/19271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->