### PR TITLE
 fix(components): 修复@trao/components swiper组件销毁时的报错

### DIFF
--- a/packages/taro-components/__tests__/swiper.spec.tsx
+++ b/packages/taro-components/__tests__/swiper.spec.tsx
@@ -99,6 +99,37 @@ describe('Swiper', () => {
     expect(page.root).toMatchSnapshot()
   })
 
+  it('should skip loopDestroy when swiper wrapper is unavailable', () => {
+    const swiper = new Swiper()
+    const child = document.createElement('taro-swiper-item-core')
+    const wrapper = {
+      appendChild: jest.fn((node) => node),
+      insertBefore: jest.fn((node) => node),
+      replaceChild: jest.fn((node) => node),
+      removeChild: jest.fn((node) => node),
+    } as unknown as HTMLElement
+    const loopDestroy = jest.fn()
+
+    Object.assign(swiper, {
+      circular: true,
+      el: {} as HTMLElement,
+      isWillLoadCalled: true,
+      swiper: {
+        destroyed: false,
+        loopDestroy,
+        params: {
+          loop: true,
+        },
+      },
+    })
+
+    swiper.watchSwiperWrapper(wrapper)
+    swiper.el.appendChild(child)
+
+    expect(loopDestroy).not.toHaveBeenCalled()
+    expect(wrapper.appendChild).toHaveBeenCalledWith(child)
+  })
+
   it('should be vertical', async () => {
     // TODO
     const interval = 1500

--- a/packages/taro-components/src/components/swiper/swiper.tsx
+++ b/packages/taro-components/src/components/swiper/swiper.tsx
@@ -199,6 +199,7 @@ export class Swiper implements ComponentInterface {
     if (!this.isWillLoadCalled || !this.swiper) return
     if (!newVal) return
     const beforeDomOperation = () => {
+      if (!this.swiper.wrapperEl) return
       this.#domChangeByOutSide = true
       // 如果是由于外部子节点的变化引起的 dom 变化，需要重新初始化 swiper。
       // 在初dom操作之前，需要调用 loopDestroy，把子节点的顺序恢复


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)

TypeError. Cannot read properties of undefined (reading 'children'). in e.loopDestroy at line 2:60102

 Swiper 在 `circular` 模式下，外部子节点变化时会先调用 `loopDestroy()` 恢复 DOM 顺序，再重新初
 始化。
 但在某些场景下，Swiper 内部的 wrapper 节点可能已经被移除或重置，此时继续调用 `loopDestroy()`
 会导致 Swiper 内部访问 wrapper children 时抛错。

**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [x] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了轮播组件的稳定性，添加了初始化检查机制，防止在组件尚未完成初始化时出现异常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->