### PR TITLE
fix(runtime): 修复 CustomWrapper 渲染数据被页面更新覆盖的问题

### DIFF
--- a/packages/shared/src/template.ts
+++ b/packages/shared/src/template.ts
@@ -576,7 +576,7 @@ ${this.buildXsImportTemplate()}<template is="{{'tmpl_0_' + i.${Shortcuts.NodeNam
 
     // 此处需要重新引入 xs 函数，否则会出现 ws.f() 在 comp.wxml 和 custom-wrapper.wxml 中永远返回 undefined 的问题 #14599
     return `<import src="./base${ext}" />
-${this.buildXsImportTemplate()}<template is="{{'tmpl_0_' + item.${Shortcuts.NodeName}}}" data="{{${data}}}" ${Adapter.for}="{{i.${Shortcuts.Childnodes}}}" ${Adapter.key}="${Shortcuts.Sid}" />
+${this.buildXsImportTemplate()}<template is="{{'tmpl_0_' + item.${Shortcuts.NodeName}}}" data="{{${data}}}" ${Adapter.for}="{{rd.${Shortcuts.Childnodes}}}" ${Adapter.key}="${Shortcuts.Sid}" />
 `
   }
 

--- a/packages/taro-platform-alipay/src/runtime-utils.ts
+++ b/packages/taro-platform-alipay/src/runtime-utils.ts
@@ -73,9 +73,13 @@ export const hostConfig = {
       ? {
         ...componentConfig,
         deriveDataFromProps (nextProps) {
-          if (this.data.i !== undefined && this.props.i !== nextProps.i) {
-            this.setData({ i: nextProps.i })
-          }
+          if (this.data.rd === undefined || this.props.i === nextProps.i || !nextProps.i) return
+
+          const { ubid: nextUpdateBatchId = 0, sid: nextSid } = nextProps.i
+          const { ubid: curUpdateBatchId = -1, sid: curSid } = this.data.rd || {}
+
+          if (curSid === nextSid && nextUpdateBatchId < curUpdateBatchId) return
+          this.setData({ rd: nextProps.i })
         }
       }
       : componentConfig

--- a/packages/taro-platform-alipay/src/runtime-utils.ts
+++ b/packages/taro-platform-alipay/src/runtime-utils.ts
@@ -78,7 +78,7 @@ export const hostConfig = {
           const { ubid: nextUpdateBatchId = 0, sid: nextSid } = nextProps.i
           const { ubid: curUpdateBatchId = -1, sid: curSid } = this.data.rd || {}
 
-          if (curSid === nextSid && nextUpdateBatchId < curUpdateBatchId) return
+          if (curSid === nextSid && nextUpdateBatchId <= curUpdateBatchId) return
           this.setData({ rd: nextProps.i })
         }
       }

