### PR TITLE
fix(types): resolve request declaration errors

### DIFF
--- a/packages/taro/types/api/network/request.d.ts
+++ b/packages/taro/types/api/network/request.d.ts
@@ -2,7 +2,7 @@ import Taro from '../../index'
 
 declare module '../../index' {
   namespace request {
-    interface Option<T = any, U extends string | TaroGeneral.IAnyObject | ArrayBuffer = any | any> {
+    interface Option<T = any, U = any> {
       /** 开发者服务器接口地址 */
       url: string
       /** 请求的参数 */
@@ -150,8 +150,7 @@ declare module '../../index' {
       storeCheck?(): boolean
     }
 
-    interface SuccessCallbackResult<T extends string | TaroGeneral.IAnyObject | ArrayBuffer = any | any>
-      extends TaroGeneral.CallbackResult {
+    interface SuccessCallbackResult<T = any> extends TaroGeneral.CallbackResult {
       /** 开发者服务器返回的数据 */
       data: T
       /** 开发者服务器返回的 HTTP Response Header */
@@ -377,6 +376,11 @@ declare module '../../index' {
         data: ArrayBuffer
       }
     }
+  }
+
+  /** @ignore */
+  interface RequestParams<T = any> extends request.Option<T, any> {
+    [propName: string]: any
   }
 
   /** @ignore */


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)

Fixes #18565.

`packages/taro/types/api/network/request.d.ts` 在严格类型检查下存在 5 个声明错误：

- `Chain` 两处引用未声明的 `RequestParams`；
- `Option`、`RequestTask` 和 `TaroStatic.request` 的外层泛型未受约束，却被传给受约束的内部泛型，产生 3 个 `TS2344`。

本 PR：

- 恢复类型文件迁移时丢失的 `RequestParams<T>`，继续继承 `request.Option<T, any>` 并允许拦截器附加自定义字段；
- 让 `Option<T, U>` 与 `SuccessCallbackResult<T>` 对齐现有公开签名 `Taro.request<T = any, U = any>`，移除造成声明自相矛盾的内部约束；
- 保留 `data: U`、HTTP method 等字段级类型校验，不改变运行时代码。

选择对齐现有无约束公开泛型，而不是向外传播约束，可以避免对已有自定义响应/请求类型造成 breaking change。

**验证**

- 隔离严格声明 A-B 编译：`origin/main` 复现 5 errors，当前分支 0 errors；
- 消费端类型 fixture：验证显式响应/请求泛型、拦截器自定义参数、primitive 响应类型，并用 `@ts-expect-error` 确认错误 request data 与 method 仍被拒绝；
- `corepack pnpm exec prettier --check packages/taro/types/api/network/request.d.ts`；
- `corepack pnpm lint`；
- `corepack pnpm --filter @tarojs/api test:ci`（2 suites / 7 tests）；
- `corepack pnpm pack`，确认发布包包含修复后的声明。

**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #18565
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [x] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [x] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 放宽网络请求参数和成功回调结果的类型限制，支持更多自定义数据类型。
  * 新增通用请求参数类型，允许传入额外的自定义属性。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->