### PR TITLE
feat(cli): support init in current directory

### DIFF
--- a/packages/taro-cli/src/__tests__/project.spec.ts
+++ b/packages/taro-cli/src/__tests__/project.spec.ts
@@ -147,6 +147,19 @@ describe('create project', () => {
     }
   )
 
+  it('should throw when initializing at the filesystem root', () => {
+    expect(() => new Project({
+      projectDir: '/',
+      projectName: '.',
+      sourceRoot: __dirname,
+      template: 'default',
+      templateSource: 'default-template',
+      npm: 'npm',
+      css: 'none',
+      framework: 'react'
+    } as any)).toThrow('无法在文件系统根目录下初始化项目')
+  })
+
   it('should skip existing-name prompt when initializing in current directory', () => {
     // fs.existsSync 被 mock 为恒 true，模拟目标目录（当前目录）已存在。
     // `.` 场景下不应因此推入“同名目录已存在”的询问。

--- a/packages/taro-cli/src/__tests__/project.spec.ts
+++ b/packages/taro-cli/src/__tests__/project.spec.ts
@@ -88,4 +88,68 @@ describe('create project', () => {
     expect(project.conf.projectDir).toBe('/a/b')
     expect(project.conf.projectName).toBe('current-project')
   })
+
+  it.each(['..', '../', '.foo', 'foo', 'my-app'])(
+    'should keep project name %p unchanged',
+    (projectName) => {
+      const project = new Project({
+        projectDir: '/a/b',
+        projectName,
+        sourceRoot: __dirname,
+        template: 'default',
+        templateSource: 'default-template',
+        npm: 'npm',
+        css: 'none',
+        framework: 'react'
+      } as any)
+
+      expect(project.conf.projectDir).toBe('/a/b')
+      expect(project.conf.projectName).toBe(projectName)
+      expect(project.conf.initInCurrentDir).toBeUndefined()
+    }
+  )
+
+  it('should skip existing-name prompt when initializing in current directory', () => {
+    // fs.existsSync 被 mock 为恒 true，模拟目标目录（当前目录）已存在。
+    // `.` 场景下不应因此推入“同名目录已存在”的询问。
+    const project = new Project({
+      projectDir: '/a/b/current-project',
+      projectName: '.',
+      sourceRoot: __dirname,
+      template: 'default',
+      templateSource: 'default-template',
+      npm: 'npm',
+      css: 'none',
+      framework: 'react'
+    } as any)
+
+    expect(project.conf.initInCurrentDir).toBe(true)
+
+    const prompts: Record<string, unknown>[] = []
+    project.askProjectName(project.conf, prompts)
+
+    expect(prompts).toHaveLength(0)
+  })
+
+  it('should prompt for a new name when a same-name directory exists (normal init)', () => {
+    // 普通命名 + 目标位置已存在同名目录时，仍应提示换名。
+    const project = new Project({
+      projectDir: '/a/b',
+      projectName: 'existing-project',
+      sourceRoot: __dirname,
+      template: 'default',
+      templateSource: 'default-template',
+      npm: 'npm',
+      css: 'none',
+      framework: 'react'
+    } as any)
+
+    expect(project.conf.initInCurrentDir).toBeUndefined()
+
+    const prompts: Record<string, unknown>[] = []
+    project.askProjectName(project.conf, prompts)
+
+    expect(prompts).toHaveLength(1)
+    expect(prompts[0]).toMatchObject({ name: 'projectName' })
+  })
 })

--- a/packages/taro-cli/src/__tests__/project.spec.ts
+++ b/packages/taro-cli/src/__tests__/project.spec.ts
@@ -89,6 +89,44 @@ describe('create project', () => {
     expect(project.conf.projectName).toBe('current-project')
   })
 
