### PR TITLE
fix(webpack5-prebundle): wrap roots param in array for enhanced-resolve compat

### DIFF
--- a/packages/taro-webpack5-prebundle/src/utils/index.ts
+++ b/packages/taro-webpack5-prebundle/src/utils/index.ts
@@ -23,7 +23,7 @@ export function createResolve (appPath: string, resolveOptions) {
     cache: true,
     mainFiles: ['index'],
     exportsFields: ['exports'],
-    roots: appPath
+    roots: [appPath]
   }
   const resolver = enhancedResolve.create({
     ...defaultResolveOptions,


### PR DESCRIPTION
## 问题

`enhanced-resolve` v5.17.0+ 要求 `roots` 参数必须是数组。当前代码传入了单个字符串 `appPath`，导致编译时抛出 `TypeError: options.roots.map is not a function`。

## 复现

在任何 Taro 4.x 项目中使用 Webpack5 构建时触发：

```
TypeError: options.roots.map is not a function
    at .../node_modules/enhanced-resolve/lib/Resolver.js
```

## 修复

```diff
-    roots: appPath
+    roots: [appPath]
```

将 `appPath` 包裹为数组字面量，符合 `enhanced-resolve` API 规范。

## 测试

- 该字段在 `createResolve` 函数中通过 `...defaultResolveOptions` 展开传入 `enhancedResolve.create()`
- `roots` 接受 `string[]` 类型，单个路径包裹为单元素数组完全兼容
- 不改变任何现有行为，仅修复类型兼容性

Closes #19372


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化资源解析的根路径配置格式：将解析根路径由单一字符串改为数组形式，确保解析器接收到一致的数据形态。
  * 提升部分项目结构下的路径解析稳定性，减少可能出现的解析异常与行为不一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->