### PR TITLE
feat(taro-init): 支持按平台精简生成 package.json / config/index.js

### DIFF
--- a/crates/native_binding/binding.d.ts
+++ b/crates/native_binding/binding.d.ts
@@ -34,6 +34,7 @@ export interface CreateOptions {
   changeExt?: boolean
   isCustomTemplate?: boolean
   pluginType?: string
+  platforms?: Array<string>
 }
 
 export function createPage(conf: Page, handlers: Record<string, (err: Error | null, arg: CreateOptions) => any>): Promise<void>
@@ -116,5 +117,6 @@ export interface Project {
   date?: string
   compiler?: CompilerType
   period: PeriodType
+  platforms?: Array<string>
 }
 

--- a/crates/native_binding/src/lib.rs
+++ b/crates/native_binding/src/lib.rs
@@ -28,6 +28,7 @@ pub async fn create_project(
     conf.date,
     conf.compiler,
     conf.period,
+    conf.platforms,
   );
   let mut thread_safe_functions = HashMap::new();
   for (key, callback) in handlers {

--- a/crates/taro_init/src/constants.rs
+++ b/crates/taro_init/src/constants.rs
@@ -9,10 +9,15 @@ use serde::Serialize;
 handlebars_helper!(includes: |{ s: str = "" }, *args| args.iter().map(|a| a.render()).any(|arg| arg == s));
 // handlebars_helper!(eq: |x: str, y: str| x == y);
 
+// 语义：运行时数组 `arr` 中是否包含 `vals` 中任意一个候选值（字符串比较）。
+// 与 `includes` 相反：`includes` 是"候选值列表（模板里写死）中是否存在等于运行时变量的项"。
+handlebars_helper!(array_includes: |arr: array, *vals| vals.iter().any(|v| arr.iter().any(|item| item.as_str() == v.as_str())));
+
 pub static HANDLEBARS: Lazy<Handlebars<'static>> = Lazy::new(|| {
   let mut hbs = new_hbs();
   register(&mut hbs);
   hbs.register_helper("includes", Box::new(includes));
+  hbs.register_helper("array_includes", Box::new(array_includes));
   hbs
 });
 
