### PR TITLE
fix(webpack5-prebundle): wrap roots option in array for enhanced-resolve compatibility

### DIFF
--- a/packages/taro-webpack5-prebundle/src/utils/index.ts
+++ b/packages/taro-webpack5-prebundle/src/utils/index.ts
@@ -23,7 +23,7 @@ export function createResolve (appPath: string, resolveOptions) {
     cache: true,
     mainFiles: ['index'],
     exportsFields: ['exports'],
-    roots: appPath
+    roots: [appPath]
   }
   const resolver = enhancedResolve.create({
     ...defaultResolveOptions,


### PR DESCRIPTION
This PR backports a small compatibility fix for `@tarojs/webpack5-prebundle` to the `3.x` branch.

`enhanced-resolve` expects the `roots` option to be an array, but Taro 3.x currently passes `appPath` as a string:

```ts
roots: appPath
```

With newer `enhanced-resolve` versions, this causes:

```text
TypeError: options.roots.map is not a function
```

This PR changes it to:

```ts
roots: [appPath]
```

## Background

Taro 3.6.x can still resolve newer `enhanced-resolve` versions through semver ranges, for example `enhanced-resolve@5.24.x`.

The same compatibility fix already exists on the main branch / newer Taro releases, so this PR ports the fix back to `3.x`.

## Reproduction

Environment:

```text
Taro: 3.6.40
Node: 18.20.8
pnpm
enhanced-resolve: 5.24.x
```

Steps:

```bash
pnpm install
pnpm dev:h5
```

Error:

```text
TypeError: options.roots.map is not a function
    at createOptions (.../enhanced-resolve/lib/ResolverFactory.js)
    at createResolve (.../@tarojs/webpack5-prebundle/src/utils/index.ts)
```

## Changes

- Wrap `appPath` in an array when passing it to `enhanced-resolve` via the `roots` option.

## Checklist

- [x] Target branch is `3.x`
- [x] Small compatibility fix only
- [x] No behavior change expected except avoiding the resolver crash
