### PR TITLE
feat: ttdom 支持 vite，修复 catchMove 适配

### DIFF
--- a/packages/taro-runtime/src/bom/document.ts
+++ b/packages/taro-runtime/src/bom/document.ts
@@ -115,8 +115,12 @@ export function createTTDomDocument(): TaroDocument {
         const result = originalSetAttribute(name, value)
 
         // 处理 catchMove 属性
-        if (name === 'catchMove' && value) {
-          el.addEventListener('catchtouchmove', emptyFunction)
+        if (name === 'catchMove') {
+          if (value) {
+            el.addEventListener('catchtouchmove', emptyFunction)
+          } else {
+            el.removeEventListener('catchtouchmove', emptyFunction)
+          }
         }
 
         return result

--- a/packages/taro-vite-runner/src/mini/emit.ts
+++ b/packages/taro-vite-runner/src/mini/emit.ts
@@ -15,6 +15,16 @@ import type { PluginOption } from 'vite'
 export default function (viteCompilerContext: ViteMiniCompilerContext): PluginOption {
   return [{
     name: 'taro:vite-mini-emit',
+    renderChunk (code, chunk) {
+      if (viteCompilerContext && chunk.isEntry && chunk.name === viteCompilerContext.app.name) {
+        const { app } = viteCompilerContext
+        const appConfig = app.config
+        if (process.env.TARO_ENV === 'tt' && appConfig) {
+          return `if (typeof tt !== 'undefined') {\n  tt.__$enableTTDom$__ = ${appConfig.enableTTDom};\n}\n${code}`
+        }
+      }
+      return null
+    },
     async generateBundle (_outputOpts, bundle) {
       const isUsingCustomWrapper = componentConfig.thirdPartyComponents.has('custom-wrapper')
 


### PR DESCRIPTION
## Summary

补合 PR #18998 的改动到 `main`。

原 PR #18998 的目标分支是 `feat/tt-ttdom` 而非 `main`，虽然显示为 MERGED，但其改动实际未随 `feat/tt-ttdom` → `main` 的 squash merge（#18850）进入 `main`，导致以下两处改动丢失。本 PR cherry-pick 原 commit `e3a1886` 补齐。

## Changes

- `packages/taro-runtime/src/bom/document.ts`：`catchMove` 属性为 `false` 时补上 `removeEventListener('catchtouchmove')`，修复 catchMove 动态切换失效的问题。
- `packages/taro-vite-runner/src/mini/emit.ts`：新增 `renderChunk`，在 tt 环境下向入口 chunk 注入 `tt.__$enableTTDom$__`，让 ttdom 支持 vite。

## Test plan

- [ ] tt 小程序 vite 构建产物入口包含 `tt.__$enableTTDom$__` 注入
- [ ] catchMove 由 `true` 切换为 `false` 时，`catchtouchmove` 监听被正确移除

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复 `catchMove` 属性值变化后的事件监听处理，确保可正确注册或移除 `catchtouchmove` 监听。
  * 优化抖音小程序运行时配置注入，使 TT DOM 能力按应用配置正确启用或关闭。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->