--- a/packages/taro-runtime/src/dom/element.ts
+++ b/packages/taro-runtime/src/dom/element.ts
@@ -28,6 +28,7 @@ import type { TaroEvent } from './event'
 
 export class TaroElement extends TaroNode {
   public ctx?
+  public updateBatchId?: number
   public tagName: string
   public props: Record<string, any> = {}
   public style: Style

--- a/packages/taro-runtime/src/dom/root.ts
+++ b/packages/taro-runtime/src/dom/root.ts
@@ -30,6 +30,10 @@ interface CustomWrapperPathInfo {
   updateTarget?: CustomWrapperUpdateTarget
 }
 
+function isChildNodesPath (relativePath: string): boolean {
+  return relativePath === Shortcuts.Childnodes || relativePath.startsWith(`${Shortcuts.Childnodes}.`)
+}
+
 function resolveCustomWrapperPath (root: TaroRootElement, dataPath: string[]): CustomWrapperPathInfo | undefined {
   let currentData: any = root
   let updateTarget: CustomWrapperUpdateTarget | undefined
@@ -54,12 +58,12 @@ function resolveCustomWrapperPath (root: TaroRootElement, dataPath: string[]): C
     if (currentData.nodeName === CUSTOM_WRAPPER) {
       const wrapper = { node: currentData, pathIndex }
       const ctx = customWrapperCache.get(currentData.sid)
+      const chainIndex = wrapperChain.length
+      const relativePath = dataPath.slice(pathIndex + 1).join('.')
       wrapperChain.push(wrapper)
 
-      // 持续覆盖更新目标，最终由路径中最深的已 attached CustomWrapper 执行 setData
-      if (ctx) {
-        const chainIndex = wrapperChain.length - 1
-        const relativePath = dataPath.slice(pathIndex + 1).join('.')
+      // 持续覆盖更新目标，最终由路径中最深且实际持有此子节点数据的已 attached CustomWrapper 执行 setData
+      if (ctx && isChildNodesPath(relativePath)) {
         updateTarget = { ...wrapper, ctx, chainIndex, relativePath }
       }
     }
@@ -126,8 +130,13 @@ export class TaroRootElement extends TaroElement {
 
       while (this.updatePayloads.length > 0) {
         const { path, value } = this.updatePayloads.shift()!
-        const pathInfo = resolveCustomWrapperPath(this, path.split('.'))
+        const dataPath = path.split('.')
+        const pathInfo = resolveCustomWrapperPath(this, dataPath)
         pathInfo?.wrapperChain.forEach((wrapper) => {
+          const relativePath = dataPath.slice(wrapper.pathIndex + 1).join('.')
+
+          if (!isChildNodesPath(relativePath)) return
+
           wrapper.node.updateBatchId = updateBatchId
         })
         if (path.endsWith(Shortcuts.Childnodes)) {
@@ -170,15 +179,21 @@ export class TaroRootElement extends TaroElement {
             // 此项数据使用 CustomWrapper 去更新
             const { updateTarget, wrapperChain } = pathInfo
             const { ctx: customWrapper, relativePath } = updateTarget
-            const update = {
+            const update: Record<string, any> = {
               ...(customWrapperUpdates.get(customWrapper) || {}),
-              [`rd${relativePath ? `.${relativePath}` : ''}`]: data[p],
+              [`rd.${relativePath}`]: data[p],
               'rd.ubid': updateTarget.node.updateBatchId
             }
 
-            // 未 attached 的内层 CustomWrapper 会通过当前更新目标接收数据，需要同时传递对应的批次号
+            // 未 attached 的内层 CustomWrapper 会通过当前更新目标接收数据。
+            // 只有更新进入其子节点数据域时，才需要传递对应的批次号。
             wrapperChain.slice(updateTarget.chainIndex + 1).forEach((nestedWrapper) => {
+              const nestedRelativePath = dataPath.slice(nestedWrapper.pathIndex + 1).join('.')
+
+              if (!isChildNodesPath(nestedRelativePath)) return
+
               const nestedWrapperPath = dataPath.slice(updateTarget.pathIndex + 1, nestedWrapper.pathIndex + 1).join('.')
+
               update[`rd.${nestedWrapperPath}.ubid`] = nestedWrapper.node.updateBatchId
             })
 
@@ -188,6 +203,10 @@ export class TaroRootElement extends TaroElement {
             // 此项数据使用页面去更新
             normalUpdate[p] = data[p]
             pathInfo?.wrapperChain.forEach((wrapper) => {
+              const relativePath = dataPath.slice(wrapper.pathIndex + 1).join('.')
+
+              if (!isChildNodesPath(relativePath)) return
+
               normalUpdate[`${wrapper.node._path}.ubid`] = wrapper.node.updateBatchId
             })
           }

--- a/packages/taro-runtime/src/dom/root.ts
+++ b/packages/taro-runtime/src/dom/root.ts
@@ -13,15 +13,31 @@ import { TaroElement } from './element'
 
 import type { HydratedData, MpInstance, TFunc, UpdatePayload, UpdatePayloadValue } from '../interface'
 
-function findCustomWrapper (root: TaroRootElement, dataPathArr: string[]) {
-  // ['root', 'cn', '[0]'] remove 'root' => ['cn', '[0]']
-  const list = dataPathArr.slice(1)
-  let currentData: any = root
-  let customWrapper: Record<string, any> | undefined
-  let splitedPath = ''
+interface CustomWrapperInPath {
+  node: TaroElement
+  // CustomWrapper 节点在完整 dataPath 中的位置
+  pathIndex: number
+}
 
-  list.some((item, i) => {
-    const key = item
+interface CustomWrapperUpdateTarget extends CustomWrapperInPath {
+  ctx: Record<string, any>
+  chainIndex: number
+  relativePath: string
+}
+
+interface CustomWrapperPathInfo {
+  wrapperChain: CustomWrapperInPath[]
+  updateTarget?: CustomWrapperUpdateTarget
+}
+
+function resolveCustomWrapperPath (root: TaroRootElement, dataPath: string[]): CustomWrapperPathInfo | undefined {
+  let currentData: any = root
+  let updateTarget: CustomWrapperUpdateTarget | undefined
+  const wrapperChain: CustomWrapperInPath[] = []
+
+  // 跳过 root，收集更新路径经过的每一层 CustomWrapper
+  for (let pathIndex = 1; pathIndex < dataPath.length; pathIndex++) {
+    const key = dataPath[pathIndex]
       // '[0]' => '0'
       .replace(/^\[(.+)\]$/, '$1')
       // 'cn' => 'childNodes'
@@ -33,23 +49,25 @@ function findCustomWrapper (root: TaroRootElement, dataPathArr: string[]) {
       currentData = currentData.filter(el => !isComment(el))
     }
 
-    if (isUndefined(currentData)) return true
+    if (isUndefined(currentData)) break
 
     if (currentData.nodeName === CUSTOM_WRAPPER) {
-      const res = customWrapperCache.get(currentData.sid)
-      if (res) {
-        customWrapper = res
-        splitedPath = dataPathArr.slice(i + 2).join('.')
+      const wrapper = { node: currentData, pathIndex }
+      const ctx = customWrapperCache.get(currentData.sid)
+      wrapperChain.push(wrapper)
+
+      // 持续覆盖更新目标，最终由路径中最深的已 attached CustomWrapper 执行 setData
+      if (ctx) {
+        const chainIndex = wrapperChain.length - 1
+        const relativePath = dataPath.slice(pathIndex + 1).join('.')
+        updateTarget = { ...wrapper, ctx, chainIndex, relativePath }
       }
     }
-  })
-
-  if (customWrapper) {
-    return {
-      customWrapper,
-      splitedPath
-    }
   }
+
+  if (!wrapperChain.length) return
+
+  return { wrapperChain, updateTarget }
 }
 
 export class TaroRootElement extends TaroElement {
@@ -58,6 +76,8 @@ export class TaroRootElement extends TaroElement {
   private updateCallbacks: TFunc[] = []
 
   public pendingUpdate = false
+
+  public updateBatchId = 0
 
   public ctx: null | MpInstance = null
 
@@ -94,6 +114,7 @@ export class TaroRootElement extends TaroElement {
     const ctx = hooks.call('proxyToRaw', this.ctx)!
 
     this.scheduleTask(() => {
+      const updateBatchId = ++this.updateBatchId
       const setDataMark = `${SET_DATA} 开始时间戳 ${Date.now()}`
       perf.start(setDataMark)
       const data: Record<string, UpdatePayloadValue | ReturnType<HydratedData>> = Object.create(null)
@@ -105,6 +126,10 @@ export class TaroRootElement extends TaroElement {
 
       while (this.updatePayloads.length > 0) {
         const { path, value } = this.updatePayloads.shift()!
+        const pathInfo = resolveCustomWrapperPath(this, path.split('.'))
+        pathInfo?.wrapperChain.forEach((wrapper) => {
+          wrapper.node.updateBatchId = updateBatchId
+        })
         if (path.endsWith(Shortcuts.Childnodes)) {
           resetPaths.add(path)
         }
@@ -131,7 +156,7 @@ export class TaroRootElement extends TaroElement {
       // 正常渲染
       this.pendingUpdate = false
       let normalUpdate = {}
-      const customWrapperMap: Map<Record<any, any>, Record<string, any>> = new Map()
+      const customWrapperUpdates: Map<Record<any, any>, Record<string, any>> = new Map()
 
       if (initRender) {
         // 初次渲染，使用页面级别的 setData
@@ -139,24 +164,37 @@ export class TaroRootElement extends TaroElement {
       } else {
         // 更新渲染，区分 CustomWrapper 与页面级别的 setData
         for (const p in data) {
-          const dataPathArr = p.split('.')
-          const found = findCustomWrapper(this, dataPathArr)
-          if (found) {
+          const dataPath = p.split('.')
+          const pathInfo = resolveCustomWrapperPath(this, dataPath)
+          if (pathInfo?.updateTarget) {
             // 此项数据使用 CustomWrapper 去更新
-            const { customWrapper, splitedPath } = found
-            // 合并同一个 customWrapper 的相关更新到一次 setData 中
-            customWrapperMap.set(customWrapper, {
-              ...(customWrapperMap.get(customWrapper) || {}),
-              [`i.${splitedPath}`]: data[p]
+            const { updateTarget, wrapperChain } = pathInfo
+            const { ctx: customWrapper, relativePath } = updateTarget
+            const update = {
+              ...(customWrapperUpdates.get(customWrapper) || {}),
+              [`rd${relativePath ? `.${relativePath}` : ''}`]: data[p],
+              'rd.ubid': updateTarget.node.updateBatchId
+            }
+
+            // 未 attached 的内层 CustomWrapper 会通过当前更新目标接收数据，需要同时传递对应的批次号
+            wrapperChain.slice(updateTarget.chainIndex + 1).forEach((nestedWrapper) => {
+              const nestedWrapperPath = dataPath.slice(updateTarget.pathIndex + 1, nestedWrapper.pathIndex + 1).join('.')
+              update[`rd.${nestedWrapperPath}.ubid`] = nestedWrapper.node.updateBatchId
             })
+
+            // 合并同一个 customWrapper 的相关更新到一次 setData 中
+            customWrapperUpdates.set(customWrapper, update)
           } else {
             // 此项数据使用页面去更新
             normalUpdate[p] = data[p]
+            pathInfo?.wrapperChain.forEach((wrapper) => {
+              normalUpdate[`${wrapper.node._path}.ubid`] = wrapper.node.updateBatchId
+            })
           }
         }
       }
 
-      const customWrapperCount = customWrapperMap.size
+      const customWrapperCount = customWrapperUpdates.size
       const isNeedNormalUpdate = Object.keys(normalUpdate).length > 0
       const updateArrLen = customWrapperCount + (isNeedNormalUpdate ? 1 : 0)
       let executeTime = 0
@@ -171,7 +209,7 @@ export class TaroRootElement extends TaroElement {
 
       // custom-wrapper setData
       if (customWrapperCount) {
-        customWrapperMap.forEach((data, ctx) => {
+        customWrapperUpdates.forEach((data, ctx) => {
           if (process.env.NODE_ENV !== 'production' && options.debug) {
             // eslint-disable-next-line no-console
             console.log('custom wrapper setData: ', data)

--- a/packages/taro-runtime/src/dsl/common.ts
+++ b/packages/taro-runtime/src/dsl/common.ts
@@ -424,7 +424,7 @@ export function createRecursiveComponentConfig (componentName?: string) {
                 const { ubid: nextUpdateBatchId = 0, sid: nextSid } = nextProps
                 const { ubid: curUpdateBatchId = -1, sid: curSid } = this.data.rd || {}
 
-                if (curSid === nextSid && nextUpdateBatchId < curUpdateBatchId) return
+                if (curSid === nextSid && nextUpdateBatchId <= curUpdateBatchId) return
                 this.setData({ rd: nextProps })
               }
             }

--- a/packages/taro-runtime/src/dsl/common.ts
+++ b/packages/taro-runtime/src/dsl/common.ts
@@ -375,7 +375,7 @@ export function createRecursiveComponentConfig (componentName?: string) {
           return
         }
 
-        const componentId = this.data.i?.sid || this.props.i?.sid
+        const componentId = this.data.rd?.sid || this.data.i?.sid || this.props.i?.sid
         if (isString(componentId)) {
           customWrapperCache.set(componentId, this)
           const el = env.document.getElementById(componentId)
@@ -389,7 +389,7 @@ export function createRecursiveComponentConfig (componentName?: string) {
           return
         }
 
-        const componentId = this.data.i?.sid || this.props.i?.sid
+        const componentId = this.data.rd?.sid || this.data.i?.sid || this.props.i?.sid
         if (isString(componentId)) {
           customWrapperCache.delete(componentId)
           const el = env.document.getElementById(componentId)
@@ -413,8 +413,22 @@ export function createRecursiveComponentConfig (componentName?: string) {
         i: {
           type: Object,
           value: {
-            [Shortcuts.NodeName]: getComponentsAlias(internalComponents)[VIEW]._num
-          }
+            [Shortcuts.NodeName]: getComponentsAlias(internalComponents)[VIEW]._num,
+            ...(isCustomWrapper ? { ubid: 0 } : {})
+          },
+          ...(isCustomWrapper
+            ? {
+              observer (nextProps) {
+                if (!nextProps) return
+
+                const { ubid: nextUpdateBatchId = 0, sid: nextSid } = nextProps
+                const { ubid: curUpdateBatchId = -1, sid: curSid } = this.data.rd || {}
+
+                if (curSid === nextSid && nextUpdateBatchId < curUpdateBatchId) return
+                this.setData({ rd: nextProps })
+              }
+            }
+            : {})
         },
         l: {
           type: String,
@@ -428,6 +442,17 @@ export function createRecursiveComponentConfig (componentName?: string) {
       methods: {
         eh: eventHandler
       },
+      ...(isCustomWrapper
+        ? {
+          data: {
+            rd: {
+              [Shortcuts.NodeName]: getComponentsAlias(internalComponents)[VIEW]._num,
+              [Shortcuts.Childnodes]: [],
+              ubid: -1
+            }
+          }
+        }
+        : {}),
       ...lifeCycles
     }, { isCustomWrapper })
 }

--- a/packages/taro-runtime/src/hydrate.ts
+++ b/packages/taro-runtime/src/hydrate.ts
@@ -6,6 +6,7 @@ import {
   CLASS,
   CLICK_VIEW,
   COMPILE_MODE,
+  CUSTOM_WRAPPER,
   ID,
   PURE_VIEW,
   STYLE,
@@ -94,6 +95,11 @@ export function hydrate (node: TaroElement | TaroText): MiniData {
 
   // Children
   data[Shortcuts.Childnodes] = node.childNodes.filter(node => !isComment(node)).map(hydrate)
+
+  if (nodeName === CUSTOM_WRAPPER) {
+    node.updateBatchId ??= node._root?.updateBatchId ?? 0
+    data.ubid = node.updateBatchId
+  }
 
   if (node.className !== '') {
     data[Shortcuts.Class] = node.className

--- a/tests/__tests__/__snapshots__/mini-platform.spec.ts.snap
+++ b/tests/__tests__/__snapshots__/mini-platform.spec.ts.snap
@@ -767,11 +767,13 @@ require("./runtime");
             modifyRecursiveComponentConfig(componentConfig, {isCustomWrapper: isCustomWrapper}) {
                 return isCustomWrapper ? Object.assign(Object.assign({}, componentConfig), {
                     deriveDataFromProps(nextProps) {
-                        if (this.data.i !== undefined && this.props.i !== nextProps.i) {
-                            this.setData({
-                                i: nextProps.i
-                            });
-                        }
+                        if (this.data.rd === undefined || this.props.i === nextProps.i || !nextProps.i) return;
+                        const {ubid: nextUpdateBatchId = 0, sid: nextSid} = nextProps.i;
+                        const {ubid: curUpdateBatchId = -1, sid: curSid} = this.data.rd || {};
+                        if (curSid === nextSid && nextUpdateBatchId <= curUpdateBatchId) return;
+                        this.setData({
+                            rd: nextProps.i
+                        });
                     }
                 }) : componentConfig;
             }

--- a/tests/__tests__/__snapshots__/skyline.spec.ts.snap
+++ b/tests/__tests__/__snapshots__/skyline.spec.ts.snap
@@ -1684,7 +1684,7 @@ require("./runtime");
 /** filePath: dist/custom-wrapper.wxml **/
 <import src="./base.wxml" />
 <wxs module="xs" src="./utils.wxs" />
-<template is="{{'tmpl_0_' + item.nn}}" data="{{i:item,c:1,l:xs.f('',item.nn)}}" wx:for="{{i.cn}}" wx:key="sid" />
+<template is="{{'tmpl_0_' + item.nn}}" data="{{i:item,c:1,l:xs.f('',item.nn)}}" wx:for="{{rd.cn}}" wx:key="sid" />
 
 
 /** filePath: dist/pages/index/index.js **/

--- a/tests/__tests__/__snapshots__/tabbar.spec.ts.snap
+++ b/tests/__tests__/__snapshots__/tabbar.spec.ts.snap
@@ -2704,11 +2704,13 @@ require("./runtime");
             modifyRecursiveComponentConfig(componentConfig, {isCustomWrapper: isCustomWrapper}) {
                 return isCustomWrapper ? Object.assign(Object.assign({}, componentConfig), {
                     deriveDataFromProps(nextProps) {
-                        if (this.data.i !== undefined && this.props.i !== nextProps.i) {
-                            this.setData({
-                                i: nextProps.i
-                            });
-                        }
+                        if (this.data.rd === undefined || this.props.i === nextProps.i || !nextProps.i) return;
+                        const {ubid: nextUpdateBatchId = 0, sid: nextSid} = nextProps.i;
+                        const {ubid: curUpdateBatchId = -1, sid: curSid} = this.data.rd || {};
+                        if (curSid === nextSid && nextUpdateBatchId <= curUpdateBatchId) return;
+                        this.setData({
+                            rd: nextProps.i
+                        });
                     }
                 }) : componentConfig;
             }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南：https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
并使用 "[x]" 进行勾选
-->
**这个 PR 做了什么？** (简要描述所做更改)

修复 `CustomWrapper` 自身渲染数据可能被页面级异步更新中的旧数据覆盖，导致组件内容回退或渲染异常的问题。

主要改动：

- 为 `CustomWrapper` 增加独立渲染数据 `rd`，避免直接依赖可能被页面更新覆盖的 `i`
- 引入更新批次号 `ubid`，忽略同一节点收到的过期更新
- 更新路径解析逻辑，支持嵌套 `CustomWrapper`，由路径中最深且已挂载的节点执行更新
- 未挂载的内层 `CustomWrapper` 会同步透传对应批次号
- 兼容支付宝小程序的 `deriveDataFromProps` 数据同步机制
- 更新 Skyline 模板快照，使 `custom-wrapper` 从 `rd.cn` 渲染子节点
<details>
<summary>点击展开复现场景</summary>



<img width="1250" height="1000" alt="image" src="https://github.com/user-attachments/assets/aeb5246b-15f5-46b5-b561-c907fb42ae59" />

1. 配置`baseLevel`要求`CustomWrapper`所在元素层级超过`baseLevel`
```
import { defineConfig, type UserConfigExport } from '@tarojs/cli'
import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin'
import devConfig from './dev'
import prodConfig from './prod'

// https://taro-docs.jd.com/docs/next/config#defineconfig-辅助函数
export default defineConfig<'webpack5'>(async (merge, { command, mode }) => {
  const baseConfig: UserConfigExport<'webpack5'> = {
    projectName: 'my-app',
    date: '2026-9-7',
    designWidth: 750,
    deviceRatio: {
      640: 2.34 / 2,
      750: 1,
      375: 2,
      828: 1.81 / 2
    },
    sourceRoot: 'src',
    outputRoot: 'dist',
    plugins: [
      "@tarojs/plugin-generator"
    ],
    baseLevel:8,
    defineConstants: {
    },
    copy: {
      patterns: [
      ],
      options: {
      }
    },
    framework: 'react',
    compiler: 'webpack5',
    cache: {
      enable: false // Webpack 持久化缓存配置，建议开启。默认配置请参考：https://docs.taro.zone/docs/config-detail#cache
    },
    mini: {
      postcss: {
        pxtransform: {
          enable: true,
          config: {

          }
        },
        cssModules: {
          enable: false, // 默认为 false，如需使用 css modules 功能，则设为 true
          config: {
            namingPattern: 'module', // 转换模式，取值为 global/module
            generateScopedName: '[name]__[local]___[hash:base64:5]'
          }
        }
      },
      webpackChain(chain) {
        chain.resolve.plugin('tsconfig-paths').use(TsconfigPathsPlugin)
      },
    },
    h5: {
      publicPath: '/',
      staticDirectory: 'static',
      output: {
        filename: 'js/[name].[hash:8].js',
        chunkFilename: 'js/[name].[chunkhash:8].js'
      },
      miniCssExtractPluginOption: {
        ignoreOrder: true,
        filename: 'css/[name].[hash].css',
        chunkFilename: 'css/[name].[chunkhash].css'
      },
      postcss: {
        autoprefixer: {
          enable: true,
          config: {}
        },
        cssModules: {
          enable: false, // 默认为 false，如需使用 css modules 功能，则设为 true
          config: {
            namingPattern: 'module', // 转换模式，取值为 global/module
            generateScopedName: '[name]__[local]___[hash:base64:5]'
          }
        }
      },
      webpackChain(chain) {
        chain.resolve.plugin('tsconfig-paths').use(TsconfigPathsPlugin)
      }
    },
    rn: {
      appName: 'taroDemo',
      postcss: {
        cssModules: {
          enable: false, // 默认为 false，如需使用 css modules 功能，则设为 true
        }
      }
    }
  }


  if (process.env.NODE_ENV === 'development') {
    // 本地开发构建配置（不混淆压缩）
    return merge({}, baseConfig, devConfig)
  }
  // 生产构建配置（默认开启压缩混淆等）
  return merge({}, baseConfig, prodConfig)
})

```

2. 实现复现逻辑，同时更新字段数据页面
```
import { Button, CustomWrapper, Text, View } from '@tarojs/components';
import React, { useEffect, useState } from 'react';
import './index.less';

interface Counters {
  operationCount: number;
  outsideCount: number;
  insideCount: number;
}

const INITIAL_COUNTERS: Counters = {
  operationCount: 0,
  outsideCount: 0,
  insideCount: 0,
};

const CustomWrapperRace = () => {
  const [counters, setCounters] = useState<Counters>(INITIAL_COUNTERS);

  const handleUpdate = () => {
    setCounters((previousCounters) => {
      const nextValue = previousCounters.operationCount + 1;

      return {
        operationCount: nextValue,
        outsideCount: nextValue,
        insideCount: nextValue,
      };
    });
  };

  useEffect(() => console.log(counters), [counters]);

  return (
    <View className="custom-wrapper-race-page">
      <View className="race-panel">
        <View className="race-button-row">
          <Button onClick={handleUpdate}>更新一次</Button>
        </View>
      </View>

      <View className="race-depth-1">
        <View className="race-depth-2">
          <View className="race-depth-3">
            <View className="race-depth-4">
              <View className="race-depth-5">
                <View className="race-depth-6">
                  <View className="race-depth-7">
                    <View className="race-depth-8">
                      <View className="race-depth-9">
                        <View className="race-depth-10">
                          <View className="race-business-tree">
                            <View className="race-value-row">
                              <Text>operationCount：</Text>
                              <Text>{counters.operationCount}</Text>
                            </View>

                            <View className="race-value-row">
                              <Text>outsideCount（CustomWrapper 外）：</Text>
                              <Text>{counters.outsideCount}</Text>
                            </View>

                            <CustomWrapper>
                              <View className="race-value-row race-inside-row">
                                <Text>insideCount（CustomWrapper 内）：</Text>
                                <Text>{counters.insideCount}</Text>
                              </View>
                            </CustomWrapper>
                          </View>
                        </View>
                      </View>
                    </View>
                  </View>
                </View>
              </View>
            </View>
          </View>
        </View>
      </View>
    </View>
  );
};

export default CustomWrapperRace;
```
3. 样式为了好看没其他作用
```
.custom-wrapper-race-page {
  min-height: 100vh;
  padding: 24px;
  color: #222;
  background: #f5f6f8;
  box-sizing: border-box;

  .race-panel,
  .race-status,
  .race-business-tree {
    margin-bottom: 20px;
    padding: 20px;
    background: #fff;
    border-radius: 12px;
    box-sizing: border-box;
  }

  .race-status {
    display: flex;
    flex-direction: column;
    gap: 8px;
    border: 2px solid transparent;
  }

  .race-status-pass {
    color: #16794a;
    border-color: #53b483;
    background: #eefaf3;
  }

  .race-status-fail {
    color: #b42318;
    border-color: #ef7b73;
    background: #fff1f0;
  }

  .race-status-text {
    font-size: 44px;
    font-weight: 700;
  }

  .race-button-row {
    display: flex;
    flex-wrap: wrap;
    gap: 12px;

    button {
      min-width: 190px;
      margin: 0;
      font-size: 26px;
    }
  }

  .race-value-row {
    display: flex;
    justify-content: space-between;
    padding: 14px 0;
    border-bottom: 1px solid #eee;
    font-size: 28px;
  }

  .race-inside-row {
    color: #6d4c00;
    background: #fff8e1;
  }
}

```
</details>



**这个 PR 是什么类型？** (至少选择一个)

- [x] 错误修复 (Bugfix) issue: fix #
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Types)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 构建优化 (Chore)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 涉及以下平台：**

- [ ] 所有平台
- [ ] Web 端（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（Harmony）
- [ ] 鸿蒙容器（Harmony Hybrid）
- [ ] ASCF 元服务
- [ ] 快应用（QuickApp）
- [x] 所有小程序
- [ ] 微信小程序
- [ ] 企业微信小程序
- [ ] 京东小程序
- [ ] 百度小程序
- [ ] 支付宝小程序
- [ ] 支付宝 IOT 小程序
- [ ] 钉钉小程序
- [ ] QQ 小程序
- [ ] 飞书小程序
- [ ] 快手小程序
- [ ] 头条小程序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 修复自定义组件及嵌套包装组件更新时的数据同步问题。
  * 改善连续快速更新场景下的处理，避免旧批次或重复更新覆盖最新内容。
  * 提升递归组件挂载、卸载及页面更新过程中的状态一致性。
  * 修复自定义组件子节点列表读取异常，确保子节点正确渲染。
  * 优化页面级属性与子节点更新的处理，减少不相关字段被重复同步的问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->