### PR TITLE
fix(swan): support hold-keyboard for input fields

### DIFF
--- a/packages/taro-components/types/Input.d.ts
+++ b/packages/taro-components/types/Input.d.ts
@@ -99,7 +99,7 @@ interface InputProps extends StandardProps, FormItemProps {
   adjustPosition?: boolean
   /** focus 时，点击页面的时候不收起键盘
    * @default false
-   * @supported weapp, tt
+   * @supported weapp, swan, tt
    */
   holdKeyboard?: boolean
   /**

--- a/packages/taro-components/types/Textarea.d.ts
+++ b/packages/taro-components/types/Textarea.d.ts
@@ -85,7 +85,7 @@ interface TextareaProps extends StandardProps, FormItemProps {
   adjustPosition?: boolean
   /** focus 时，点击页面的时候不收起键盘
    * @default false
-   * @supported weapp, tt
+   * @supported weapp, swan, tt
    */
   holdKeyboard?: boolean
   /** 是否去掉 iOS 下的默认内边距

--- a/packages/taro-platform-swan/src/components.ts
+++ b/packages/taro-platform-swan/src/components.ts
@@ -46,13 +46,15 @@ export const components = {
     'skip-subscribe-authorize': 'false'
   },
   Input: {
-    'adjust-position': 'true'
+    'adjust-position': 'true',
+    'hold-keyboard': 'false'
   },
   Textarea: {
     'confirm-type': singleQuote('default'),
     'confirm-hold': 'false',
     'show-confirm-bar': 'true',
-    'adjust-position': 'true'
+    'adjust-position': 'true',
+    'hold-keyboard': 'false'
   },
   Navigator: {
     target: singleQuote('self'),


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)

Fixes #15572.

百度智能小程序的 `input` 和 `textarea` 已支持 `hold-keyboard`。本 PR：

- 为 `InputProps.holdKeyboard` 与 `TextareaProps.holdKeyboard` 补充 `swan` 平台标注；
- 在百度小程序平台模板属性表中为两个组件透传 `hold-keyboard`；
- 保持官方默认值 `false`，不改变未传入该属性时的行为。

官方文档：

- Input：https://smartprogram.baidu.com/docs/develop/component/formlist_input/
- Textarea：https://smartprogram.baidu.com/docs/develop/component/formlist_textarea/

**验证**

- `corepack pnpm lint`
- `corepack pnpm --filter @tarojs/plugin-platform-swan run build`
- `corepack pnpm --filter @tarojs/components run build:ci`
- 模板红绿对照：修复前 Input/Textarea 均不生成 `hold-keyboard`；修复后均生成该属性并保留 `false` 默认值
- `@tarojs/components` spec：70 suites / 106 tests / 35 snapshots 全部通过

**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #15572
- [x] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [x] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [x] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 百度小程序平台的 Input 和 Textarea 组件新增 `hold-keyboard` 属性支持。
  * 更新组件文档，标明该属性适用于百度小程序平台。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->