### PR TITLE
fix(ci): 放行 SWC 插件 wasm 链接的宿主 import 符号

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,6 +16,12 @@ rustflags = ["-C", "target-feature=+crt-static"]
 [target.i686-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
 
+# SWC 插件依赖宿主注入的 import 函数(如 __set_transform_result),
+# 编译到 wasm 时这些符号本应作为 wasm import 保留为未定义。
+# rustc 1.97 起 rust-lld 默认将其视为链接错误,故显式放行。
+[target.wasm32-wasip1]
+rustflags = ["-C", "link-args=--allow-undefined"]
+
 [alias]
 # Alias to build actual SWC plugin binary for the specified target.
 build-wasi = "build --target wasm32-wasip1"


### PR DESCRIPTION
rustc 1.97 起 rust-lld 默认将未定义符号视为链接错误,导致
SWC 插件编译到 wasm32-wasip1 时因 __set_transform_result 等 宿主注入的 import 符号链接失败。为该 target 增加
--allow-undefined 予以放行。

<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)


**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 修复 WebAssembly 构建与测试过程中因未解析符号导致的链接失败问题。
  - 提升相关测试环境下的构建稳定性，确保宿主环境提供的导入函数能够正常使用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->