@@ -122,4 +127,37 @@ pub enum CompilerType {
 pub enum PeriodType {
   CreateAPP,
   CreatePage,
+}
+
+#[cfg(test)]
+mod tests {
+  use serde_json::json;
+
+  use super::HANDLEBARS;
+
+  fn render(tpl: &str, platforms: &[&str]) -> String {
+    HANDLEBARS
+      .render_template(tpl, &json!({ "platforms": platforms }))
+      .unwrap()
+  }
+
+  #[test]
+  fn test_array_includes_single_value() {
+    assert_eq!(
+      render("{{#if (array_includes platforms \"weapp\")}}yes{{else}}no{{/if}}", &["weapp", "h5"]),
+      "yes"
+    );
+    assert_eq!(
+      render("{{#if (array_includes platforms \"weapp\")}}yes{{else}}no{{/if}}", &["h5"]),
+      "no"
+    );
+  }
+
+  #[test]
+  fn test_array_includes_multiple_values() {
+    let tpl = "{{#if (array_includes platforms \"weapp\" \"alipay\" \"swan\" \"tt\" \"qq\" \"jd\")}}yes{{else}}no{{/if}}";
+    assert_eq!(render(tpl, &["h5"]), "no");
+    assert_eq!(render(tpl, &["h5", "swan"]), "yes");
+    assert_eq!(render(tpl, &[]), "no");
+  }
 }

--- a/crates/taro_init/src/creator.rs
+++ b/crates/taro_init/src/creator.rs
@@ -41,6 +41,7 @@ pub struct CreateOptions {
   pub change_ext: Option<bool>,
   pub is_custom_template: Option<bool>,
   pub plugin_type: Option<String>,
+  pub platforms: Option<Vec<String>>,
 }
 
 #[derive(Debug)]

--- a/crates/taro_init/src/page.rs
+++ b/crates/taro_init/src/page.rs
@@ -116,6 +116,7 @@ impl Page {
       build_es5: None,
       is_custom_template: self.is_custom_template.clone(),
       plugin_type: None,
+      platforms: None,
     };
     let files = self
       .base_page_files

--- a/crates/taro_init/src/plugin.rs
+++ b/crates/taro_init/src/plugin.rs
@@ -67,6 +67,7 @@ impl Plugin {
       sub_pkg: None,
       page_dir: None,
       set_sub_pkg_page_name: None,
+      platforms: None,
     };
     let all_files = all_files
       .iter()

--- a/crates/taro_init/src/project.rs
+++ b/crates/taro_init/src/project.rs
@@ -29,6 +29,7 @@ pub struct Project {
   pub date: Option<String>,
   pub compiler: Option<CompilerType>,
   pub period: PeriodType,
+  pub platforms: Option<Vec<String>>,
 }
 
 impl Project {
@@ -48,6 +49,7 @@ impl Project {
     date: Option<String>,
     compiler: Option<CompilerType>,
     period: PeriodType,
+    platforms: Option<Vec<String>>,
   ) -> Self {
     Project {
       project_root,
@@ -65,6 +67,7 @@ impl Project {
       date,
       compiler,
       period,
+      platforms,
     }
   }
 
@@ -117,6 +120,7 @@ impl Project {
       change_ext: None,
       is_custom_template: None,
       plugin_type: None,
+      platforms: self.platforms.clone(),
     };
     let all_files = all_files
       .iter()

--- a/packages/taro-cli/src/__tests__/project.spec.ts
+++ b/packages/taro-cli/src/__tests__/project.spec.ts
@@ -262,4 +262,43 @@ describe('create project', () => {
     expect(project.conf.platforms).toEqual(['weapp', 'h5'])
     expect(prompts).toHaveLength(0)
   })
+
+  it.each([
+    [[], '未选择平台'],
+    [['unknown'], 'unknown']
+  ])('should reject invalid platforms %p', (platforms, message) => {
+    const project = new Project({
+      projectDir: '/a/b',
+      projectName: 'my-project',
+      sourceRoot: __dirname,
+      template: 'default',
+      templateSource: 'default-template',
+      npm: 'npm',
+      css: 'none',
+      framework: 'react',
+      platforms
+    } as any)
+
+    expect(() => project.askPlatforms(project.conf, [])).toThrow(message)
+  })
+
+  it('should require at least one platform when prompting', () => {
+    const project = new Project({
+      projectDir: '/a/b',
+      projectName: 'my-project',
+      sourceRoot: __dirname,
+      template: 'default',
+      templateSource: 'default-template',
+      npm: 'npm',
+      css: 'none',
+      framework: 'react'
+    } as any)
+
+    const prompts: Record<string, unknown>[] = []
+    project.askPlatforms(project.conf, prompts)
+    const validate = prompts[0].validate as (input: string[]) => true | string
+
+    expect(validate([])).toBe('请至少选择一个平台！')
+    expect(validate(['weapp'])).toBe(true)
+  })
 })

--- a/packages/taro-cli/src/__tests__/project.spec.ts
+++ b/packages/taro-cli/src/__tests__/project.spec.ts
@@ -203,4 +203,63 @@ describe('create project', () => {
     expect(prompts).toHaveLength(1)
     expect(prompts[0]).toMatchObject({ name: 'projectName' })
   })
+
+  it('should prompt for platforms when conf.platforms is undefined', () => {
+    const project = new Project({
+      projectDir: '/a/b',
+      projectName: 'my-project',
+      sourceRoot: __dirname,
+      template: 'default',
+      templateSource: 'default-template',
+      npm: 'npm',
+      css: 'none',
+      framework: 'react'
+    } as any)
+
+    const prompts: Record<string, unknown>[] = []
+    project.askPlatforms(project.conf, prompts)
+
+    expect(prompts).toHaveLength(1)
+    expect(prompts[0]).toMatchObject({ type: 'checkbox', name: 'platforms' })
+  })
+
+  it('should not prompt for platforms when conf.platforms is already an array', () => {
+    const project = new Project({
+      projectDir: '/a/b',
+      projectName: 'my-project',
+      sourceRoot: __dirname,
+      template: 'default',
+      templateSource: 'default-template',
+      npm: 'npm',
+      css: 'none',
+      framework: 'react',
+      platforms: ['weapp', 'h5']
+    } as any)
+
+    const prompts: Record<string, unknown>[] = []
+    project.askPlatforms(project.conf, prompts)
+
+    expect(prompts).toHaveLength(0)
+    expect(project.conf.platforms).toEqual(['weapp', 'h5'])
+  })
+
+  it('should normalize a comma-separated platforms string into an array', () => {
+    const project = new Project({
+      projectDir: '/a/b',
+      projectName: 'my-project',
+      sourceRoot: __dirname,
+      template: 'default',
+      templateSource: 'default-template',
+      npm: 'npm',
+      css: 'none',
+      framework: 'react',
+      platforms: 'weapp, h5'
+    } as any)
+
+    const prompts: Record<string, unknown>[] = []
+    project.askPlatforms(project.conf, prompts)
+
+    expect(project.conf.platforms).toEqual(['weapp', 'h5'])
+    expect(prompts).toHaveLength(0)
+  })
 })