+  it('should resolve windows-style ".\\" project name to current directory', () => {
+    const project = new Project({
+      projectDir: '/a/b/current-project',
+      projectName: '.\\',
+      sourceRoot: __dirname,
+      template: 'default',
+      templateSource: 'default-template',
+      npm: 'npm',
+      css: 'none',
+      framework: 'react'
+    } as any)
+
+    expect(project.conf.projectDir).toBe('/a/b')
+    expect(project.conf.projectName).toBe('current-project')
+    expect(project.conf.initInCurrentDir).toBe(true)
+  })
+
+  it('should fall back to process.cwd() when projectDir is empty', () => {
+    const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue('/x/y/z')
+    try {
+      const project = new Project({
+        projectName: '.',
+        sourceRoot: __dirname,
+        template: 'default',
+        templateSource: 'default-template',
+        npm: 'npm',
+        css: 'none',
+        framework: 'react'
+      } as any)
+
+      expect(project.conf.projectDir).toBe('/x/y')
+      expect(project.conf.projectName).toBe('z')
+      expect(project.conf.initInCurrentDir).toBe(true)
+    } finally {
+      cwdSpy.mockRestore()
+    }
+  })
+
   it.each(['..', '../', '.foo', 'foo', 'my-app'])(
     'should keep project name %p unchanged',
     (projectName) => {

--- a/packages/taro-cli/src/__tests__/project.spec.ts
+++ b/packages/taro-cli/src/__tests__/project.spec.ts
@@ -1,0 +1,91 @@
+import Project from '../create/project'
+
+jest.mock('@tarojs/helper', () => ({
+  chalk: {
+    blueBright: jest.fn((text) => text),
+    green: jest.fn((text) => text),
+    red: jest.fn((text) => text)
+  },
+  DEFAULT_TEMPLATE_SRC: 'https://github.com/NervJS/taro-project-templates',
+  DEFAULT_TEMPLATE_SRC_GITEE: 'https://gitee.com/o2team/taro-project-templates',
+  fs: {
+    ensureDirSync: jest.fn(),
+    existsSync: jest.fn(() => true)
+  },
+  getUserHomeDir: jest.fn(() => '/tmp'),
+  SOURCE_DIR: 'src',
+  TARO_BASE_CONFIG: 'index.json',
+  TARO_CONFIG_FOLDER: '.taro'
+}))
+
+jest.mock('@tarojs/shared', () => ({
+  isArray: Array.isArray
+}), { virtual: true })
+
+jest.mock('@tarojs/binding', () => ({
+  CompilerType: {
+    Solid: 'solid',
+    Vite: 'vite',
+    Webpack5: 'webpack5'
+  },
+  createProject: jest.fn(() => Promise.resolve()),
+  CSSType: {
+    None: 'none'
+  },
+  FrameworkType: {
+    Preact: 'preact',
+    React: 'react',
+    Solid: 'solid',
+    Vue3: 'vue3'
+  },
+  NpmType: {
+    Npm: 'npm'
+  },
+  PeriodType: {
+    CreateAPP: 'createApp'
+  }
+}))
+
+describe('create project', () => {
+  let logSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation()
+  })
+
+  afterEach(() => {
+    logSpy.mockRestore()
+  })
+
+  it('should resolve dot project name to current directory', () => {
+    const project = new Project({
+      projectDir: '/a/b/current-project',
+      projectName: '.',
+      sourceRoot: __dirname,
+      template: 'default',
+      templateSource: 'default-template',
+      npm: 'npm',
+      css: 'none',
+      framework: 'react'
+    } as any)
+
+    expect(project.conf.projectDir).toBe('/a/b')
+    expect(project.conf.projectName).toBe('current-project')
+  })
+
+  it('should resolve current directory path project name to current directory', () => {
+    const project = new Project({
+      projectDir: '/a/b/current-project',
+      projectName: './',
+      sourceRoot: __dirname,
+      template: 'default',
+      templateSource: 'default-template',
+      npm: 'npm',
+      css: 'none',
+      framework: 'react'
+    } as any)
+
+    expect(project.conf.projectDir).toBe('/a/b')
+    expect(project.conf.projectName).toBe('current-project')
+  })
+})

--- a/packages/taro-cli/src/create/project.ts
+++ b/packages/taro-cli/src/create/project.ts
@@ -44,6 +44,12 @@ export interface IProjectConf {
   framework: FrameworkType
   compiler?: CompilerType
   ask?: (config: object) => Promise<void> | void
+  /**
+   * 内部标记：由 `taro init .` / `./` 触发。
+   * 表示目标目录即当前工作目录，projectName 已被解析为当前目录名。
+   * 仅在 CLI 内部流转，不会传递给底层 createProject。
+   */
+  initInCurrentDir?: boolean
 }
 
 type CustomPartial<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
