### PR TITLE
fix(types): declare disablePrerender on StandardProps

### DIFF
--- a/packages/taro-components/types/common.d.ts
+++ b/packages/taro-components/types/common.d.ts
@@ -37,6 +37,11 @@ export interface StandardProps<T = any, TouchEvent extends BaseTouchEvent<any> =
    * @supported harmony
    */
   harmonyDirection?: 'row' | 'column' | 'flex'
+  /**
+   * 在预渲染（Prerender）过程中跳过当前节点，不对其进行预渲染
+   * @see https://docs.taro.zone/docs/prerender
+   */
+  disablePrerender?: boolean
 }
 
 export interface FormItemProps {


### PR DESCRIPTION
**这个 PR 做了什么？** (简要描述所做更改)

为公共组件属性类型 `StandardProps` 补充 `disablePrerender?: boolean` 声明。

预渲染运行时 (`packages/taro-webpack5-runner/src/prerender/prerender.ts`) 会读取元素上的 `disablePrerender` 属性来跳过该节点的预渲染，但该属性从未在 `StandardProps` 上声明，导致在任意组件上使用（如 `<View disablePrerender />`）时报 TS 错误：

```
不能将类型“{ ...; disablePrerender: true; ... }”分配给类型“IntrinsicAttributes & ViewProps”。
类型“IntrinsicAttributes & ViewProps”上不存在属性“disablePrerender”。
```

由于该属性作用于任意元素，故加在所有组件共享的基类型 `StandardProps` 上，与运行时行为一致。

**这个 PR 是什么类型？** (至少选择一个)

- [ ] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [x] TypeScript 类型定义修改 (Types) issue: fix #19029
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [x] 所有平台

Fixes #19029

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * `StandardProps` 新增可选属性 `disablePrerender`，用于在预渲染过程中跳过当前节点。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->