### PR TITLE
fix(weapp): support phone number quota toast prop

### DIFF
--- a/packages/taro-components/types/Button.d.ts
+++ b/packages/taro-components/types/Button.d.ts
@@ -138,6 +138,13 @@ interface ButtonProps extends StandardProps {
    * @default false
    */
   showMessageCard?: boolean
+  /** 当手机号快速验证或手机号实时验证额度用尽时，是否对用户展示平台默认提示
+   *
+   * 生效时机：`open-type="getPhoneNumber"` 或 `open-type="getRealtimePhoneNumber"`
+   * @supported weapp
+   * @default true
+   */
+  phoneNumberNoQuotaToast?: boolean
   /** 生活号 id，必须是当前小程序同主体且已关联的生活号，open-type="lifestyle" 时有效。
    * @supported alipay, qq
    */

--- a/packages/taro-platform-weapp/src/components.ts
+++ b/packages/taro-platform-weapp/src/components.ts
@@ -61,6 +61,7 @@ export const components = {
     'send-message-img': _empty,
     'app-parameter': _empty,
     'show-message-card': _false,
+    'phone-number-no-quota-toast': _true,
     'business-id': _empty,
     bindGetUserInfo: _empty,
     bindContact: _empty,


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)

Fixes #15845.

- 为 `ButtonProps` 补充微信小程序 `phoneNumberNoQuotaToast?: boolean` 类型声明。
- 在微信小程序 Button 模板属性表中透传 `phone-number-no-quota-toast`，默认值保持微信基础库的 `true`。
- 该属性在 `open-type="getPhoneNumber"` 或 `open-type="getRealtimePhoneNumber"` 时生效，允许业务在额度用尽时关闭平台默认提示并自行处理错误码。

官方文档：https://developers.weixin.qq.com/miniprogram/dev/component/button

**验证**

- `corepack pnpm lint`
- `corepack pnpm --filter @tarojs/plugin-platform-weapp run build`
- `corepack pnpm --filter @tarojs/components run build:ci`
- 独立 TypeScript fixture：验证 `phoneNumberNoQuotaToast` 接受 boolean，并拒绝 string
- 模板生成断言：验证属性输出为 `phone-number-no-quota-toast`，且默认值为 `true`
- `@tarojs/components` spec：70 suites / 106 tests / 35 snapshots 全部通过

补充：全量 e2e 在本机 Chrome 上仍有与本改动无关的既有差异（CSS `transition` 序列化、页面 hydration 超时与 focus/blur 次数差异），未更新任何快照。

**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #15845
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [x] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [x] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增手机号快速验证/实时验证额度用尽时的提示控制选项。
  * 支持通过 `phoneNumberNoQuotaToast` 控制是否显示平台默认提示；默认开启，仅适用于微信小程序。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->