@@ -63,7 +69,8 @@ function resolveProjectConf (conf: IProjectConfOptions): IProjectConfOptions {
   return {
     ...conf,
     projectDir: path.dirname(projectDir),
-    projectName: path.basename(projectDir)
+    projectName: path.basename(projectDir),
+    initInCurrentDir: true
   }
 }
 
@@ -156,6 +163,10 @@ export default class Project extends Creator {
   }
 
   askProjectName: AskMethods = function (conf, prompts) {
+    // `taro init .` 场景：目标目录即当前目录，projectName 已解析为当前目录名，
+    // 目录存在是预期行为，跳过“同名目录已存在”校验，避免误报。
+    if (conf.initInCurrentDir) return
+
     if ((typeof conf.projectName) !== 'string') {
       prompts.push({
         type: 'input',

--- a/packages/taro-cli/src/create/project.ts
+++ b/packages/taro-cli/src/create/project.ts
@@ -66,10 +66,16 @@ function resolveProjectConf (conf: IProjectConfOptions): IProjectConfOptions {
   if (!conf.projectName || !/^\.(?:[\\/])?$/.test(conf.projectName)) return conf
 
   const projectDir = conf.projectDir || process.cwd()
+  const currentDirName = path.basename(projectDir)
+  // 文件系统根目录（如 `/` 或 `C:\`）下 basename 为空，无法推断项目名，
+  // 显式报错而非静默传空名，避免在根目录创建文件、init git、装依赖。
+  if (!currentDirName) {
+    throw new Error('无法在文件系统根目录下初始化项目，请切换到具体目录，或使用 `taro init <项目名>` 指定项目名称')
+  }
   return {
     ...conf,
     projectDir: path.dirname(projectDir),
-    projectName: path.basename(projectDir),
+    projectName: currentDirName,
     initInCurrentDir: true
   }
 }

--- a/packages/taro-cli/src/create/project.ts
+++ b/packages/taro-cli/src/create/project.ts
@@ -56,6 +56,17 @@ interface AskMethods {
 
 const NONE_AVAILABLE_TEMPLATE = '无可用模板'
 
+function resolveProjectConf (conf: IProjectConfOptions): IProjectConfOptions {
+  if (!conf.projectName || !/^\.(?:[\\/])?$/.test(conf.projectName)) return conf
+
+  const projectDir = conf.projectDir || process.cwd()
+  return {
+    ...conf,
+    projectDir: path.dirname(projectDir),
+    projectName: path.basename(projectDir)
+  }
+}
+
 export default class Project extends Creator {
   public rootPath: string
   public conf: IProjectConfOptions
@@ -68,7 +79,7 @@ export default class Project extends Creator {
     }
     this.rootPath = this._rootPath
 
-    this.conf = Object.assign(
+    this.conf = resolveProjectConf(Object.assign(
       {
         projectName: '',
         projectDir: '',
@@ -77,7 +88,7 @@ export default class Project extends Creator {
         npm: ''
       },
       options
-    )
+    ))
   }
 
   init () {


### PR DESCRIPTION
## Summary

- Support `taro init .` / `npx @tarojs/cli init .` by resolving `.` to the current directory name while keeping the target path as the current directory.
- Add unit coverage for `.` and `./` project names.

## Motivation

Closes #19249. This lets users initialize a Taro project directly in an existing current directory. Existing non-conflicting files are preserved by the existing template copy behavior, while same-name template files can still be overwritten.

## Validation

- `pnpm --filter @tarojs/cli exec jest packages/taro-cli/src/__tests__/project.spec.ts --runInBand`
- `pnpm --filter @tarojs/cli exec eslint src/create/project.ts src/__tests__/project.spec.ts`

Note: I also tried running `cli.spec.ts`, but this temporary worktree had unbuilt workspace package entries such as `@tarojs/service`, so that broader suite could not start in this local environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * 新增对项目名为 `.` / `./` / `.\` 等场景的项目目录与项目名解析覆盖，并覆盖当前目录初始化与同名目录询问行为。

* **Bug Fixes**
  * `taro init` 在当前目录标识下自动规范项目目录与名称推导；当前目录初始化时跳过多余的同名目录校验与询问。
  * 对根目录初始化并选择 `.` 的异常场景增加校验，避免异常行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->