--- a/packages/taro-cli/src/create/project.ts
+++ b/packages/taro-cli/src/create/project.ts
@@ -286,18 +286,28 @@ export default class Project extends Creator {
       { name: 'React Native', value: 'rn' }
     ]
 
-    if (!isArray(conf.platforms)) {
-      prompts.push({
-        type: 'checkbox',
-        name: 'platforms',
-        message: '请选择需要支持的平台？',
-        choices: platformChoices,
-        default: ['weapp', 'h5'],
-        validate (input: string[]) {
-          return input.length > 0 || '请至少选择一个平台！'
-        }
-      })
+    if (isArray(conf.platforms)) {
+      const supportedPlatforms = new Set(platformChoices.map(choice => choice.value))
+      const invalidPlatforms = conf.platforms.filter(
+        platform => !supportedPlatforms.has(platform)
+      )
+
+      if (conf.platforms.length === 0 || invalidPlatforms.length > 0) {
+        throw new Error(`无效的平台配置: ${invalidPlatforms.join(', ') || '未选择平台'}`)
+      }
+      return
     }
+
+    prompts.push({
+      type: 'checkbox',
+      name: 'platforms',
+      message: '请选择需要支持的平台？',
+      choices: platformChoices,
+      default: ['weapp', 'h5'],
+      validate (input: string[]) {
+        return input.length > 0 || '请至少选择一个平台！'
+      }
+    })
   }
 
   askCompiler: AskMethods = function (conf, prompts) {

--- a/packages/taro-cli/src/create/project.ts
+++ b/packages/taro-cli/src/create/project.ts
@@ -43,6 +43,7 @@ export interface IProjectConf {
   hideDefaultTemplate?: boolean
   framework: FrameworkType
   compiler?: CompilerType
+  platforms?: string[]
   ask?: (config: object) => Promise<void> | void
   /**
    * 内部标记：由 `taro init .` / `./` 触发。
@@ -133,6 +134,7 @@ export default class Project extends Creator {
     this.askTypescript(conf, prompts)
     this.askBuildEs5(conf, prompts)
     this.askCSS(conf, prompts)
+    this.askPlatforms(conf, prompts)
     this.askNpm(conf, prompts)
     const answers = await inquirer.prompt<IProjectConf>(prompts)
 
@@ -263,6 +265,37 @@ export default class Project extends Creator {
         name: 'css',
         message: '请选择 CSS 预处理器（Sass/Less/Stylus）',
         choices: cssChoices
+      })
+    }
+  }
+
+  askPlatforms: AskMethods = function (conf, prompts) {
+    if (typeof conf.platforms === 'string') {
+      conf.platforms = (conf.platforms as unknown as string).split(',').map(p => p.trim()).filter(Boolean)
+    }
+
+    const platformChoices = [
+      { name: '微信小程序', value: 'weapp' },
+      { name: '支付宝小程序', value: 'alipay' },
+      { name: '百度小程序', value: 'swan' },
+      { name: '字节跳动小程序', value: 'tt' },
+      { name: 'QQ 小程序', value: 'qq' },
+      { name: '京东小程序', value: 'jd' },
+      { name: 'H5', value: 'h5' },
+      { name: '鸿蒙元服务（Hybrid）', value: 'harmony-hybrid' },
+      { name: 'React Native', value: 'rn' }
+    ]
+
+    if (!isArray(conf.platforms)) {
+      prompts.push({
+        type: 'checkbox',
+        name: 'platforms',
+        message: '请选择需要支持的平台？',
+        choices: platformChoices,
+        default: ['weapp', 'h5'],
+        validate (input: string[]) {
+          return input.length > 0 || '请至少选择一个平台！'
+        }
       })
     }
   }
@@ -519,6 +552,7 @@ export default class Project extends Creator {
       description: this.conf.description,
       compiler: this.conf.compiler,
       period: PeriodType.CreateAPP,
+      platforms: this.conf.platforms,
     }, handler).then(() => {
       cb && cb()
     })

--- a/packages/taro-cli/src/presets/commands/init.ts
+++ b/packages/taro-cli/src/presets/commands/init.ts
@@ -14,6 +14,7 @@ export default (ctx: IPluginContext) => {
       '--template [template]': '项目模板',
       '--css [css]': 'CSS预处理器(sass/less/stylus/none)',
       '--autoInstall': '自动安装依赖',
+      '--platforms [platforms]': '需要支持的平台，多个用逗号分隔（如 weapp,h5）',
       '-h, --help': 'output usage information'
     },
     async fn (opts) {
@@ -34,6 +35,7 @@ export default (ctx: IPluginContext) => {
         hideDefaultTemplate,
         sourceRoot,
         autoInstall,
+        platforms,
         ask
       } = opts.options
 
@@ -54,6 +56,7 @@ export default (ctx: IPluginContext) => {
         hideDefaultTemplate,
         autoInstall,
         css,
+        platforms,
         ask
       })
 

--- a/packages/taro-cli/templates/default/config/index.js
+++ b/packages/taro-cli/templates/default/config/index.js
@@ -32,7 +32,7 @@ export default defineConfig{{#if typescript }}<'{{ to_lower_case compiler }}'>{{
     compiler: '{{ to_lower_case compiler }}',{{#if (eq compiler "Webpack5") }}
     cache: {
       enable: false // Webpack 持久化缓存配置，建议开启。默认配置请参考：https://docs.taro.zone/docs/config-detail#cache
-    },{{/if}}
+    },{{/if}}{{#if (array_includes platforms "weapp" "alipay" "swan" "tt" "qq" "jd") }}
     mini: {
       postcss: {
         pxtransform: {
@@ -52,7 +52,7 @@ export default defineConfig{{#if typescript }}<'{{ to_lower_case compiler }}'>{{
       webpackChain(chain) {
         chain.resolve.plugin('tsconfig-paths').use(TsconfigPathsPlugin)
       }{{/unless}}{{/if}}
-    },
+    },{{/if}}{{#if (array_includes platforms "h5" "harmony-hybrid") }}
     h5: {
       publicPath: '/',
       staticDirectory: 'static',
@@ -82,7 +82,7 @@ export default defineConfig{{#if typescript }}<'{{ to_lower_case compiler }}'>{{
       webpackChain(chain) {
         chain.resolve.plugin('tsconfig-paths').use(TsconfigPathsPlugin)
       }{{/unless}}{{/if}}
-    },
+    },{{/if}}{{#if (array_includes platforms "rn") }}
     rn: {
       appName: 'taroDemo',
       postcss: {
@@ -90,7 +90,7 @@ export default defineConfig{{#if typescript }}<'{{ to_lower_case compiler }}'>{{
           enable: false, // 默认为 false，如需使用 css modules 功能，则设为 true
         }
       }
-    }
+    },{{/if}}
   }
 
   {{#if buildEs5 }}

--- a/packages/taro-cli/templates/default/package.json.tmpl
+++ b/packages/taro-cli/templates/default/package.json.tmpl
@@ -11,25 +11,25 @@
   },
   "scripts": {
     "prepare": "husky",
-    "new": "taro new",
+    "new": "taro new"{{#if (array_includes platforms "weapp")}},
     "build:weapp": "taro build --type weapp",
+    "dev:weapp": "npm run build:weapp -- --watch"{{/if}}{{#if (array_includes platforms "swan")}},
     "build:swan": "taro build --type swan",
+    "dev:swan": "npm run build:swan -- --watch"{{/if}}{{#if (array_includes platforms "alipay")}},
     "build:alipay": "taro build --type alipay",
+    "dev:alipay": "npm run build:alipay -- --watch"{{/if}}{{#if (array_includes platforms "tt")}},
     "build:tt": "taro build --type tt",
+    "dev:tt": "npm run build:tt -- --watch"{{/if}}{{#if (array_includes platforms "h5")}},
     "build:h5": "taro build --type h5",
+    "dev:h5": "npm run build:h5 -- --watch"{{/if}}{{#if (array_includes platforms "rn")}},
     "build:rn": "taro build --type rn",
+    "dev:rn": "npm run build:rn -- --watch"{{/if}}{{#if (array_includes platforms "qq")}},
     "build:qq": "taro build --type qq",
+    "dev:qq": "npm run build:qq -- --watch"{{/if}}{{#if (array_includes platforms "jd")}},
     "build:jd": "taro build --type jd",
+    "dev:jd": "npm run build:jd -- --watch"{{/if}}{{#if (array_includes platforms "harmony-hybrid")}},
     "build:harmony-hybrid": "taro build --type harmony-hybrid",
-    "dev:weapp": "npm run build:weapp -- --watch",
-    "dev:swan": "npm run build:swan -- --watch",
-    "dev:alipay": "npm run build:alipay -- --watch",
-    "dev:tt": "npm run build:tt -- --watch",
-    "dev:h5": "npm run build:h5 -- --watch",
-    "dev:rn": "npm run build:rn -- --watch",
-    "dev:qq": "npm run build:qq -- --watch",
-    "dev:jd": "npm run build:jd -- --watch",
-    "dev:harmony-hybrid": "npm run build:harmony-hybrid -- --watch"
+    "dev:harmony-hybrid": "npm run build:harmony-hybrid -- --watch"{{/if}}
   },
   {{#if buildEs5 }}
   "browserslist": {
@@ -53,15 +53,15 @@
   "dependencies": {
     "@babel/runtime": "^7.24.4",
     "@tarojs/components": "{{ version }}",
-    "@tarojs/helper": "{{ version }}",
-    "@tarojs/plugin-platform-weapp": "{{ version }}",
-    "@tarojs/plugin-platform-alipay": "{{ version }}",
-    "@tarojs/plugin-platform-tt": "{{ version }}",
-    "@tarojs/plugin-platform-swan": "{{ version }}",
-    "@tarojs/plugin-platform-jd": "{{ version }}",
-    "@tarojs/plugin-platform-qq": "{{ version }}",
-    "@tarojs/plugin-platform-h5": "{{ version }}",
-    "@tarojs/plugin-platform-harmony-hybrid": "{{ version }}",
+    "@tarojs/helper": "{{ version }}",{{#if (array_includes platforms "weapp")}}
+    "@tarojs/plugin-platform-weapp": "{{ version }}",{{/if}}{{#if (array_includes platforms "alipay")}}
+    "@tarojs/plugin-platform-alipay": "{{ version }}",{{/if}}{{#if (array_includes platforms "tt")}}
+    "@tarojs/plugin-platform-tt": "{{ version }}",{{/if}}{{#if (array_includes platforms "swan")}}
+    "@tarojs/plugin-platform-swan": "{{ version }}",{{/if}}{{#if (array_includes platforms "jd")}}
+    "@tarojs/plugin-platform-jd": "{{ version }}",{{/if}}{{#if (array_includes platforms "qq")}}
+    "@tarojs/plugin-platform-qq": "{{ version }}",{{/if}}{{#if (array_includes platforms "h5")}}
+    "@tarojs/plugin-platform-h5": "{{ version }}",{{/if}}{{#if (array_includes platforms "harmony-hybrid")}}
+    "@tarojs/plugin-platform-harmony-hybrid": "{{ version }}",{{/if}}
     "@tarojs/runtime": "{{ version }}",
     "@tarojs/shared": "{{ version }}",
     "@tarojs/taro": "{{ version }}",{{#if (includes "React" "Preact" s=framework)}}


### PR DESCRIPTION
## 背景

`taro init` 生成的 default 模板项目中，`package.json`（scripts + dependencies）和 `config/index.js`（mini/h5/rn 配置段）目前无条件包含 weapp/alipay/swan/tt/qq/jd/h5/harmony-hybrid/rn 全部平台的内容，与用户实际要开发的平台无关，导致新项目里存在大量永远用不到的依赖包、构建脚本和配置段。

## 改动内容

新增交互式询问“请选择需要支持的平台？”（多选），并让`package.json`/`config/index.js` 只包含被选中平台相关的内容。实现方式是把选择结果透传进 Handlebars 渲染上下文，在模板里按条件生成，而非生成完整内容后用 JS 二次过滤。

- **Handlebars helper**：`constants.rs` 新增 `array_includes` helper，用于判断运行时数组（`platforms`）是否包含给定的一个或多个候选字符串；已有的`includes` helper 语义相反（固定候选值 vs 运行时变量），无法复用。
- **数据透传（Rust）**：`Project`/`CreateOptions` 新增 `platforms: Option<Vec<String>>`字段，沿 `project.ts → createProject → native_binding::create_project →Project::create → CreateOptions` 链路透传到 Handlebars 渲染上下文；`page.rs`/`plugin.rs` 中构造 `CreateOptions` 处补 `platforms: None`（页面/插件生成场景不涉及平台选择）；`binding.d.ts` 手动同步新增字段。
- **模板改造**：
  - `package.json.tmpl`：scripts 的 build/dev、dependencies 的`@tarojs/plugin-platform-*` 均按 `array_includes` 条件包裹；`rn` 无配套依赖包，只在 scripts 里出现，与现状行为一致。
  - `config/index.js`：`mini`/`h5`/`rn` 三段按平台条件生成（`mini` 对应weapp/alipay/swan/tt/qq/jd，`h5` 对应 h5/harmony-hybrid）。
  - 均验证过极端情况：一个平台都不选时仍是合法 JSON/JS；全选时结构与改动前等价。
- **JS 交互层**：`project.ts` 新增 `askPlatforms`（checkbox 多选，支持`--platforms weapp,h5` 这种逗号分隔字符串的归一化），接入 `ask()`/`write()`。
- **CLI 参数层**：`init.ts` 新增 `--platforms [platforms]` 选项并透传给`Project`。

## 测试

- `project.spec.ts` 新增 `askPlatforms` 用例：未定义时 push checkbox prompt、已是数组时不 push、逗号分隔字符串被归一化为数组。
- `constants.rs` 新增 `array_includes` 的 `#[cfg(test)]` 单测（单值/多值/空数组场景）。

## 验证方式

手动验证：

1. `cd crates/native_binding && npm run build:debug` 重新编译并核对生成的`binding.d.ts` 与手动编辑内容一致
2. 本地跑一次交互式 `taro init`，只勾选部分平台（如 weapp + h5），检查生成项目的 `package.json`/`config/index.js` 是否合法且只包含选中平台内容
3. 反向验证：全选全部平台，生成结果应与改动前一致
4. `pnpm --filter @tarojs/cli test` 确认新增单测通过、未破坏现有测试
5. `cargo test`（或对应的 Rust 测试入口）确认 `array_includes` 单测通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 项目初始化支持通过 `--platforms` 指定目标平台。
  - 支持同时选择多个小程序、H5、鸿蒙元服务和 React Native 平台。
  - 未指定平台时提供交互式平台选择，平台配置支持自动规范化与校验。
- **改进**
  - 生成的项目配置、开发命令及平台依赖将根据所选平台自动生成，减少无关内容。
- **测试**
  - 新增平台选择、配置保留及格式转换相关验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->