### PR TITLE
fix(alipay): 修复 Slider 属性别名错位导致 min/max/step 失效 (#19483)

### DIFF
--- a/packages/taro-platform-alipay/src/runtime.ts
+++ b/packages/taro-platform-alipay/src/runtime.ts
@@ -7,10 +7,21 @@ const { userAgent } = navigator
 Object.defineProperty(navigator, 'userAgent', {
   configurable: true,
   enumerable: true,
-  get () {
+  get() {
     return userAgent || (navigator as any).swuserAgent || ''
-  }
+  },
 })
 
 mergeReconciler(hostConfig)
-mergeInternalComponents(components)
+const internalComponents = mergeInternalComponents(components)
+
+// 支付宝原生 slider 不支持 block-size / block-color（改用 handle-size / handle-color）。
+// 编译期 program.ts 的 modifySlider 已经从模板属性表里删除了这两个属性，
+// 运行期这里必须同步删除，否则运行时与编译期的 Slider 属性集不一致，
+// 会导致 getComponentsAlias 计算出的属性别名（p0/p1/...）错位，
+// 进而导致 min/max/step/value 等属性无法正确传递到原生组件。
+const slider = internalComponents.Slider
+if (slider) {
+  delete slider['block-size']
+  delete slider['block-color']
+}


### PR DESCRIPTION
支付宝原生 slider 不支持 block-size / block-color，编译期 modifySlider 已从模板属性表中删除这两个属性，但运行期未同步删除，导致运行期与编译期 Slider 属性集不一致。getComponentsAlias 据此计算属性别名（p0/p1/...）时 发生错位，min/max/step/value 等属性无法正确传递到原生组件。

运行期同步删除 block-size / block-color，保证两端属性集一致。

<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)
支付宝原生 slider 不支持 block-size / block-color，编译期 modifySlider 已从模板属性表中删除这两个属性，但运行期未同步删除，导致运行期与编译期 Slider 属性集不一致。getComponentsAlias 据此计算属性别名（p0/p1/...）时 发生错位，min/max/step/value 等属性无法正确传递到原生组件。

**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [x] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 优化支付宝小程序运行时的组件处理，提升组件配置合并后的稳定性。
  - 修复原生 Slider 不支持特定属性导致的兼容性问题，Slider 的使用更加可靠。
- **兼容性**
  - 改善在支付宝平台运行时的组件适配表现，减少因不支持属性引发的异常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->