### PR TITLE
fix(runtime): correct alias after removing event listener

### DIFF
--- a/packages/taro-runtime/src/dom/element.ts
+++ b/packages/taro-runtime/src/dom/element.ts
@@ -386,7 +386,7 @@ export class TaroElement extends TaroNode {
 
     if (sideEffect !== false && !this.isAnyEventBinded() && SPECIAL_NODES.indexOf(name) > -1) {
       const componentsAlias = getComponentsAlias()
-      const value = isHasExtractProp(this) ? `static-${name}` : `pure-${name}`
+      const value = name === VIEW && !isHasExtractProp(this) ? PURE_VIEW : `static-${name}`
       const valueAlias = componentsAlias[value]._num
       this.enqueueUpdate({
         path: `${this._path}.${Shortcuts.NodeName}`,

--- a/packages/taro-runtime/tests/event.spec.ts
+++ b/packages/taro-runtime/tests/event.spec.ts
@@ -1,8 +1,10 @@
+import { Shortcuts } from '@tarojs/shared'
 import { afterAll, describe, expect, test, vi } from 'vitest'
 
-import { EVENT_CALLBACK_RESULT } from '../src/constants'
+import { EVENT_CALLBACK_RESULT, PURE_VIEW } from '../src/constants'
 import { eventHandler } from '../src/dom/event'
 import * as runtime from '../src/index'
+import { getComponentsAlias } from '../src/utils'
 
 describe('event', () => {
   const document = runtime.document
@@ -119,6 +121,72 @@ describe('event', () => {
     expect(() => {
       div.removeEventListener('tap', vi.fn())
     }).not.toThrow()
+  })
+
+  test.each([
+    ['text', 'static-text'],
+    ['image', 'static-image']
+  ])('移除 %s 的最后一个事件监听后切换为 %s', (nodeName, aliasName) => {
+    const element = document.createElement(nodeName)
+    const handler = vi.fn()
+    const enqueueUpdate = vi.spyOn(element, 'enqueueUpdate')
+
+    element.addEventListener('tap', handler)
+    enqueueUpdate.mockClear()
+
+    expect(() => element.removeEventListener('tap', handler)).not.toThrow()
+    expect(enqueueUpdate).toHaveBeenCalledOnce()
+    expect(enqueueUpdate).toHaveBeenCalledWith({
+      path: `${element._path}.${Shortcuts.NodeName}`,
+      value: getComponentsAlias()[aliasName]._num
+    })
+  })
+
+  test('移除无提取属性 view 的最后一个事件监听后切换为 pure-view', () => {
+    const view = document.createElement('view')
+    const handler = vi.fn()
+    const enqueueUpdate = vi.spyOn(view, 'enqueueUpdate')
+
+    view.addEventListener('tap', handler)
+    enqueueUpdate.mockClear()
+    view.removeEventListener('tap', handler)
+
+    expect(enqueueUpdate).toHaveBeenCalledOnce()
+    expect(enqueueUpdate).toHaveBeenCalledWith({
+      path: `${view._path}.${Shortcuts.NodeName}`,
+      value: getComponentsAlias()[PURE_VIEW]._num
+    })
+  })
+
+  test('移除有提取属性 view 的最后一个事件监听后切换为 static-view', () => {
+    const view = document.createElement('view')
+    const handler = vi.fn()
+    const enqueueUpdate = vi.spyOn(view, 'enqueueUpdate')
+
+    view.setAttribute('hover-class', 'hover')
+    view.addEventListener('tap', handler)
+    enqueueUpdate.mockClear()
+    view.removeEventListener('tap', handler)
+
+    expect(enqueueUpdate).toHaveBeenCalledOnce()
+    expect(enqueueUpdate).toHaveBeenCalledWith({
+      path: `${view._path}.${Shortcuts.NodeName}`,
+      value: getComponentsAlias()['static-view']._num
+    })
+  })
+
+  test('移除其中一个事件监听时不会切换节点模板', () => {
+    const text = document.createElement('text')
+    const handler = vi.fn()
+    const anotherHandler = vi.fn()
+    const enqueueUpdate = vi.spyOn(text, 'enqueueUpdate')
+
+    text.addEventListener('tap', handler)
+    text.addEventListener('tap', anotherHandler)
+    enqueueUpdate.mockClear()
+    text.removeEventListener('tap', handler)
+
+    expect(enqueueUpdate).not.toHaveBeenCalled()
   })
 
   test('可以阻止冒泡', () => {


### PR DESCRIPTION
**这个 PR 做了什么？**

修复小程序端 `Text` 和 `Image` 节点移除最后一个事件监听器时，运行时访问不存在的 `pure-text` / `pure-image` alias 导致崩溃的问题。

`hydrate()` 初始化无事件节点时遵循以下规则：

- 无提取属性的 `View` 使用 `pure-view`
- 其他 `View`、`Text`、`Image` 使用对应的 `static-*` alias

但 `removeEventListener()` 原先会将所有无提取属性的特殊节点切换为 `pure-*`，导致 `Text` 和 `Image` 分别访问不存在的 `pure-text` 和 `pure-image`。

本次修改使 `removeEventListener()` 的 alias 选择逻辑与 `hydrate()` 保持一致：

- `View` 且无提取属性：`pure-view`
- 其他特殊节点：`static-${nodeName}`

同时增加回归测试，覆盖：

- `Text` 移除最后一个事件监听器后切换到 `static-text`
- `Image` 移除最后一个事件监听器后切换到 `static-image`
- 无提取属性的 `View` 切换到 `pure-view`
- 有提取属性的 `View` 切换到 `static-view`
- 节点仍有其他监听器时不切换模板

Fixes #19453

**这个 PR 是什么类型？**

- [x] 错误修复 (Bugfix) issue: fix #19453
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [x] 所有小程序
- [x] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

**测试结果**

- `pnpm --filter @tarojs/runtime exec vitest run tests/event.spec.ts`
  - 33 tests passed
- `pnpm --filter @tarojs/runtime run test:ci`
  - 133 tests passed，1 skipped
- `pnpm --filter @tarojs/runtime run build`
  - passed
- ESLint
  - passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复移除节点最后一个事件监听器时的模板别名切换逻辑，确保触发的模板更新符合预期。
  * 优化 `view` 节点在是否包含“提取属性”时的模板映射：无提取属性切换为纯模板，有提取属性切换为静态模板。
  * 仅移除部分事件监听器时不再触发不必要的模板更新。
* **Tests**
  * 增加事件监听移除与节点模板切换的断言用例，覆盖 `text`/`image`/`view` 及负向场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->