### PR TITLE
fix(components-library-react): clear removed event handler cache

### DIFF
--- a/packages/taro-components-library-react/src/react-component-lib/utils/attachProps.ts
+++ b/packages/taro-components-library-react/src/react-component-lib/utils/attachProps.ts
@@ -104,7 +104,10 @@ export const syncEvent = (
   const oldEventHandler = eventStore[eventName]
 
   if (!newEventHandler) {
-    oldEventHandler && node.removeEventListener(eventName, oldEventHandler)
+    if (oldEventHandler) {
+      node.removeEventListener(eventName, oldEventHandler)
+      delete eventStore[eventName]
+    }
   } else {
     if (oldEventHandler) {
       if (oldEventHandler.fn === newEventHandler) {


### PR DESCRIPTION
**这个 PR 做了什么？** (简要描述所做更改)

修复了 Taro H5 下 React 组件库事件解绑后无法用同一 handler 重新绑定的问题。

问题可通过如下代码复现：

```tsx
import { View } from '@tarojs/components'
import { useCallback, useState } from 'react'

export default function Page() {
  const [loading, setLoading] = useState(false)

  const handleClick = useCallback(async () => {
    console.log('click')
    setLoading(true)
    await new Promise(resolve => setTimeout(resolve, 1000))
    setLoading(false)
  }, [])

  return (
    <View onClick={loading ? undefined : handleClick}>
      Button
    </View>
  )
}
```

在上述场景中，`onClick` 会经历 `handleClick -> undefined -> handleClick` 的切换：
- 第一次点击可以正常触发
- 当 `loading` 恢复为 `false` 后，第二次点击在 Taro H5 下失效
- 同样的代码在纯 React 和小程序端可以正常工作

原因是 `syncEvent` 在移除事件监听时，没有同步清理 `node.__events` 中的缓存，导致后续再次传入同一个 handler 时被误判为事件已存在，进而跳过重新绑定。

本 PR 的修复内容：
- 在移除事件监听时同步删除 `eventStore[eventName]`
- 保证 `handler -> undefined -> same handler` 的场景下可以正确重新绑定事件
- 新增对应回归测试，覆盖该问题路径

**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [x] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 优化事件监听移除流程：在移除事件处理器时，同步清理内部事件缓存中对应的记录，避免保留过期处理器引用，从而提升事件系统的稳定性与可靠性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->