### PR TITLE
fix(vite): 去掉开头的/,而不是第一个字符

### DIFF
--- a/packages/taro-vite-runner/src/h5/entry.ts
+++ b/packages/taro-vite-runner/src/h5/entry.ts
@@ -58,7 +58,7 @@ export default function (viteCompilerContext: ViteH5CompilerContext): PluginOpti
         const getTabbarIconPath = (iconPath) => {
           return isProd
             ? path.posix.join('/', taroConfig.staticDirectory as string, 'images', path.basename(iconPath))
-            : iconPath.replace(/^./, '')
+            : iconPath.replace(/^\//, '')
         }
 
         const emitTabbarIcon = async (sourceDir, iconPath) => {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)


**这个 PR 是什么类型？** (至少选择一个)

- [ x] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ x] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* 修复了生产环境中标签栏图标路径的处理逻辑：现在仅在路径以“/”开头时移除前导斜杠，避免误删其他字符，提升图标路径拼装的准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->